### PR TITLE
Refactor CID helpers into dedicated module

### DIFF
--- a/cid_utils.py
+++ b/cid_utils.py
@@ -1,0 +1,377 @@
+import base64
+import hashlib
+import json
+from urllib.parse import urlparse
+
+import requests
+from flask import make_response, request
+
+try:
+    from db_access import (
+        create_cid_record,
+        get_cid_by_path,
+        get_user_servers,
+        get_user_variables,
+        get_user_secrets,
+    )
+except (RuntimeError, ImportError):
+    create_cid_record = None
+    get_cid_by_path = None
+    get_user_servers = None
+    get_user_variables = None
+    get_user_secrets = None
+
+
+def _ensure_db_access():
+    global create_cid_record, get_cid_by_path, get_user_servers, get_user_variables, get_user_secrets
+    if None in (create_cid_record, get_cid_by_path, get_user_servers, get_user_variables, get_user_secrets):
+        from db_access import (
+            create_cid_record as _create_cid_record,
+            get_cid_by_path as _get_cid_by_path,
+            get_user_servers as _get_user_servers,
+            get_user_variables as _get_user_variables,
+            get_user_secrets as _get_user_secrets,
+        )
+
+        if create_cid_record is None:
+            create_cid_record = _create_cid_record
+        if get_cid_by_path is None:
+            get_cid_by_path = _get_cid_by_path
+        if get_user_servers is None:
+            get_user_servers = _get_user_servers
+        if get_user_variables is None:
+            get_user_variables = _get_user_variables
+        if get_user_secrets is None:
+            get_user_secrets = _get_user_secrets
+
+# ============================================================================
+# CID GENERATION AND STORAGE HELPERS
+# ============================================================================
+
+def generate_cid(file_data):
+    """Generate a simple CID-like hash from file data only"""
+    hasher = hashlib.sha256()
+    hasher.update(file_data)
+    sha256_hash = hasher.digest()
+
+    encoded = base64.b32encode(sha256_hash).decode('ascii').lower().rstrip('=')
+    return f"bafybei{encoded[:52]}"  # Truncate to reasonable length
+
+
+def process_file_upload(form):
+    """Process file upload from form and return file content and filename"""
+    uploaded_file = form.file.data
+    file_content = uploaded_file.read()
+    filename = uploaded_file.filename or 'upload'
+    return file_content, filename
+
+
+def process_text_upload(form):
+    """Process text upload from form and return file content"""
+    text_content = form.text_content.data
+    file_content = text_content.encode('utf-8')
+    return file_content
+
+
+def process_url_upload(form):
+    """Process URL upload from form by downloading content and return file content and MIME type"""
+    url = form.url.data.strip()
+
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                          '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+
+        response = requests.get(url, timeout=30, headers=headers, stream=True)
+        response.raise_for_status()
+
+        content_type = response.headers.get('content-type', 'application/octet-stream')
+        mime_type = content_type.split(';')[0].strip().lower()
+
+        content_length = response.headers.get('content-length')
+        if content_length and int(content_length) > 100 * 1024 * 1024:
+            raise ValueError("File too large (>100MB)")
+
+        file_content = b''
+        downloaded_size = 0
+        max_size = 100 * 1024 * 1024
+
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                downloaded_size += len(chunk)
+                if downloaded_size > max_size:
+                    raise ValueError("File too large (>100MB)")
+                file_content += chunk
+
+        parsed_url = urlparse(url)
+        filename = parsed_url.path.split('/')[-1]
+
+        if not filename or '.' not in filename:
+            extension = get_extension_from_mime_type(mime_type)
+            if extension:
+                filename = f"download{extension}"
+            else:
+                filename = "download"
+
+        return file_content, mime_type
+
+    except requests.exceptions.RequestException as e:
+        raise ValueError(f"Failed to download from URL: {str(e)}")
+    except Exception as e:
+        raise ValueError(f"Error processing URL: {str(e)}")
+
+
+def save_server_definition_as_cid(definition, user_id):
+    """Save server definition as CID and return the CID string"""
+    _ensure_db_access()
+    definition_bytes = definition.encode('utf-8')
+    cid = generate_cid(definition_bytes)
+
+    existing_cid = get_cid_by_path(f"/{cid}")
+    if not existing_cid:
+        create_cid_record(cid, definition_bytes, user_id)
+
+    return cid
+
+
+def store_cid_from_json(json_content, user_id):
+    """Store JSON content in a CID record and return the CID"""
+    _ensure_db_access()
+    json_bytes = json_content.encode('utf-8')
+    cid = generate_cid(json_bytes)
+
+    existing_cid = get_cid_by_path(f"/{cid}")
+    if not existing_cid:
+        create_cid_record(cid, json_bytes, user_id)
+
+    return cid
+
+
+# ============================================================================
+# DEFINITIONS CID HELPERS
+# ============================================================================
+
+def generate_all_server_definitions_json(user_id):
+    """Generate JSON containing all server definitions for a user"""
+    _ensure_db_access()
+    servers = get_user_servers(user_id)
+
+    server_definitions = {}
+    for server in servers:
+        server_definitions[server.name] = server.definition
+
+    return json.dumps(server_definitions, indent=2, sort_keys=True)
+
+
+def store_server_definitions_cid(user_id):
+    """Store all server definitions as JSON in a CID and return the CID path"""
+    _ensure_db_access()
+    json_content = generate_all_server_definitions_json(user_id)
+    return store_cid_from_json(json_content, user_id)
+
+
+def get_current_server_definitions_cid(user_id):
+    """Get the CID path for the current server definitions JSON"""
+    _ensure_db_access()
+    json_content = generate_all_server_definitions_json(user_id)
+    json_bytes = json_content.encode('utf-8')
+    expected_cid = generate_cid(json_bytes)
+
+    existing_cid = get_cid_by_path(f"/{expected_cid}")
+    if existing_cid:
+        return expected_cid
+    return store_server_definitions_cid(user_id)
+
+
+def generate_all_variable_definitions_json(user_id):
+    """Generate JSON containing all variable definitions for a user"""
+    _ensure_db_access()
+    variables = get_user_variables(user_id)
+
+    variable_definitions = {}
+    for variable in variables:
+        variable_definitions[variable.name] = variable.definition
+
+    return json.dumps(variable_definitions, indent=2, sort_keys=True)
+
+
+def store_variable_definitions_cid(user_id):
+    """Store all variable definitions as JSON in a CID and return the CID path"""
+    _ensure_db_access()
+    json_content = generate_all_variable_definitions_json(user_id)
+    return store_cid_from_json(json_content, user_id)
+
+
+def get_current_variable_definitions_cid(user_id):
+    """Get the CID path for the current variable definitions JSON"""
+    _ensure_db_access()
+    json_content = generate_all_variable_definitions_json(user_id)
+    json_bytes = json_content.encode('utf-8')
+    expected_cid = generate_cid(json_bytes)
+
+    existing_cid = get_cid_by_path(f"/{expected_cid}")
+    if existing_cid:
+        return expected_cid
+    return store_variable_definitions_cid(user_id)
+
+
+def generate_all_secret_definitions_json(user_id):
+    """Generate JSON containing all secret definitions for a user"""
+    _ensure_db_access()
+    secrets = get_user_secrets(user_id)
+
+    secret_definitions = {}
+    for secret in secrets:
+        secret_definitions[secret.name] = secret.definition
+
+    return json.dumps(secret_definitions, indent=2, sort_keys=True)
+
+
+def store_secret_definitions_cid(user_id):
+    """Store all secret definitions as JSON in a CID and return the CID path"""
+    _ensure_db_access()
+    json_content = generate_all_secret_definitions_json(user_id)
+    json_bytes = json_content.encode('utf-8')
+    cid = generate_cid(json_bytes)
+
+    existing_cid = get_cid_by_path(f"/{cid}")
+    if not existing_cid:
+        create_cid_record(cid, json_bytes, user_id)
+
+    return cid
+
+
+def get_current_secret_definitions_cid(user_id):
+    """Get the CID path for the current secret definitions JSON"""
+    _ensure_db_access()
+    json_content = generate_all_secret_definitions_json(user_id)
+    json_bytes = json_content.encode('utf-8')
+    expected_cid = generate_cid(json_bytes)
+
+    existing_cid = get_cid_by_path(f"/{expected_cid}")
+    if existing_cid:
+        return expected_cid
+    return store_secret_definitions_cid(user_id)
+
+
+# ============================================================================
+# MIME TYPE AND CID SERVING HELPERS
+# ============================================================================
+
+EXTENSION_TO_MIME = {
+    'html': 'text/html',
+    'htm': 'text/html',
+    'txt': 'text/plain',
+    'css': 'text/css',
+    'js': 'application/javascript',
+    'json': 'application/json',
+    'xml': 'application/xml',
+    'pdf': 'application/pdf',
+    'zip': 'application/zip',
+    'tar': 'application/x-tar',
+    'gz': 'application/gzip',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png',
+    'gif': 'image/gif',
+    'svg': 'image/svg+xml',
+    'webp': 'image/webp',
+    'ico': 'image/x-icon',
+    'mp3': 'audio/mpeg',
+    'wav': 'audio/wav',
+    'ogg': 'audio/ogg',
+    'mp4': 'video/mp4',
+    'webm': 'video/webm',
+    'avi': 'video/x-msvideo',
+    'mov': 'video/quicktime',
+    'md': 'text/markdown',
+    'csv': 'text/csv',
+    'py': 'text/x-python',
+    'java': 'text/x-java-source',
+    'c': 'text/x-c',
+    'cpp': 'text/x-c++',
+    'h': 'text/x-c',
+    'hpp': 'text/x-c++',
+    'sh': 'application/x-sh',
+    'bat': 'application/x-msdos-program',
+    'exe': 'application/x-msdownload',
+    'dmg': 'application/x-apple-diskimage',
+    'deb': 'application/vnd.debian.binary-package',
+    'rpm': 'application/x-rpm'
+}
+
+MIME_TO_EXTENSION = {}
+for ext, mime in EXTENSION_TO_MIME.items():
+    if mime not in MIME_TO_EXTENSION:
+        MIME_TO_EXTENSION[mime] = ext
+
+
+def get_mime_type_from_extension(path):
+    """Determine MIME type from file extension in URL path"""
+    if '.' in path:
+        extension = path.split('.')[-1].lower()
+        return EXTENSION_TO_MIME.get(extension, 'application/octet-stream')
+    return 'application/octet-stream'
+
+
+def get_extension_from_mime_type(content_type):
+    """Get file extension from MIME type"""
+    base_mime = content_type.split(';')[0].strip().lower()
+    return MIME_TO_EXTENSION.get(base_mime, '')
+
+
+def extract_filename_from_cid_path(path):
+    """Extract filename from CID path for content disposition header."""
+    if path.startswith('/'):
+        path = path[1:]
+
+    if not path or path in ['.', '..']:
+        return None
+
+    parts = path.split('.')
+
+    if len(parts) < 3:
+        return None
+
+    filename_parts = parts[1:]
+    filename = '.'.join(filename_parts)
+
+    return filename
+
+
+def serve_cid_content(cid_content, path):
+    """Serve CID content with appropriate headers and caching"""
+    if cid_content is None or cid_content.file_data is None:
+        return None
+
+    cid = path[1:] if path.startswith('/') else path
+
+    content_type = get_mime_type_from_extension(path)
+
+    etag = f'"{cid.split(".")[0]}"'
+    if request.headers.get('If-None-Match') == etag:
+        response = make_response('', 304)
+        response.headers['ETag'] = etag
+        return response
+
+    if request.headers.get('If-Modified-Since'):
+        response = make_response('', 304)
+        response.headers['ETag'] = etag
+        response.headers['Last-Modified'] = cid_content.created_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
+        return response
+
+    response = make_response(cid_content.file_data)
+    response.headers['Content-Type'] = content_type
+    response.headers['Content-Length'] = len(cid_content.file_data)
+
+    filename = extract_filename_from_cid_path(path)
+    if filename:
+        response.headers['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+    response.headers['ETag'] = etag
+    response.headers['Last-Modified'] = cid_content.created_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
+    response.headers['Cache-Control'] = 'public, max-age=31536000, immutable'
+    response.headers['Expires'] = 'Thu, 31 Dec 2037 23:55:55 GMT'
+
+    return response

--- a/migrate_add_server_cid.py
+++ b/migrate_add_server_cid.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from app import app, db
 from models import Server
-from routes import save_server_definition_as_cid
+from cid_utils import save_server_definition_as_cid
 import sqlite3
 
 def migrate_add_server_cid():

--- a/routes.py
+++ b/routes.py
@@ -28,8 +28,22 @@ from db_access import (
 from forms import PaymentForm, TermsAcceptanceForm, FileUploadForm, InvitationForm, InvitationCodeForm, ServerForm, VariableForm, SecretForm
 from auth_providers import require_login, auth_manager, save_user_from_claims
 from secrets import token_urlsafe as secrets_token_urlsafe
-import hashlib
-import base64
+from cid_utils import (
+    generate_cid,
+    process_file_upload,
+    process_text_upload,
+    process_url_upload,
+    save_server_definition_as_cid,
+    store_server_definitions_cid,
+    get_current_server_definitions_cid,
+    store_variable_definitions_cid,
+    get_current_variable_definitions_cid,
+    store_secret_definitions_cid,
+    get_current_secret_definitions_cid,
+    get_mime_type_from_extension,
+    get_extension_from_mime_type,
+    serve_cid_content,
+)
 import traceback
 import json
 from text_function_runner import run_text_function
@@ -130,110 +144,6 @@ def privacy():
     """Display privacy policy"""
     return render_template('privacy.html')
 
-# ============================================================================
-# FILE UPLOAD AND CID HELPERS
-# ============================================================================
-
-def generate_cid(file_data):
-    """Generate a simple CID-like hash from file data only"""
-    # Create SHA-256 hash of the file content only
-    hasher = hashlib.sha256()
-    hasher.update(file_data)
-    sha256_hash = hasher.digest()
-
-    # Encode to base64 and create a CID-like string
-    encoded = base64.b32encode(sha256_hash).decode('ascii').lower().rstrip('=')
-    # Add CID prefix to make it look like an IPFS CID
-    return f"bafybei{encoded[:52]}"  # Truncate to reasonable length
-
-def process_file_upload(form):
-    """Process file upload from form and return file content and filename"""
-    uploaded_file = form.file.data
-    file_content = uploaded_file.read()
-    filename = uploaded_file.filename or 'upload'
-    return file_content, filename
-
-def process_text_upload(form):
-    """Process text upload from form and return file content"""
-    text_content = form.text_content.data
-    file_content = text_content.encode('utf-8')
-    return file_content
-
-def process_url_upload(form):
-    """Process URL upload from form by downloading content and return file content and MIME type"""
-    import requests
-    from urllib.parse import urlparse
-
-    url = form.url.data.strip()
-
-    try:
-        # Set reasonable timeout and headers
-        headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
-        }
-
-        response = requests.get(url, timeout=30, headers=headers, stream=True)
-        response.raise_for_status()
-
-        # Get MIME type from response headers
-        content_type = response.headers.get('content-type', 'application/octet-stream')
-        # Clean up MIME type (remove charset and other parameters)
-        mime_type = content_type.split(';')[0].strip().lower()
-
-        # Check content length to avoid downloading huge files
-        content_length = response.headers.get('content-length')
-        if content_length and int(content_length) > 100 * 1024 * 1024:  # 100MB limit
-            raise ValueError("File too large (>100MB)")
-
-        # Download content in chunks to handle large files efficiently
-        file_content = b''
-        downloaded_size = 0
-        max_size = 100 * 1024 * 1024  # 100MB limit
-
-        for chunk in response.iter_content(chunk_size=8192):
-            if chunk:
-                downloaded_size += len(chunk)
-                if downloaded_size > max_size:
-                    raise ValueError("File too large (>100MB)")
-                file_content += chunk
-
-        # Extract filename from URL for potential future use
-        parsed_url = urlparse(url)
-        filename = parsed_url.path.split('/')[-1]
-
-        # If no filename from URL or no extension, use MIME type to determine extension
-        if not filename or '.' not in filename:
-            extension = get_extension_from_mime_type(mime_type)
-            if extension:
-                filename = f"download{extension}"
-            else:
-                filename = "download"
-
-        return file_content, mime_type
-
-    except requests.exceptions.RequestException as e:
-        raise ValueError(f"Failed to download from URL: {str(e)}")
-    except Exception as e:
-        raise ValueError(f"Error processing URL: {str(e)}")
-def save_server_definition_as_cid(definition, user_id):
-    """Save server definition as CID and return the CID string"""
-    # Convert definition to bytes
-    definition_bytes = definition.encode('utf-8')
-
-    # Generate CID for the definition
-    cid = generate_cid(definition_bytes)
-
-    # Check if CID already exists to avoid duplicates
-    existing_cid = get_cid_by_path(f"/{cid}")
-    if not existing_cid:
-        create_cid_record(cid, definition_bytes, user_id)
-
-    return cid
-
-# ============================================================================
-# SERVER DEFINITIONS CID HELPERS
-# ============================================================================
-
 def get_server_definition_history(user_id, server_name):
     """Get historical server definitions for a specific server, ordered by time (latest first)"""
     from models import CID, db
@@ -296,52 +206,6 @@ def get_server_definition_history(user_id, server_name):
     
     return history
 
-def generate_all_server_definitions_json(user_id):
-    """Generate JSON containing all server definitions for a user"""
-    servers = get_user_servers(user_id)
-
-    # Create dictionary with server names as keys and definitions as values
-    server_definitions = {}
-    for server in servers:
-        server_definitions[server.name] = server.definition
-
-    # Convert to JSON string
-    return json.dumps(server_definitions, indent=2, sort_keys=True)
-
-def store_cid_from_json(json_content, user_id):
-    """Store all server definitions as JSON in a CID and return the CID path"""
-    json_bytes = json_content.encode('utf-8')
-
-    # Generate CID for the JSON content
-    cid = generate_cid(json_bytes)
-
-    # Check if CID already exists to avoid duplicates
-    existing_cid = get_cid_by_path(f"/{cid}")
-    if not existing_cid:
-        create_cid_record(cid, json_bytes, user_id)
-
-    return cid
-
-def store_server_definitions_cid(user_id):
-    """Store all server definitions as JSON in a CID and return the CID path"""
-    json_content = generate_all_server_definitions_json(user_id)
-    return store_cid_from_json(json_content, user_id)
-
-def get_current_server_definitions_cid(user_id):
-    """Get the CID path for the current server definitions JSON"""
-    # Generate what the current CID should be based on current servers
-    json_content = generate_all_server_definitions_json(user_id)
-    json_bytes = json_content.encode('utf-8')
-    expected_cid = generate_cid(json_bytes)
-
-    # Check if this CID exists in the database
-    existing_cid = get_cid_by_path(f"/{expected_cid}")
-    if existing_cid:
-        return expected_cid
-    else:
-        # If it doesn't exist, create it
-        return store_server_definitions_cid(user_id)
-
 def update_server_definitions_cid(user_id):
     """Update the server definitions CID after server changes"""
     return store_server_definitions_cid(user_id)
@@ -350,38 +214,6 @@ def update_server_definitions_cid(user_id):
 # VARIABLE DEFINITIONS CID HELPERS
 # ============================================================================
 
-def generate_all_variable_definitions_json(user_id):
-    """Generate JSON containing all variable definitions for a user"""
-    variables = get_user_variables(user_id)
-
-    # Create dictionary with variable names as keys and definitions as values
-    variable_definitions = {}
-    for variable in variables:
-        variable_definitions[variable.name] = variable.definition
-
-    # Convert to JSON string
-    return json.dumps(variable_definitions, indent=2, sort_keys=True)
-
-def store_variable_definitions_cid(user_id):
-    """Store all variable definitions as JSON in a CID and return the CID path"""
-    json_content = generate_all_variable_definitions_json(user_id)
-    return store_cid_from_json(json_content, user_id)
-
-def get_current_variable_definitions_cid(user_id):
-    """Get the CID path for the current variable definitions JSON"""
-    # Generate what the current CID should be based on current variables
-    json_content = generate_all_variable_definitions_json(user_id)
-    json_bytes = json_content.encode('utf-8')
-    expected_cid = generate_cid(json_bytes)
-
-    # Check if this CID exists in the database
-    existing_cid = get_cid_by_path(f"/{expected_cid}")
-    if existing_cid:
-        return expected_cid
-    else:
-        # If it doesn't exist, create it
-        return store_variable_definitions_cid(user_id)
-
 def update_variable_definitions_cid(user_id):
     """Update the variable definitions CID after variable changes"""
     return store_variable_definitions_cid(user_id)
@@ -389,48 +221,6 @@ def update_variable_definitions_cid(user_id):
 # ============================================================================
 # SERVER DEFINITIONS CID HELPERS
 # ============================================================================
-
-def generate_all_secret_definitions_json(user_id):
-    """Generate JSON containing all secret definitions for a user"""
-    secrets = get_user_secrets(user_id)
-
-    # Create dictionary with secret names as keys and definitions as values
-    secret_definitions = {}
-    for secret in secrets:
-        secret_definitions[secret.name] = secret.definition
-
-    # Convert to JSON string
-    return json.dumps(secret_definitions, indent=2, sort_keys=True)
-
-def store_secret_definitions_cid(user_id):
-    """Store all secret definitions as JSON in a CID and return the CID path"""
-    json_content = generate_all_secret_definitions_json(user_id)
-    json_bytes = json_content.encode('utf-8')
-
-    # Generate CID for the JSON content
-    cid = generate_cid(json_bytes)
-
-    # Check if CID already exists to avoid duplicates
-    existing_cid = get_cid_by_path(f"/{cid}")
-    if not existing_cid:
-        create_cid_record(cid, json_bytes, user_id)
-
-    return cid
-
-def get_current_secret_definitions_cid(user_id):
-    """Get the CID path for the current secret definitions JSON"""
-    # Generate what the current CID should be based on current secrets
-    json_content = generate_all_secret_definitions_json(user_id)
-    json_bytes = json_content.encode('utf-8')
-    expected_cid = generate_cid(json_bytes)
-
-    # Check if this CID exists in the database
-    existing_cid = get_cid_by_path(f"/{expected_cid}")
-    if existing_cid:
-        return expected_cid
-    else:
-        # If it doesn't exist, create it
-        return store_secret_definitions_cid(user_id)
 
 def update_secret_definitions_cid(user_id):
     """Update the secret definitions CID after secret changes"""
@@ -955,105 +745,6 @@ def execute_server_code(server, server_name):
         response.status_code = 500
         return response
 
-# ============================================================================
-# CID CONTENT SERVING HELPERS
-# ============================================================================
-
-# Shared MIME type and extension mappings
-EXTENSION_TO_MIME = {
-    'html': 'text/html',
-    'htm': 'text/html',
-    'txt': 'text/plain',
-    'css': 'text/css',
-    'js': 'application/javascript',
-    'json': 'application/json',
-    'xml': 'application/xml',
-    'pdf': 'application/pdf',
-    'zip': 'application/zip',
-    'tar': 'application/x-tar',
-    'gz': 'application/gzip',
-    'jpg': 'image/jpeg',
-    'jpeg': 'image/jpeg',
-    'png': 'image/png',
-    'gif': 'image/gif',
-    'svg': 'image/svg+xml',
-    'webp': 'image/webp',
-    'ico': 'image/x-icon',
-    'mp3': 'audio/mpeg',
-    'wav': 'audio/wav',
-    'ogg': 'audio/ogg',
-    'mp4': 'video/mp4',
-    'webm': 'video/webm',
-    'avi': 'video/x-msvideo',
-    'mov': 'video/quicktime',
-    'md': 'text/markdown',
-    'csv': 'text/csv',
-    'py': 'text/x-python',
-    'java': 'text/x-java-source',
-    'c': 'text/x-c',
-    'cpp': 'text/x-c++',
-    'h': 'text/x-c',
-    'hpp': 'text/x-c++',
-    'sh': 'application/x-sh',
-    'bat': 'application/x-msdos-program',
-    'exe': 'application/x-msdownload',
-    'dmg': 'application/x-apple-diskimage',
-    'deb': 'application/vnd.debian.binary-package',
-    'rpm': 'application/x-rpm'
-}
-
-# Create reverse mapping from MIME types to extensions
-MIME_TO_EXTENSION = {}
-for ext, mime in EXTENSION_TO_MIME.items():
-    if mime not in MIME_TO_EXTENSION:
-        # Use the first extension for each MIME type as the preferred one
-        MIME_TO_EXTENSION[mime] = ext
-
-def get_mime_type_from_extension(path):
-    """Determine MIME type from file extension in URL path"""
-    # Extract extension from path
-    if '.' in path:
-        extension = path.split('.')[-1].lower()
-        return EXTENSION_TO_MIME.get(extension, 'application/octet-stream')
-    # No extension, return default
-    return 'application/octet-stream'
-
-def get_extension_from_mime_type(content_type):
-    """Get file extension from MIME type"""
-    # Handle MIME types with parameters (e.g., "text/html; charset=utf-8")
-    base_mime = content_type.split(';')[0].strip().lower()
-    return MIME_TO_EXTENSION.get(base_mime, '')
-
-def extract_filename_from_cid_path(path):
-    """
-    Extract filename from CID path for content disposition header.
-
-    Rules:
-    - /{CID} -> no filename (no content disposition)
-    - /{CID}.{ext} -> no filename (no content disposition)
-    - /{CID}.{filename}.{ext} -> filename = {filename}.{ext}
-    """
-    # Remove leading slash
-    if path.startswith('/'):
-        path = path[1:]
-
-    # Handle empty or invalid paths
-    if not path or path in ['.', '..']:
-        return None
-    
-    # Split by dots
-    parts = path.split('.')
-
-    # Need at least 3 parts for filename: CID.filename.ext
-    if len(parts) < 3:
-        return None
-
-    # First part is CID, rest form the filename
-    filename_parts = parts[1:]
-    filename = '.'.join(filename_parts)
-
-    return filename
-
 def is_potential_versioned_server_path(path, existing_routes):
     """Check if path could be a versioned server invocation: /{server_name}/{partial_CID}"""
     if not path or not path.startswith('/'):
@@ -1154,52 +845,6 @@ def try_server_execution_with_partial(path):
     target = matches[0]
     definition_text = target.get('definition', '')
     return execute_server_code_from_definition(definition_text, server_name)
-
-def serve_cid_content(cid_content, path):
-    """Serve CID content with appropriate headers and caching"""
-    # Check if file_data is None (corrupted or missing data)
-    if cid_content is None or cid_content.file_data is None:
-        return None  # Return None to indicate content not found, let caller handle 404
-
-    # Extract CID from path (remove leading slash)
-    cid = path[1:] if path.startswith('/') else path
-
-    # Determine MIME type from URL extension
-    content_type = get_mime_type_from_extension(path)
-
-    # Check conditional requests using ETag (CID is perfect as ETag since it's content-based hash)
-    etag = f'"{cid.split(".")[0]}"'  # Use base CID without extension for ETag
-    if request.headers.get('If-None-Match') == etag:
-        # Client has the file cached, return 304 Not Modified
-        response = make_response('', 304)
-        response.headers['ETag'] = etag
-        return response
-
-    # Check If-Modified-Since (though ETag is more reliable for immutable content)
-    if request.headers.get('If-Modified-Since'):
-        # Since content is immutable, we can always return 304 if they have any cached version
-        response = make_response('', 304)
-        response.headers['ETag'] = etag
-        response.headers['Last-Modified'] = cid_content.created_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
-        return response
-
-    # Serve the file with aggressive caching headers
-    response = make_response(cid_content.file_data)
-    response.headers['Content-Type'] = content_type
-    response.headers['Content-Length'] = len(cid_content.file_data)
-
-    # Set content disposition header if filename is indicated in the path
-    filename = extract_filename_from_cid_path(path)
-    if filename:
-        response.headers['Content-Disposition'] = f'attachment; filename="{filename}"'
-
-    # Immutable content caching headers
-    response.headers['ETag'] = etag
-    response.headers['Last-Modified'] = cid_content.created_at.strftime('%a, %d %b %Y %H:%M:%S GMT')
-    response.headers['Cache-Control'] = 'public, max-age=31536000, immutable'  # 1 year
-    response.headers['Expires'] = 'Thu, 31 Dec 2037 23:55:55 GMT'  # Far future
-
-    return response
 
 # ============================================================================
 # CRUD OPERATION HELPERS

--- a/test_cid_functionality.py
+++ b/test_cid_functionality.py
@@ -4,7 +4,8 @@ import base64
 from unittest.mock import patch, MagicMock
 from app import app, db
 from models import CID, User
-from routes import generate_cid, get_mime_type_from_extension, create_cid_record, serve_cid_content
+from cid_utils import generate_cid, get_mime_type_from_extension, serve_cid_content
+from db_access import create_cid_record
 
 
 class TestCIDFunctionality(unittest.TestCase):
@@ -166,7 +167,7 @@ class TestCIDFunctionality(unittest.TestCase):
             self.assertFalse(hasattr(cid_record, 'content_type'))
             self.assertFalse(hasattr(cid_record, 'updated_at'))
     
-    @patch('routes.make_response')
+    @patch('cid_utils.make_response')
     def test_serve_cid_content_with_extension(self, mock_make_response):
         """Test serving CID content with file extension for MIME type detection"""
         with self.app.app_context():
@@ -203,7 +204,7 @@ class TestCIDFunctionality(unittest.TestCase):
                 mock_response.headers.__setitem__.assert_any_call('Content-Length', len(file_content))
                 mock_response.headers.__setitem__.assert_any_call('Cache-Control', 'public, max-age=31536000, immutable')
     
-    @patch('routes.make_response')
+    @patch('cid_utils.make_response')
     def test_serve_cid_content_without_extension(self, mock_make_response):
         """Test serving CID content without extension (should use application/octet-stream)"""
         with self.app.app_context():
@@ -236,7 +237,7 @@ class TestCIDFunctionality(unittest.TestCase):
                 # Verify default MIME type was set
                 mock_response.headers.__setitem__.assert_any_call('Content-Type', 'application/octet-stream')
     
-    @patch('routes.make_response')
+    @patch('cid_utils.make_response')
     def test_serve_cid_content_caching_headers(self, mock_make_response):
         """Test that proper caching headers are set for CID content"""
         with self.app.app_context():
@@ -268,7 +269,7 @@ class TestCIDFunctionality(unittest.TestCase):
                 mock_response.headers.__setitem__.assert_any_call('Cache-Control', 'public, max-age=31536000, immutable')
                 mock_response.headers.__setitem__.assert_any_call('Expires', 'Thu, 31 Dec 2037 23:55:55 GMT')
     
-    @patch('routes.make_response')
+    @patch('cid_utils.make_response')
     def test_serve_cid_content_etag_caching(self, mock_make_response):
         """Test ETag-based caching returns 304 when content hasn't changed"""
         with self.app.app_context():

--- a/test_cid_generation.py
+++ b/test_cid_generation.py
@@ -1,7 +1,7 @@
 import unittest
 import hashlib
 import base64
-from routes import generate_cid
+from cid_utils import generate_cid
 
 
 class TestCIDGeneration(unittest.TestCase):

--- a/test_extension_logic.py
+++ b/test_extension_logic.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import Mock
-from routes import process_file_upload, process_text_upload
+from cid_utils import process_file_upload, process_text_upload
 
 
 class TestExtensionLogic(unittest.TestCase):

--- a/test_routes_comprehensive.py
+++ b/test_routes_comprehensive.py
@@ -15,7 +15,7 @@ os.environ['TESTING'] = 'True'
 
 from app import app, db
 from models import User, Payment, TermsAcceptance, CID, Invitation, PageView, Server, Variable, Secret, CURRENT_TERMS_VERSION
-from routes import generate_cid
+from cid_utils import generate_cid
 
 
 class BaseTestCase(unittest.TestCase):

--- a/test_secret_definitions_cid.py
+++ b/test_secret_definitions_cid.py
@@ -6,12 +6,12 @@ import os
 import json
 from app import app, db
 from models import User, Secret, CID
-from routes import (
+from cid_utils import (
     generate_all_secret_definitions_json,
     store_secret_definitions_cid,
     get_current_secret_definitions_cid,
-    update_secret_definitions_cid
 )
+from routes import update_secret_definitions_cid
 
 class TestSecretDefinitionsCID(unittest.TestCase):
     def setUp(self):

--- a/test_serve_cid_content.py
+++ b/test_serve_cid_content.py
@@ -31,10 +31,10 @@ flask_login_mock = Mock()
 sys.modules['flask_login'] = flask_login_mock
 
 # Now we can import the function we want to test
-from routes import serve_cid_content  # noqa: E402
+from cid_utils import serve_cid_content  # noqa: E402
 
 
-# Mock the Flask app and other dependencies before importing routes
+# Mock the Flask app and other dependencies before importing cid_utils
 class MockApp:
     def __init__(self):
         self.config = {'TESTING': True}
@@ -49,11 +49,11 @@ class MockRequestContext:
     
     def __enter__(self):
         # Mock the request object
-        import routes
-        routes.request = Mock()
-        routes.request.path = self.path
-        routes.request.headers = Mock()
-        routes.request.headers.get = lambda key, default=None: self.headers.get(key, default)
+        import cid_utils
+        cid_utils.request = Mock()
+        cid_utils.request.path = self.path
+        cid_utils.request.headers = Mock()
+        cid_utils.request.headers.get = lambda key, default=None: self.headers.get(key, default)
         return self
     
     def __exit__(self, *args):
@@ -78,7 +78,7 @@ class TestServeCidContent(unittest.TestCase):
         path = "/bafybeihelloworld123456789012345678901234567890123456"
         
         with self.app.test_request_context(path):
-            with patch('routes.make_response') as mock_make_response:
+            with patch('cid_utils.make_response') as mock_make_response:
                 mock_response = Mock()
                 mock_response.headers = {}
                 mock_make_response.return_value = mock_response
@@ -100,7 +100,7 @@ class TestServeCidContent(unittest.TestCase):
         for path in test_cases:
             with self.subTest(path=path):
                 with self.app.test_request_context(path):
-                    with patch('routes.make_response') as mock_make_response:
+                    with patch('cid_utils.make_response') as mock_make_response:
                         mock_response = Mock()
                         mock_response.headers = {}
                         mock_make_response.return_value = mock_response
@@ -124,7 +124,7 @@ class TestServeCidContent(unittest.TestCase):
         for path, expected_filename in test_cases:
             with self.subTest(path=path, filename=expected_filename):
                 with self.app.test_request_context(path):
-                    with patch('routes.make_response') as mock_make_response:
+                    with patch('cid_utils.make_response') as mock_make_response:
                         mock_response = Mock()
                         mock_response.headers = {}
                         mock_make_response.return_value = mock_response
@@ -146,7 +146,7 @@ class TestServeCidContent(unittest.TestCase):
         for path, expected_filename in test_cases:
             with self.subTest(path=path, filename=expected_filename):
                 with self.app.test_request_context(path):
-                    with patch('routes.make_response') as mock_make_response:
+                    with patch('cid_utils.make_response') as mock_make_response:
                         mock_response = Mock()
                         mock_response.headers = {}
                         mock_make_response.return_value = mock_response
@@ -169,7 +169,7 @@ class TestServeCidContent(unittest.TestCase):
         for path, expected_filename in test_cases:
             with self.subTest(path=path, filename=expected_filename):
                 with self.app.test_request_context(path):
-                    with patch('routes.make_response') as mock_make_response:
+                    with patch('cid_utils.make_response') as mock_make_response:
                         mock_response = Mock()
                         mock_response.headers = {}
                         mock_make_response.return_value = mock_response
@@ -193,7 +193,7 @@ class TestServeCidContent(unittest.TestCase):
         for path, expected_filename in test_cases:
             with self.subTest(path=path, filename=expected_filename):
                 with self.app.test_request_context(path):
-                    with patch('routes.make_response') as mock_make_response:
+                    with patch('cid_utils.make_response') as mock_make_response:
                         mock_response = Mock()
                         mock_response.headers = {}
                         mock_make_response.return_value = mock_response
@@ -227,7 +227,7 @@ class TestServeCidContent(unittest.TestCase):
         path = "/bafybeihelloworld123456789012345678901234567890123456.document.txt"
         
         with self.app.test_request_context(path):
-            with patch('routes.make_response') as mock_make_response:
+            with patch('cid_utils.make_response') as mock_make_response:
                 mock_response = Mock()
                 mock_response.headers = {}
                 mock_make_response.return_value = mock_response
@@ -248,7 +248,7 @@ class TestServeCidContent(unittest.TestCase):
         
         # Test If-None-Match
         with self.app.test_request_context(path, headers={'If-None-Match': '"bafybeihelloworld123456789012345678901234567890123456"'}):
-            with patch('routes.make_response') as mock_make_response:
+            with patch('cid_utils.make_response') as mock_make_response:
                 mock_response = Mock()
                 mock_response.headers = {}
                 mock_make_response.return_value = mock_response

--- a/test_serve_cid_integration.py
+++ b/test_serve_cid_integration.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock
 # Add the current directory to the path so we can import modules
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# Mock all the dependencies before importing routes
+# Mock all the dependencies before importing cid_utils
 # Mock Flask and other dependencies
 sys.modules['app'] = Mock()
 sys.modules['models'] = Mock()
@@ -34,7 +34,7 @@ flask_mock.abort = Mock()
 sys.modules['flask'] = flask_mock
 
 # Now import the function we want to test
-from routes import extract_filename_from_cid_path  # noqa: E402
+from cid_utils import extract_filename_from_cid_path  # noqa: E402
 
 
 class TestExtractFilenameFromCidPath(unittest.TestCase):

--- a/test_server_cid_functionality.py
+++ b/test_server_cid_functionality.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from app import app, db
 from models import User, Server, CID
-from routes import save_server_definition_as_cid
+from cid_utils import save_server_definition_as_cid
 
 def test_server_cid_functionality():
     """Test that server definitions are saved as CIDs when created/updated"""

--- a/test_server_definitions_cid.py
+++ b/test_server_definitions_cid.py
@@ -31,12 +31,12 @@ sqlalchemy_mock = Mock()
 sys.modules['sqlalchemy'] = sqlalchemy_mock
 
 # Now import the functions we want to test
-from routes import (  # noqa: E402
+from cid_utils import (  # noqa: E402
     generate_all_server_definitions_json,
     store_server_definitions_cid,
     get_current_server_definitions_cid,
-    update_server_definitions_cid
 )
+from routes import update_server_definitions_cid  # noqa: E402
 
 
 class TestServerDefinitionsCID(unittest.TestCase):
@@ -61,7 +61,7 @@ class TestServerDefinitionsCID(unittest.TestCase):
         """Clean up after tests"""
         pass
 
-    @patch('routes.get_user_servers')
+    @patch('cid_utils.get_user_servers')
     def test_generate_all_server_definitions_json(self, mock_get_servers):
         """Test generating JSON of all server definitions for a user"""
         mock_get_servers.return_value = [self.mock_server1, self.mock_server2]
@@ -82,7 +82,7 @@ class TestServerDefinitionsCID(unittest.TestCase):
         # Should be valid JSON
         self.assertIsInstance(data, dict)
 
-    @patch('routes.get_user_servers')
+    @patch('cid_utils.get_user_servers')
     def test_generate_all_server_definitions_json_empty(self, mock_get_servers):
         """Test generating JSON when user has no servers"""
         mock_get_servers.return_value = []
@@ -93,10 +93,10 @@ class TestServerDefinitionsCID(unittest.TestCase):
         # Should be empty dict
         self.assertEqual(data, {})
 
-    @patch('routes.create_cid_record')
-    @patch('routes.get_cid_by_path')
-    @patch('routes.generate_cid')
-    @patch('routes.generate_all_server_definitions_json')
+    @patch('cid_utils.create_cid_record')
+    @patch('cid_utils.get_cid_by_path')
+    @patch('cid_utils.generate_cid')
+    @patch('cid_utils.generate_all_server_definitions_json')
     def test_store_server_definitions_cid(self, mock_json_gen, mock_generate_cid, mock_get_cid, mock_create_cid):
         """Test storing server definitions JSON as CID"""
         # Mock the JSON generation
@@ -114,10 +114,10 @@ class TestServerDefinitionsCID(unittest.TestCase):
         self.assertIsInstance(cid_path, str)
         self.assertTrue(len(cid_path) > 0)
 
-    @patch('routes.generate_all_server_definitions_json')
-    @patch('routes.store_server_definitions_cid')
-    @patch('routes.get_cid_by_path')
-    @patch('routes.generate_cid')
+    @patch('cid_utils.generate_all_server_definitions_json')
+    @patch('cid_utils.store_server_definitions_cid')
+    @patch('cid_utils.get_cid_by_path')
+    @patch('cid_utils.generate_cid')
     def test_get_current_server_definitions_cid(self, mock_generate_cid, mock_get_cid, mock_store_cid, mock_generate_json):
         """Test retrieving current server definitions CID"""
         # Mock the JSON generation

--- a/test_upload_extensions.py
+++ b/test_upload_extensions.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import io
 from app import app, db
 from models import CID, User
-from routes import process_file_upload, process_text_upload
+from cid_utils import process_file_upload, process_text_upload
 from forms import FileUploadForm
 
 

--- a/test_variable_definitions_cid.py
+++ b/test_variable_definitions_cid.py
@@ -6,12 +6,12 @@ import os
 import json
 from app import app, db
 from models import User, Variable, CID
-from routes import (
+from cid_utils import (
     generate_all_variable_definitions_json,
     store_variable_definitions_cid,
     get_current_variable_definitions_cid,
-    update_variable_definitions_cid
 )
+from routes import update_variable_definitions_cid
 
 class TestVariableDefinitionsCID(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- centralize CID generation, upload processing, JSON definition storage, and content serving helpers in a new `cid_utils` module with lazy database imports
- adjust `routes.py` and the migration script to import the shared helpers from `cid_utils`
- update CID-related tests to reference the new utility module and patch the relocated helpers

## Testing
- `pytest test_cid_generation.py`
- `pytest test_serve_cid_content.py`
- `pytest test_server_definitions_cid.py`
- `DATABASE_URL=sqlite:///test.db pytest test_variable_definitions_cid.py`
- `DATABASE_URL=sqlite:///test.db pytest test_secret_definitions_cid.py`
- `DATABASE_URL=sqlite:///test.db pytest test_upload_extensions.py` *(fails: session backend did not open a session)*

------
https://chatgpt.com/codex/tasks/task_b_68cab179fea48331965aa442041ba85e