### PR TITLE
Refactor page view tracking and invitation persistence

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -1,0 +1,22 @@
+from app import db
+
+
+def log_page_view(page_view):
+    """Persist a page view record."""
+    db.session.add(page_view)
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def save_invitation(invitation):
+    """Persist an invitation record."""
+    db.session.add(invitation)
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return invitation


### PR DESCRIPTION
## Summary
- add db_access helpers for logging page views and saving invitations
- refactor routes to use new helpers instead of direct db session calls

## Testing
- `pytest` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_b_68c783a661d48331809a76bd5409c120