### PR TITLE
refactor: encapsulate db access in helper module

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -1,0 +1,162 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Dict, Any
+
+from app import db
+from models import (
+    Payment,
+    TermsAcceptance,
+    Invitation,
+    CURRENT_TERMS_VERSION,
+    User,
+    Server,
+    Variable,
+    Secret,
+    ServerInvocation,
+    CID,
+)
+
+
+def get_user_profile_data(user_id: str) -> Dict[str, Any]:
+    """Gather payment and terms data for a user."""
+    payments = (
+        Payment.query.filter_by(user_id=user_id)
+        .order_by(Payment.payment_date.desc())
+        .all()
+    )
+    terms_history = (
+        TermsAcceptance.query.filter_by(user_id=user_id)
+        .order_by(TermsAcceptance.accepted_at.desc())
+        .all()
+    )
+    current_terms = TermsAcceptance.query.filter_by(
+        user_id=user_id, terms_version=CURRENT_TERMS_VERSION
+    ).first()
+    return {
+        "payments": payments,
+        "terms_history": terms_history,
+        "needs_terms_acceptance": current_terms is None,
+        "current_terms_version": CURRENT_TERMS_VERSION,
+    }
+
+
+def create_payment_record(plan: str, amount: float, user: User) -> Payment:
+    """Create and persist a payment record, updating the user as needed."""
+    payment = Payment(user_id=user.id, amount=amount, plan_type=plan)
+    if plan == "annual":
+        payment.expires_at = datetime.now(timezone.utc) + timedelta(days=365)
+        user.is_paid = True
+        user.payment_expires_at = payment.expires_at
+    else:
+        user.is_paid = False
+        user.payment_expires_at = None
+    payment.transaction_id = f"mock_txn_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    db.session.add(payment)
+    db.session.commit()
+    return payment
+
+
+def create_terms_acceptance_record(user: User, ip_address: str) -> TermsAcceptance:
+    """Create and persist a terms acceptance record for the user."""
+    terms_acceptance = TermsAcceptance(
+        user_id=user.id,
+        terms_version=CURRENT_TERMS_VERSION,
+        ip_address=ip_address,
+    )
+    user.current_terms_accepted = True
+    db.session.add(terms_acceptance)
+    db.session.commit()
+    return terms_acceptance
+
+
+def validate_invitation_code(invitation_code: str) -> Optional[Invitation]:
+    """Validate an invitation code and return the invitation if valid."""
+    invitation = Invitation.query.filter_by(invitation_code=invitation_code).first()
+    if invitation and invitation.is_valid():
+        return invitation
+    return None
+
+
+def get_user_servers(user_id: str):
+    return Server.query.filter_by(user_id=user_id).order_by(Server.name).all()
+
+
+def get_server_by_name(user_id: str, name: str):
+    return Server.query.filter_by(user_id=user_id, name=name).first()
+
+
+def get_user_variables(user_id: str):
+    return Variable.query.filter_by(user_id=user_id).order_by(Variable.name).all()
+
+
+def get_variable_by_name(user_id: str, name: str):
+    return Variable.query.filter_by(user_id=user_id, name=name).first()
+
+
+def get_user_secrets(user_id: str):
+    return Secret.query.filter_by(user_id=user_id).order_by(Secret.name).all()
+
+
+def get_secret_by_name(user_id: str, name: str):
+    return Secret.query.filter_by(user_id=user_id, name=name).first()
+
+
+def count_user_servers(user_id: str) -> int:
+    return Server.query.filter_by(user_id=user_id).count()
+
+
+def count_user_variables(user_id: str) -> int:
+    return Variable.query.filter_by(user_id=user_id).count()
+
+
+def count_user_secrets(user_id: str) -> int:
+    return Secret.query.filter_by(user_id=user_id).count()
+
+
+def save_entity(entity):
+    db.session.add(entity)
+    db.session.commit()
+    return entity
+
+
+def delete_entity(entity):
+    db.session.delete(entity)
+    db.session.commit()
+
+
+def create_server_invocation(
+    user_id: str,
+    server_name: str,
+    result_cid: str,
+    servers_cid: Optional[str] = None,
+    variables_cid: Optional[str] = None,
+    secrets_cid: Optional[str] = None,
+) -> ServerInvocation:
+    invocation = ServerInvocation(
+        user_id=user_id,
+        server_name=server_name,
+        result_cid=result_cid,
+        servers_cid=servers_cid,
+        variables_cid=variables_cid,
+        secrets_cid=secrets_cid,
+    )
+    save_entity(invocation)
+    return invocation
+
+
+def get_cid_by_path(path: str) -> Optional[CID]:
+    return CID.query.filter_by(path=path).first()
+
+
+def create_cid_record(cid: str, file_content: bytes, user_id: str) -> CID:
+    record = CID(
+        path=f"/{cid}",
+        file_data=file_content,
+        file_size=len(file_content),
+        uploaded_by_user_id=user_id,
+    )
+    save_entity(record)
+    return record
+
+
+def get_user_uploads(user_id: str):
+    return CID.query.filter_by(uploaded_by_user_id=user_id).order_by(CID.created_at.desc()).all()

