### PR TITLE
Add CI workflow for linting and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
   tests:
     name: Unit Tests and Coverage
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite:////tmp/secureapp-ci.db
+      SESSION_SECRET: test-secret-key
+      TESTING: "True"
 
     steps:
       - name: Checkout repository
@@ -51,28 +55,51 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests with coverage
+        id: run_tests
         run: |
           python -m coverage run -m unittest discover -v
+        continue-on-error: true
 
       - name: Generate coverage reports
+        id: coverage
+        if: always()
         run: |
-          python -m coverage report > coverage-report.txt
-          cat coverage-report.txt
-          python -m coverage xml
-          python -m coverage html
-          echo "### Coverage summary" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat coverage-report.txt >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f ".coverage" ]; then
+            python -m coverage report > coverage-report.txt
+            cat coverage-report.txt
+            python -m coverage xml
+            python -m coverage html
+            {
+              echo "### Coverage summary"
+              echo '```'
+              cat coverage-report.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No coverage data found. Tests may not have run." | tee coverage-report.txt
+            {
+              echo "### Coverage summary"
+              echo
+              echo "No coverage data was generated."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload coverage XML
+        if: always() && steps.coverage.outputs.generated == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml
 
       - name: Upload HTML coverage report
+        if: always() && steps.coverage.outputs.generated == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov
+
+      - name: Fail if tests failed
+        if: steps.run_tests.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Ruff Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Run Ruff
+        run: ruff check .
+
+  tests:
+    name: Unit Tests and Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests with coverage
+        run: |
+          python -m coverage run -m unittest discover -v
+
+      - name: Generate coverage reports
+        run: |
+          python -m coverage report > coverage-report.txt
+          cat coverage-report.txt
+          python -m coverage xml
+          python -m coverage html
+          echo "### Coverage summary" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat coverage-report.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Ruff on pushes and pull requests
- execute the unit test suite under coverage, publish the summary, and upload coverage artifacts

## Testing
- not run (CI workflow only)


------
https://chatgpt.com/codex/tasks/task_b_68caedbf5d4c83319643e14ce8ba9a41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI pipeline that runs linting and tests on pushes and pull requests, using Python 3.11; improves reliability, visibility into code health, and feedback speed. Artifacts (coverage reports) are uploaded when available.

* **Tests**
  * Automated unit test execution with coverage collection and summarized coverage output in PR checks; includes fallback behavior when no coverage data exists to keep status and reporting consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->