--- a/test_db_access.py
+++ b/test_db_access.py
@@ -1,0 +1,95 @@
+"""Tests for database access helper functions."""
+import os
+import unittest
+
+# Configure environment before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SESSION_SECRET'] = 'test-secret-key'
+os.environ['TESTING'] = 'True'
+
+from app import app
+from models import db, User, Invitation, Server, Variable, Secret
+from db_access import (
+    create_payment_record,
+    create_terms_acceptance_record,
+    get_user_profile_data,
+    validate_invitation_code,
+    get_server_by_name,
+    get_variable_by_name,
+    get_secret_by_name,
+    count_user_servers,
+    create_server_invocation,
+    create_cid_record,
+    get_cid_by_path,
+)
+
+
+class TestDBAccess(unittest.TestCase):
+    def setUp(self):
+        self.app = app
+        self.app.config['TESTING'] = True
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.app.config['WTF_CSRF_ENABLED'] = False
+
+        with self.app.app_context():
+            db.create_all()
+
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+        self.user = User(id='user1', email='user@example.com')
+        db.session.add(self.user)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_create_payment_record(self):
+        create_payment_record('annual', 50.0, self.user)
+        self.assertTrue(self.user.is_paid)
+        self.assertEqual(len(self.user.payments), 1)
+        self.assertEqual(self.user.payments[0].plan_type, 'annual')
+
+    def test_create_terms_acceptance_record(self):
+        create_terms_acceptance_record(self.user, '127.0.0.1')
+        self.assertTrue(self.user.current_terms_accepted)
+        self.assertEqual(len(self.user.terms_acceptances), 1)
+        self.assertEqual(self.user.terms_acceptances[0].ip_address, '127.0.0.1')
+
+    def test_get_user_profile_data(self):
+        create_payment_record('free', 0.0, self.user)
+        create_terms_acceptance_record(self.user, '127.0.0.1')
+        data = get_user_profile_data(self.user.id)
+        self.assertEqual(len(data['payments']), 1)
+        self.assertFalse(data['needs_terms_acceptance'])
+
+    def test_validate_invitation_code(self):
+        invitation = Invitation(inviter_user_id=self.user.id, invitation_code='ABC123')
+        db.session.add(invitation)
+        db.session.commit()
+        self.assertIsNotNone(validate_invitation_code('ABC123'))
+        self.assertIsNone(validate_invitation_code('NOTREAL'))
+
+    def test_entity_helpers(self):
+        server = Server(name='srv', definition='print(1)', user_id=self.user.id)
+        variable = Variable(name='var', definition='1', user_id=self.user.id)
+        secret = Secret(name='sec', definition='x', user_id=self.user.id)
+        db.session.add_all([server, variable, secret])
+        db.session.commit()
+
+        self.assertIsNotNone(get_server_by_name(self.user.id, 'srv'))
+        self.assertIsNotNone(get_variable_by_name(self.user.id, 'var'))
+        self.assertIsNotNone(get_secret_by_name(self.user.id, 'sec'))
+        self.assertEqual(count_user_servers(self.user.id), 1)
+
+    def test_server_invocation_and_cid_helpers(self):
+        create_cid_record('cid1', b'data', self.user.id)
+        self.assertIsNotNone(get_cid_by_path('/cid1'))
+        invocation = create_server_invocation(self.user.id, 'srv', 'cid1')
+        self.assertIsNotNone(invocation.id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_variables_secrets_issue.py
+++ b/test_variables_secrets_issue.py
@@ -47,8 +47,8 @@ class TestVariablesSecretsIssue(unittest.TestCase):
         pass
     
     @patch('routes.current_user')
-    @patch('routes.Variable')
-    def test_user_variables_returns_model_objects(self, mock_variable_class, mock_current_user):
+    @patch('routes.get_user_variables')
+    def test_user_variables_returns_model_objects(self, mock_get_vars, mock_current_user):
         """Test that user_variables() returns SQLAlchemy model objects, not serializable data"""
         # Mock current user
         mock_current_user.id = 'test_user_123'
@@ -64,10 +64,7 @@ class TestVariablesSecretsIssue(unittest.TestCase):
         mock_var2.definition = 'value2'
         mock_var2.user_id = 'test_user_123'
         
-        # Mock the query chain
-        mock_query = Mock()
-        mock_query.filter_by.return_value.order_by.return_value.all.return_value = [mock_var1, mock_var2]
-        mock_variable_class.query = mock_query
+        mock_get_vars.return_value = [mock_var1, mock_var2]
         
         # Call the function
         result = user_variables()
@@ -88,8 +85,8 @@ class TestVariablesSecretsIssue(unittest.TestCase):
         print(f"First item has definition: {hasattr(result[0], 'definition')}")
     
     @patch('routes.current_user')
-    @patch('routes.Secret')
-    def test_user_secrets_returns_model_objects(self, mock_secret_class, mock_current_user):
+    @patch('routes.get_user_secrets')
+    def test_user_secrets_returns_model_objects(self, mock_get_secrets, mock_current_user):
         """Test that user_secrets() returns SQLAlchemy model objects, not serializable data"""
         # Mock current user
         mock_current_user.id = 'test_user_123'
@@ -100,10 +97,7 @@ class TestVariablesSecretsIssue(unittest.TestCase):
         mock_secret1.definition = 'secret_value1'
         mock_secret1.user_id = 'test_user_123'
         
-        # Mock the query chain
-        mock_query = Mock()
-        mock_query.filter_by.return_value.order_by.return_value.all.return_value = [mock_secret1]
-        mock_secret_class.query = mock_query
+        mock_get_secrets.return_value = [mock_secret1]
         
         # Call the function
         result = user_secrets()


### PR DESCRIPTION
## Summary
- extract database helper functions into new `db_access.py`
- update routes to use db helpers instead of raw ORM queries
- add unit tests for database helpers

## Testing
- `DATABASE_URL=sqlite:///test.db SESSION_SECRET=test-secret-key pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c77713e5848331be69a627f0a60b06