### PR TITLE
Stabilize auth manager and local auth tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
 import os
 import logging
+from typing import Optional
+
 from flask import Flask
-from database import db, init_db
 from werkzeug.middleware.proxy_fix import ProxyFix
 from dotenv import load_dotenv
+
+from database import db, init_db
 
 # Load environment variables from .env file
 load_dotenv()
@@ -11,46 +14,68 @@ load_dotenv()
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
-# Initialize Flask app
-app = Flask(__name__)
-app.secret_key = os.environ.get("SESSION_SECRET")
-app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1) # needed for url_for to generate with https
 
-# Database configuration
-app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("DATABASE_URL")
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
-    'pool_pre_ping': True,
-    "pool_recycle": 300,
-}
+def create_app(config_override: Optional[dict] = None) -> Flask:
+    """Application factory for creating configured Flask instances."""
+    app = Flask(__name__)
 
-# Initialize database
-init_db(app)
+    default_database_uri = os.environ.get("DATABASE_URL") or "sqlite:///secureapp.db"
 
-# Create tables
-# Need to put this in module-level to make it work with Gunicorn.
-with app.app_context():
-    import models  # noqa: F401
-    import routes  # noqa: F401 - Import routes to register them
-    import local_auth  # noqa: F401 - Import local auth routes
-    import analytics  # noqa: F401 - Import analytics to register functions
+    app.config.update(
+        SECRET_KEY=os.environ.get("SESSION_SECRET", "dev-secret"),
+        SQLALCHEMY_DATABASE_URI=default_database_uri,
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "pool_pre_ping": True,
+            "pool_recycle": 300,
+        },
+    )
 
-    # Register analytics functions
+    if config_override:
+        app.config.update(config_override)
+
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)  # needed for url_for to generate with https
+
+    # Initialize database
+    init_db(app)
+
+    # Register application components
     from analytics import make_session_permanent, track_page_view
+    from local_auth import local_auth_bp
+    from routes import main_bp
+    from auth_providers import auth_manager
+
     app.before_request(make_session_permanent)
     app.after_request(track_page_view)
 
-    # Register blueprints
-    from local_auth import local_auth_bp
+    app.register_blueprint(main_bp)
     app.register_blueprint(local_auth_bp, url_prefix="/auth")
 
     # Register Replit auth if available
     try:
-        from replit_auth import make_replit_blueprint
-        if os.environ.get('REPL_ID'):
+        from replit_auth import make_replit_blueprint, init_login_manager
+
+        init_login_manager(app)
+        providers = getattr(auth_manager, "providers", None)
+        replit_provider = None
+        if isinstance(providers, dict):
+            replit_provider = providers.get("replit")
+
+        if replit_provider and getattr(replit_provider, "blueprint", None):
+            app.register_blueprint(replit_provider.blueprint, url_prefix="/auth")
+        elif os.environ.get("REPL_ID"):
             app.register_blueprint(make_replit_blueprint(), url_prefix="/auth")
     except ImportError:
         pass
 
-    db.create_all()
-    logging.info("Database tables created")
+    with app.app_context():
+        import models  # noqa: F401 ensure models are registered
+
+        db.create_all()
+        logging.info("Database tables created")
+
+    return app
+
+
+# Maintain module-level application for backwards compatibility
+app = create_app()

--- a/db_access.py
+++ b/db_access.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 
-from app import db
+from database import db
 from models import (
     Payment,
     TermsAcceptance,

--- a/inspect_db.py
+++ b/inspect_db.py
@@ -9,8 +9,10 @@ from datetime import datetime
 sys.path.insert(0, '.')
 
 # Import Flask app and models
-from app import app
+from app import create_app
 from models import User, CID, PageView, Server, Variable, Secret, Payment, TermsAcceptance, Invitation
+
+app = create_app()
 
 def inspect_database():
     """Inspect the database and show summary information"""

--- a/local_auth.py
+++ b/local_auth.py
@@ -25,7 +25,7 @@ def login():
         next_url = session.pop('next_url', None)
         if next_url:
             return redirect(next_url)
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('main.dashboard'))
 
     # GET request - show login page
     return render_template('local_login.html')
@@ -36,7 +36,7 @@ def logout():
     """Local development logout."""
     logout_user()
     flash('You have been logged out.', 'info')
-    return redirect(url_for('index'))
+    return redirect(url_for('main.index'))
 
 
 @local_auth_bp.route('/register', methods=['GET', 'POST'])
@@ -63,7 +63,7 @@ def register():
         next_url = session.pop('next_url', None)
         if next_url:
             return redirect(next_url)
-        return redirect(url_for('dashboard'))
+        return redirect(url_for('main.dashboard'))
 
     # GET request - show registration page
     return render_template('local_register.html')

--- a/migrate_add_server_cid.py
+++ b/migrate_add_server_cid.py
@@ -4,10 +4,13 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from app import app, db
+from app import create_app
+from database import db
 from models import Server
 from cid_utils import save_server_definition_as_cid
 import sqlite3
+
+app = create_app()
 
 def migrate_add_server_cid():
     """Add definition_cid column to Server table and populate existing servers"""

--- a/templates/403.html
+++ b/templates/403.html
@@ -11,7 +11,7 @@
                     <p class="card-text text-muted mb-4">
                         You don't have permission to access this resource. Please check your authentication status.
                     </p>
-                    <a href="{{ url_for('index') }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.index') }}" class="btn btn-primary">
                         <i class="fas fa-home me-2"></i>Back to Home
                     </a>
                 </div>

--- a/templates/404.html
+++ b/templates/404.html
@@ -18,14 +18,14 @@
                         <strong>Requested path:</strong> <code>{{ path }}</code>
                     </div>
                     <div class="d-flex gap-2 justify-content-center flex-wrap">
-                        <a href="{{ url_for('index') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.index') }}" class="btn btn-primary">
                             <i class="fas fa-home me-2"></i>Back to Home
                         </a>
-                        <a href="{{ url_for('upload') }}" class="btn btn-success">
+                        <a href="{{ url_for('main.upload') }}" class="btn btn-success">
                             <i class="fas fa-upload me-2"></i>Upload File
                         </a>
                         {% if current_user.is_authenticated %}
-                            <a href="{{ url_for('profile') }}" class="btn btn-outline-secondary">
+                            <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-user me-2"></i>Profile
                             </a>
                         {% endif %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -11,7 +11,7 @@
                     <p class="card-text text-muted mb-4">
                         Something went wrong on our end. We're working to fix the issue. Please try again later.
                     </p>
-                    <a href="{{ url_for('index') }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.index') }}" class="btn btn-primary">
                         <i class="fas fa-home me-2"></i>Back to Home
                     </a>
                 </div>

--- a/templates/accept_terms.html
+++ b/templates/accept_terms.html
@@ -27,7 +27,7 @@
                             <li>Service availability and limitations</li>
                         </ul>
                         <p class="small mb-0">
-                            <a href="{{ url_for('terms') }}" target="_blank">
+                            <a href="{{ url_for('main.terms') }}" target="_blank">
                                 <i class="fas fa-external-link-alt me-1"></i>Read full terms and conditions
                             </a>
                         </p>
@@ -58,7 +58,7 @@
                     <hr class="my-4">
                     
                     <div class="text-center">
-                        <a href="{{ url_for('profile') }}" class="btn btn-outline-secondary">
+                        <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary">
                             <i class="fas fa-arrow-left me-2"></i>Back to Profile
                         </a>
                     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
-            <a class="navbar-brand fw-bold" href="{{ url_for('index') }}">
+            <a class="navbar-brand fw-bold" href="{{ url_for('main.index') }}">
                 <i class="fas fa-shield-alt me-2"></i>SecureApp
             </a>
 
@@ -30,46 +30,46 @@
                 <ul class="navbar-nav me-auto">
                     {% if current_user.is_authenticated %}
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('profile') }}">
+                            <a class="nav-link" href="{{ url_for('main.profile') }}">
                                 <i class="fas fa-user me-1"></i>Profile
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('invitations') }}">
+                            <a class="nav-link" href="{{ url_for('main.invitations') }}">
                                 <i class="fas fa-users me-1"></i>Invitations
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('uploads') }}">
+                            <a class="nav-link" href="{{ url_for('main.uploads') }}">
                                 <i class="fas fa-upload me-1"></i>Uploads
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('history') }}">
+                            <a class="nav-link" href="{{ url_for('main.history') }}">
                                 <i class="fas fa-history me-1"></i>History
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('settings') }}">
+                            <a class="nav-link" href="{{ url_for('main.settings') }}">
                                 <i class="fas fa-cog me-1"></i>Settings
                             </a>
                         </li>
                         {% if current_user.has_access() %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('content') }}">
+                                <a class="nav-link" href="{{ url_for('main.content') }}">
                                     <i class="fas fa-lock me-1"></i>Content
                                 </a>
                             </li>
                         {% endif %}
                     {% endif %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('plans') }}">Plans</a>
+                        <a class="nav-link" href="{{ url_for('main.plans') }}">Plans</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('terms') }}">Terms</a>
+                        <a class="nav-link" href="{{ url_for('main.terms') }}">Terms</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('privacy') }}">Privacy</a>
+                        <a class="nav-link" href="{{ url_for('main.privacy') }}">Privacy</a>
                     </li>
                 </ul>
 
@@ -80,7 +80,7 @@
                                 <i class="fas fa-user-circle me-1"></i>{{ current_user.username }}
                             </a>
                             <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="{{ url_for('profile') }}">
+                                <li><a class="dropdown-item" href="{{ url_for('main.profile') }}">
                                     <i class="fas fa-user me-2"></i>Profile
                                 </a></li>
                                 <li><hr class="dropdown-divider"></li>
@@ -133,8 +133,8 @@
                     <p class="text-muted">Secure content management platform</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <a href="{{ url_for('terms') }}" class="text-light text-decoration-none me-3">Terms</a>
-                    <a href="{{ url_for('privacy') }}" class="text-light text-decoration-none">Privacy</a>
+                    <a href="{{ url_for('main.terms') }}" class="text-light text-decoration-none me-3">Terms</a>
+                    <a href="{{ url_for('main.privacy') }}" class="text-light text-decoration-none">Privacy</a>
                 </div>
             </div>
             <hr class="my-3">

--- a/templates/cid_content.html
+++ b/templates/cid_content.html
@@ -17,11 +17,11 @@
                 </div>
                 <div class="card-footer">
                     <div class="d-flex gap-2">
-                        <a href="{{ url_for('index') }}" class="btn btn-outline-primary btn-sm">
+                        <a href="{{ url_for('main.index') }}" class="btn btn-outline-primary btn-sm">
                             <i class="fas fa-home me-1"></i>Home
                         </a>
                         {% if current_user.is_authenticated %}
-                            <a href="{{ url_for('profile') }}" class="btn btn-outline-secondary btn-sm">
+                            <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary btn-sm">
                                 <i class="fas fa-user me-1"></i>Profile
                             </a>
                         {% endif %}

--- a/templates/create_invitation.html
+++ b/templates/create_invitation.html
@@ -38,7 +38,7 @@
                         
                         <div class="d-flex gap-2">
                             {{ form.submit(class="btn btn-primary") }}
-                            <a href="{{ url_for('invitations') }}" class="btn btn-outline-secondary">Cancel</a>
+                            <a href="{{ url_for('main.invitations') }}" class="btn btn-outline-secondary">Cancel</a>
                         </div>
                     </form>
                 </div>

--- a/templates/history.html
+++ b/templates/history.html
@@ -133,7 +133,7 @@
                                 <ul class="pagination justify-content-center">
                                     {% if page_views.has_prev %}
                                         <li class="page-item">
-                                            <a class="page-link" href="{{ url_for('history', page=page_views.prev_num) }}">Previous</a>
+                                            <a class="page-link" href="{{ url_for('main.history', page=page_views.prev_num) }}">Previous</a>
                                         </li>
                                     {% endif %}
                                     
@@ -141,7 +141,7 @@
                                         {% if page_num %}
                                             {% if page_num != page_views.page %}
                                                 <li class="page-item">
-                                                    <a class="page-link" href="{{ url_for('history', page=page_num) }}">{{ page_num }}</a>
+                                                    <a class="page-link" href="{{ url_for('main.history', page=page_num) }}">{{ page_num }}</a>
                                                 </li>
                                             {% else %}
                                                 <li class="page-item active">
@@ -157,7 +157,7 @@
                                     
                                     {% if page_views.has_next %}
                                         <li class="page-item">
-                                            <a class="page-link" href="{{ url_for('history', page=page_views.next_num) }}">Next</a>
+                                            <a class="page-link" href="{{ url_for('main.history', page=page_views.next_num) }}">Next</a>
                                         </li>
                                     {% endif %}
                                 </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
                     <i class="fas fa-user-plus me-2"></i>Get Started
                 </a>
                 {% endif %}
-                <a href="{{ url_for('plans') }}" class="btn btn-outline-secondary btn-lg">
+                <a href="{{ url_for('main.plans') }}" class="btn btn-outline-secondary btn-lg">
                     <i class="fas fa-info-circle me-2"></i>View Plans
                 </a>
             </div>
@@ -124,7 +124,7 @@
                 <i class="fas fa-rocket me-2"></i>Start Free Trial
             </a>
             {% endif %}
-            <a href="{{ url_for('plans') }}" class="btn btn-outline-primary btn-lg">
+            <a href="{{ url_for('main.plans') }}" class="btn btn-outline-primary btn-lg">
                 <i class="fas fa-eye me-2"></i>View Pricing
             </a>
         </div>

--- a/templates/invitations.html
+++ b/templates/invitations.html
@@ -8,7 +8,7 @@
         <div class="col-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-users me-2"></i>Manage Invitations</h2>
-                <a href="{{ url_for('create_invitation') }}" class="btn btn-primary">
+                <a href="{{ url_for('main.create_invitation') }}" class="btn btn-primary">
                     <i class="fas fa-plus me-1"></i>Create Invitation
                 </a>
             </div>
@@ -90,7 +90,7 @@
                         <i class="fas fa-user-plus text-muted mb-3" style="font-size: 3rem;"></i>
                         <h4>No Invitations Yet</h4>
                         <p class="text-muted">You haven't created any invitations. Create your first invitation to start referring users.</p>
-                        <a href="{{ url_for('create_invitation') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.create_invitation') }}" class="btn btn-primary">
                             <i class="fas fa-plus me-1"></i>Create First Invitation
                         </a>
                     </div>

--- a/templates/local_login.html
+++ b/templates/local_login.html
@@ -36,7 +36,7 @@
                     </div>
 
                     <div class="text-center mt-4">
-                        <a href="{{ url_for('index') }}" class="text-muted text-decoration-none">
+                        <a href="{{ url_for('main.index') }}" class="text-muted text-decoration-none">
                             <i class="fas fa-arrow-left me-1"></i>Back to Home
                         </a>
                     </div>

--- a/templates/local_register.html
+++ b/templates/local_register.html
@@ -56,7 +56,7 @@
                     </div>
 
                     <div class="text-center mt-4">
-                        <a href="{{ url_for('index') }}" class="text-muted text-decoration-none">
+                        <a href="{{ url_for('main.index') }}" class="text-muted text-decoration-none">
                             <i class="fas fa-arrow-left me-1"></i>Back to Home
                         </a>
                     </div>

--- a/templates/plans.html
+++ b/templates/plans.html
@@ -48,7 +48,7 @@
                 </div>
                 <div class="card-footer">
                     {% if current_user.is_authenticated %}
-                        <a href="{{ url_for('subscribe') }}" class="btn btn-primary w-100">
+                        <a href="{{ url_for('main.subscribe') }}" class="btn btn-primary w-100">
                             <i class="fas fa-credit-card me-2"></i>Select Free Plan
                         </a>
                     {% else %}
@@ -111,7 +111,7 @@
                 </div>
                 <div class="card-footer">
                     {% if current_user.is_authenticated %}
-                        <a href="{{ url_for('subscribe') }}" class="btn btn-success w-100">
+                        <a href="{{ url_for('main.subscribe') }}" class="btn btn-success w-100">
                             <i class="fas fa-star me-2"></i>Subscribe Annual
                         </a>
                     {% else %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -150,11 +150,11 @@
                     <hr class="my-4">
 
                     <div class="text-center">
-                        <a href="{{ url_for('index') }}" class="btn btn-outline-primary btn-lg">
+                        <a href="{{ url_for('main.index') }}" class="btn btn-outline-primary btn-lg">
                             <i class="fas fa-home me-2"></i>Back to Home
                         </a>
                         {% if current_user.is_authenticated %}
-                            <a href="{{ url_for('profile') }}" class="btn btn-primary btn-lg ms-2">
+                            <a href="{{ url_for('main.profile') }}" class="btn btn-primary btn-lg ms-2">
                                 <i class="fas fa-user me-2"></i>My Profile
                             </a>
                         {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -38,7 +38,7 @@
                             {% endif %}
                         {% else %}
                             <span class="badge bg-warning">Unpaid</span><br>
-                            <a href="{{ url_for('subscribe') }}" class="btn btn-sm btn-warning mt-1">Subscribe</a>
+                            <a href="{{ url_for('main.subscribe') }}" class="btn btn-sm btn-warning mt-1">Subscribe</a>
                         {% endif %}
                     </p>
                 </div>
@@ -56,7 +56,7 @@
                             <small class="text-muted">Version {{ current_terms_version }}</small>
                         {% else %}
                             <span class="badge bg-danger">Pending</span><br>
-                            <a href="{{ url_for('accept_terms') }}" class="btn btn-sm btn-danger mt-1">Accept Terms</a>
+                            <a href="{{ url_for('main.accept_terms') }}" class="btn btn-sm btn-danger mt-1">Accept Terms</a>
                         {% endif %}
                     </p>
                 </div>
@@ -69,7 +69,7 @@
         <div class="alert alert-success" role="alert">
             <i class="fas fa-check-circle me-2"></i>
             <strong>Full Access Granted!</strong> You can now access all premium content.
-            <a href="{{ url_for('content') }}" class="btn btn-success btn-sm ms-2">
+            <a href="{{ url_for('main.content') }}" class="btn btn-success btn-sm ms-2">
                 <i class="fas fa-arrow-right me-1"></i>Access Content
             </a>
         </div>
@@ -95,7 +95,7 @@
                         <i class="fas fa-credit-card me-2"></i>Payment History
                     </h5>
                     {% if not current_user.is_paid %}
-                        <a href="{{ url_for('subscribe') }}" class="btn btn-primary btn-sm">
+                        <a href="{{ url_for('main.subscribe') }}" class="btn btn-primary btn-sm">
                             <i class="fas fa-plus me-1"></i>Subscribe
                         </a>
                     {% endif %}
@@ -132,7 +132,7 @@
                         <div class="text-center py-4">
                             <i class="fas fa-credit-card text-muted mb-3" style="font-size: 3rem;"></i>
                             <p class="text-muted">No payment history found.</p>
-                            <a href="{{ url_for('subscribe') }}" class="btn btn-primary">
+                            <a href="{{ url_for('main.subscribe') }}" class="btn btn-primary">
                                 <i class="fas fa-credit-card me-2"></i>Subscribe Now
                             </a>
                         </div>
@@ -149,7 +149,7 @@
                         <i class="fas fa-file-contract me-2"></i>Terms Acceptance History
                     </h5>
                     {% if needs_terms_acceptance %}
-                        <a href="{{ url_for('accept_terms') }}" class="btn btn-warning btn-sm">
+                        <a href="{{ url_for('main.accept_terms') }}" class="btn btn-warning btn-sm">
                             <i class="fas fa-exclamation-triangle me-1"></i>Accept Current
                         </a>
                     {% endif %}
@@ -189,7 +189,7 @@
                         <div class="text-center py-4">
                             <i class="fas fa-file-contract text-muted mb-3" style="font-size: 3rem;"></i>
                             <p class="text-muted">No terms acceptance history found.</p>
-                            <a href="{{ url_for('accept_terms') }}" class="btn btn-warning">
+                            <a href="{{ url_for('main.accept_terms') }}" class="btn btn-warning">
                                 <i class="fas fa-file-contract me-2"></i>Accept Terms
                             </a>
                         </div>

--- a/templates/secret_form.html
+++ b/templates/secret_form.html
@@ -8,7 +8,7 @@
         <div class="col-lg-8">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-key me-2"></i>{{ title }}</h2>
-                <a href="{{ url_for('secrets') }}" class="btn btn-secondary">
+                <a href="{{ url_for('main.secrets') }}" class="btn btn-secondary">
                     <i class="fas fa-arrow-left me-1"></i>Back to Secrets
                 </a>
             </div>
@@ -54,7 +54,7 @@
                         </div>
 
                         <div class="d-flex justify-content-between">
-                            <a href="{{ url_for('secrets') }}" class="btn btn-secondary">
+                            <a href="{{ url_for('main.secrets') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
                             {{ form.submit(class="btn btn-primary") }}

--- a/templates/secret_view.html
+++ b/templates/secret_view.html
@@ -9,10 +9,10 @@
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-key me-2"></i>{{ secret.name }}</h2>
                 <div class="btn-group">
-                    <a href="{{ url_for('secrets') }}" class="btn btn-secondary">
+                    <a href="{{ url_for('main.secrets') }}" class="btn btn-secondary">
                         <i class="fas fa-arrow-left me-1"></i>Back to Secrets
                     </a>
-                    <a href="{{ url_for('edit_secret', secret_name=secret.name) }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.edit_secret', secret_name=secret.name) }}" class="btn btn-primary">
                         <i class="fas fa-edit me-1"></i>Edit Secret
                     </a>
                 </div>
@@ -25,7 +25,7 @@
                         <button class="btn btn-outline-secondary btn-sm" onclick="copyDefinition()">
                             <i class="fas fa-copy me-1"></i>Copy
                         </button>
-                        <form method="POST" action="{{ url_for('delete_secret', secret_name=secret.name) }}" 
+                        <form method="POST" action="{{ url_for('main.delete_secret', secret_name=secret.name) }}" 
                               onsubmit="return confirm('Are you sure you want to delete secret {{ secret.name }}?')" class="d-inline">
                             <button type="submit" class="btn btn-outline-danger btn-sm">
                                 <i class="fas fa-trash me-1"></i>Delete

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -14,7 +14,7 @@
                         <i class="fas fa-download me-1"></i>Export All as JSON
                     </a>
                     {% endif %}
-                    <a href="{{ url_for('new_secret') }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.new_secret') }}" class="btn btn-primary">
                         <i class="fas fa-plus me-1"></i>Create New Secret
                     </a>
                 </div>
@@ -30,10 +30,10 @@
                                 <i class="fas fa-key me-2"></i>{{ secret.name }}
                             </h5>
                             <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('view_secret', secret_name=secret.name) }}" class="btn btn-outline-primary btn-sm">
+                                <a href="{{ url_for('main.view_secret', secret_name=secret.name) }}" class="btn btn-outline-primary btn-sm">
                                     <i class="fas fa-eye me-1"></i>View
                                 </a>
-                                <a href="{{ url_for('edit_secret', secret_name=secret.name) }}" class="btn btn-outline-secondary btn-sm">
+                                <a href="{{ url_for('main.edit_secret', secret_name=secret.name) }}" class="btn btn-outline-secondary btn-sm">
                                     <i class="fas fa-edit me-1"></i>Edit
                                 </a>
                             </div>
@@ -60,10 +60,10 @@
                         </div>
                         <div class="card-footer">
                             <div class="d-flex justify-content-between align-items-center">
-                                <a href="{{ url_for('view_secret', secret_name=secret.name) }}" class="btn btn-primary btn-sm">
+                                <a href="{{ url_for('main.view_secret', secret_name=secret.name) }}" class="btn btn-primary btn-sm">
                                     <i class="fas fa-arrow-right me-1"></i>View Full Definition
                                 </a>
-                                <form method="POST" action="{{ url_for('delete_secret', secret_name=secret.name) }}" 
+                                <form method="POST" action="{{ url_for('main.delete_secret', secret_name=secret.name) }}" 
                                       onsubmit="return confirm('Are you sure you want to delete secret {{ secret.name }}?')" class="d-inline">
                                     <button type="submit" class="btn btn-outline-danger btn-sm">
                                         <i class="fas fa-trash me-1"></i>Delete
@@ -82,7 +82,7 @@
                         <i class="fas fa-key text-muted mb-3" style="font-size: 3rem;"></i>
                         <h4>No Secrets Created Yet</h4>
                         <p class="text-muted">Create your first secret definition to get started.</p>
-                        <a href="{{ url_for('new_secret') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.new_secret') }}" class="btn btn-primary">
                             <i class="fas fa-plus me-1"></i>Create Your First Secret
                         </a>
                     </div>

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -8,7 +8,7 @@
         <div class="col-lg-8">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-server me-2"></i>{{ title }}</h2>
-                <a href="{{ url_for('servers') }}" class="btn btn-secondary">
+                <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">
                     <i class="fas fa-arrow-left me-1"></i>Back to Servers
                 </a>
             </div>
@@ -54,7 +54,7 @@
                         </div>
 
                         <div class="d-flex justify-content-between">
-                            <a href="{{ url_for('servers') }}" class="btn btn-secondary">
+                            <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
                             {{ form.submit(class="btn btn-primary") }}

--- a/templates/server_view.html
+++ b/templates/server_view.html
@@ -9,10 +9,10 @@
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-server me-2"></i>{{ server.name }}</h2>
                 <div class="btn-group">
-                    <a href="{{ url_for('servers') }}" class="btn btn-secondary">
+                    <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">
                         <i class="fas fa-arrow-left me-1"></i>Back to Servers
                     </a>
-                    <a href="{{ url_for('edit_server', server_name=server.name) }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.edit_server', server_name=server.name) }}" class="btn btn-primary">
                         <i class="fas fa-edit me-1"></i>Edit Server
                     </a>
                 </div>
@@ -25,7 +25,7 @@
                         <button class="btn btn-outline-secondary btn-sm" onclick="copyDefinition()">
                             <i class="fas fa-copy me-1"></i>Copy
                         </button>
-                        <form method="POST" action="{{ url_for('delete_server', server_name=server.name) }}" 
+                        <form method="POST" action="{{ url_for('main.delete_server', server_name=server.name) }}" 
                               onsubmit="return confirm('Are you sure you want to delete server {{ server.name }}?')" class="d-inline">
                             <button type="submit" class="btn btn-outline-danger btn-sm">
                                 <i class="fas fa-trash me-1"></i>Delete

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -17,7 +17,7 @@
                         <i class="fas fa-download me-1"></i>Download JSON
                     </a>
                     {% endif %}
-                    <a href="{{ url_for('new_server') }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.new_server') }}" class="btn btn-primary">
                         <i class="fas fa-plus me-1"></i>Create New Server
                     </a>
                 </div>
@@ -33,10 +33,10 @@
                                 <i class="fas fa-server me-2"></i>{{ server.name }}
                             </h5>
                             <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('view_server', server_name=server.name) }}" class="btn btn-outline-primary btn-sm">
+                                <a href="{{ url_for('main.view_server', server_name=server.name) }}" class="btn btn-outline-primary btn-sm">
                                     <i class="fas fa-eye me-1"></i>View
                                 </a>
-                                <a href="{{ url_for('edit_server', server_name=server.name) }}" class="btn btn-outline-secondary btn-sm">
+                                <a href="{{ url_for('main.edit_server', server_name=server.name) }}" class="btn btn-outline-secondary btn-sm">
                                     <i class="fas fa-edit me-1"></i>Edit
                                 </a>
                             </div>
@@ -63,10 +63,10 @@
                         </div>
                         <div class="card-footer">
                             <div class="d-flex justify-content-between align-items-center">
-                                <a href="{{ url_for('view_server', server_name=server.name) }}" class="btn btn-primary btn-sm">
+                                <a href="{{ url_for('main.view_server', server_name=server.name) }}" class="btn btn-primary btn-sm">
                                     <i class="fas fa-arrow-right me-1"></i>View Full Definition
                                 </a>
-                                <form method="POST" action="{{ url_for('delete_server', server_name=server.name) }}"
+                                <form method="POST" action="{{ url_for('main.delete_server', server_name=server.name) }}"
                                       onsubmit="return confirm('Are you sure you want to delete server {{ server.name }}?')" class="d-inline">
                                     <button type="submit" class="btn btn-outline-danger btn-sm">
                                         <i class="fas fa-trash me-1"></i>Delete
@@ -85,7 +85,7 @@
                         <i class="fas fa-server text-muted mb-3" style="font-size: 3rem;"></i>
                         <h4>No Servers Created Yet</h4>
                         <p class="text-muted">Create your first server definition to get started.</p>
-                        <a href="{{ url_for('new_server') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.new_server') }}" class="btn btn-primary">
                             <i class="fas fa-plus me-1"></i>Create Your First Server
                         </a>
                     </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -25,10 +25,10 @@
                                 <span class="badge bg-primary fs-6">{{ server_count }} server{{ 's' if server_count != 1 else '' }}</span>
                             </div>
                             <div class="d-grid gap-2">
-                                <a href="{{ url_for('servers') }}" class="btn btn-primary">
+                                <a href="{{ url_for('main.servers') }}" class="btn btn-primary">
                                     <i class="fas fa-list me-1"></i>View All Servers
                                 </a>
-                                <a href="{{ url_for('new_server') }}" class="btn btn-outline-primary">
+                                <a href="{{ url_for('main.new_server') }}" class="btn btn-outline-primary">
                                     <i class="fas fa-plus me-1"></i>Create New Server
                                 </a>
                             </div>
@@ -52,10 +52,10 @@
                                 <span class="badge bg-success fs-6">{{ variable_count }} variable{{ 's' if variable_count != 1 else '' }}</span>
                             </div>
                             <div class="d-grid gap-2">
-                                <a href="{{ url_for('variables') }}" class="btn btn-success">
+                                <a href="{{ url_for('main.variables') }}" class="btn btn-success">
                                     <i class="fas fa-list me-1"></i>View All Variables
                                 </a>
-                                <a href="{{ url_for('new_variable') }}" class="btn btn-outline-success">
+                                <a href="{{ url_for('main.new_variable') }}" class="btn btn-outline-success">
                                     <i class="fas fa-plus me-1"></i>Create New Variable
                                 </a>
                             </div>
@@ -79,10 +79,10 @@
                                 <span class="badge bg-warning fs-6">{{ secret_count }} secret{{ 's' if secret_count != 1 else '' }}</span>
                             </div>
                             <div class="d-grid gap-2">
-                                <a href="{{ url_for('secrets') }}" class="btn btn-warning">
+                                <a href="{{ url_for('main.secrets') }}" class="btn btn-warning">
                                     <i class="fas fa-list me-1"></i>View All Secrets
                                 </a>
-                                <a href="{{ url_for('new_secret') }}" class="btn btn-outline-warning">
+                                <a href="{{ url_for('main.new_secret') }}" class="btn btn-outline-warning">
                                     <i class="fas fa-plus me-1"></i>Create New Secret
                                 </a>
                             </div>

--- a/templates/subscribe.html
+++ b/templates/subscribe.html
@@ -40,7 +40,7 @@
                     <hr class="my-4">
                     
                     <div class="text-center">
-                        <a href="{{ url_for('profile') }}" class="btn btn-outline-secondary">
+                        <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary">
                             <i class="fas fa-arrow-left me-2"></i>Back to Profile
                         </a>
                     </div>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -126,10 +126,10 @@
 
                     <div class="text-center">
                         {% if current_user.is_authenticated %}
-                            <a href="{{ url_for('accept_terms') }}" class="btn btn-primary btn-lg">
+                            <a href="{{ url_for('main.accept_terms') }}" class="btn btn-primary btn-lg">
                                 <i class="fas fa-check-circle me-2"></i>Accept These Terms
                             </a>
-                            <a href="{{ url_for('profile') }}" class="btn btn-outline-secondary btn-lg ms-2">
+                            <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary btn-lg ms-2">
                                 <i class="fas fa-arrow-left me-2"></i>Back to Profile
                             </a>
                         {% else %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -101,7 +101,7 @@
 
                         <div class="d-flex gap-2">
                             {{ form.submit(class="btn btn-success") }}
-                            <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">Cancel</a>
+                            <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">Cancel</a>
                         </div>
                     </form>
                 </div>

--- a/templates/upload_success.html
+++ b/templates/upload_success.html
@@ -70,10 +70,10 @@
                     </div>
                     
                     <div class="d-flex gap-2 mt-4">
-                        <a href="{{ url_for('upload') }}" class="btn btn-success">
+                        <a href="{{ url_for('main.upload') }}" class="btn btn-success">
                             <i class="fas fa-upload me-2"></i>Upload Another File
                         </a>
-                        <a href="{{ url_for('index') }}" class="btn btn-outline-primary">
+                        <a href="{{ url_for('main.index') }}" class="btn btn-outline-primary">
                             <i class="fas fa-home me-2"></i>Back to Home
                         </a>
                     </div>

--- a/templates/uploads.html
+++ b/templates/uploads.html
@@ -8,7 +8,7 @@
         <div class="col-12">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-upload me-2"></i>My Uploads</h2>
-                <a href="{{ url_for('upload') }}" class="btn btn-primary">
+                <a href="{{ url_for('main.upload') }}" class="btn btn-primary">
                     <i class="fas fa-plus me-1"></i>Upload New File
                 </a>
             </div>
@@ -129,7 +129,7 @@
                         <i class="fas fa-cloud-upload-alt text-muted mb-3" style="font-size: 3rem;"></i>
                         <h4>No Files Uploaded Yet</h4>
                         <p class="text-muted">Upload your first file to start building your content library.</p>
-                        <a href="{{ url_for('upload') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.upload') }}" class="btn btn-primary">
                             <i class="fas fa-upload me-1"></i>Upload Your First File
                         </a>
                     </div>

--- a/templates/variable_form.html
+++ b/templates/variable_form.html
@@ -8,7 +8,7 @@
         <div class="col-lg-8">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-code me-2"></i>{{ title }}</h2>
-                <a href="{{ url_for('variables') }}" class="btn btn-secondary">
+                <a href="{{ url_for('main.variables') }}" class="btn btn-secondary">
                     <i class="fas fa-arrow-left me-1"></i>Back to Variables
                 </a>
             </div>
@@ -54,7 +54,7 @@
                         </div>
 
                         <div class="d-flex justify-content-between">
-                            <a href="{{ url_for('variables') }}" class="btn btn-secondary">
+                            <a href="{{ url_for('main.variables') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
                             {{ form.submit(class="btn btn-primary") }}

--- a/templates/variable_view.html
+++ b/templates/variable_view.html
@@ -9,10 +9,10 @@
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-code me-2"></i>{{ variable.name }}</h2>
                 <div class="btn-group">
-                    <a href="{{ url_for('variables') }}" class="btn btn-secondary">
+                    <a href="{{ url_for('main.variables') }}" class="btn btn-secondary">
                         <i class="fas fa-arrow-left me-1"></i>Back to Variables
                     </a>
-                    <a href="{{ url_for('edit_variable', variable_name=variable.name) }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.edit_variable', variable_name=variable.name) }}" class="btn btn-primary">
                         <i class="fas fa-edit me-1"></i>Edit Variable
                     </a>
                 </div>
@@ -25,7 +25,7 @@
                         <button class="btn btn-outline-secondary btn-sm" onclick="copyDefinition()">
                             <i class="fas fa-copy me-1"></i>Copy
                         </button>
-                        <form method="POST" action="{{ url_for('delete_variable', variable_name=variable.name) }}" 
+                        <form method="POST" action="{{ url_for('main.delete_variable', variable_name=variable.name) }}" 
                               onsubmit="return confirm('Are you sure you want to delete variable {{ variable.name }}?')" class="d-inline">
                             <button type="submit" class="btn btn-outline-danger btn-sm">
                                 <i class="fas fa-trash me-1"></i>Delete

--- a/templates/variables.html
+++ b/templates/variables.html
@@ -14,7 +14,7 @@
                         <i class="fas fa-download me-1"></i>Export All as JSON
                     </a>
                     {% endif %}
-                    <a href="{{ url_for('new_variable') }}" class="btn btn-primary">
+                    <a href="{{ url_for('main.new_variable') }}" class="btn btn-primary">
                         <i class="fas fa-plus me-1"></i>Create New Variable
                     </a>
                 </div>
@@ -30,10 +30,10 @@
                                 <i class="fas fa-code me-2"></i>{{ variable.name }}
                             </h5>
                             <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('view_variable', variable_name=variable.name) }}" class="btn btn-outline-primary btn-sm">
+                                <a href="{{ url_for('main.view_variable', variable_name=variable.name) }}" class="btn btn-outline-primary btn-sm">
                                     <i class="fas fa-eye me-1"></i>View
                                 </a>
-                                <a href="{{ url_for('edit_variable', variable_name=variable.name) }}" class="btn btn-outline-secondary btn-sm">
+                                <a href="{{ url_for('main.edit_variable', variable_name=variable.name) }}" class="btn btn-outline-secondary btn-sm">
                                     <i class="fas fa-edit me-1"></i>Edit
                                 </a>
                             </div>
@@ -60,10 +60,10 @@
                         </div>
                         <div class="card-footer">
                             <div class="d-flex justify-content-between align-items-center">
-                                <a href="{{ url_for('view_variable', variable_name=variable.name) }}" class="btn btn-primary btn-sm">
+                                <a href="{{ url_for('main.view_variable', variable_name=variable.name) }}" class="btn btn-primary btn-sm">
                                     <i class="fas fa-arrow-right me-1"></i>View Full Definition
                                 </a>
-                                <form method="POST" action="{{ url_for('delete_variable', variable_name=variable.name) }}" 
+                                <form method="POST" action="{{ url_for('main.delete_variable', variable_name=variable.name) }}" 
                                       onsubmit="return confirm('Are you sure you want to delete variable {{ variable.name }}?')" class="d-inline">
                                     <button type="submit" class="btn btn-outline-danger btn-sm">
                                         <i class="fas fa-trash me-1"></i>Delete
@@ -82,7 +82,7 @@
                         <i class="fas fa-code text-muted mb-3" style="font-size: 3rem;"></i>
                         <h4>No Variables Created Yet</h4>
                         <p class="text-muted">Create your first variable definition to get started.</p>
-                        <a href="{{ url_for('new_variable') }}" class="btn btn-primary">
+                        <a href="{{ url_for('main.new_variable') }}" class="btn btn-primary">
                             <i class="fas fa-plus me-1"></i>Create Your First Variable
                         </a>
                     </div>

--- a/test_local_auth.py
+++ b/test_local_auth.py
@@ -4,11 +4,46 @@ Unit tests for the local authentication routes.
 """
 import unittest
 from unittest.mock import patch, MagicMock
-from flask import Flask
+from flask import Flask, Blueprint
 from flask_login import LoginManager
 from app import db
 from local_auth import local_auth_bp
 from models import User
+
+
+def _create_main_stub_blueprint() -> Blueprint:
+    """Create a minimal main blueprint to satisfy template url_for calls."""
+    main_bp = Blueprint('main', __name__)
+
+    @main_bp.route('/')
+    def index():
+        return "Index page"
+
+    @main_bp.route('/dashboard')
+    def dashboard():
+        return "Dashboard page"
+
+    @main_bp.route('/plans')
+    def plans():
+        return "Plans page"
+
+    @main_bp.route('/profile')
+    def profile():
+        return "Profile page"
+
+    @main_bp.route('/content')
+    def content():
+        return "Content page"
+
+    @main_bp.route('/terms')
+    def terms():
+        return "Terms page"
+
+    @main_bp.route('/privacy')
+    def privacy():
+        return "Privacy page"
+
+    return main_bp
 
 
 class TestLocalAuthRoutes(unittest.TestCase):
@@ -33,37 +68,9 @@ class TestLocalAuthRoutes(unittest.TestCase):
 
         db.init_app(self.app)
 
-        # Register all necessary routes
+        # Register main blueprint stubs required by local_auth redirects
+        self.app.register_blueprint(_create_main_stub_blueprint())
         self.app.register_blueprint(local_auth_bp, url_prefix="/auth")
-
-        # Add basic routes that templates need
-        @self.app.route('/')
-        def index():
-            return "Index page"
-
-        @self.app.route('/dashboard')
-        def dashboard():
-            return "Dashboard page"
-
-        @self.app.route('/plans')
-        def plans():
-            return "Plans page"
-
-        @self.app.route('/profile')
-        def profile():
-            return "Profile page"
-
-        @self.app.route('/content')
-        def content():
-            return "Content page"
-
-        @self.app.route('/terms')
-        def terms():
-            return "Terms page"
-
-        @self.app.route('/privacy')
-        def privacy():
-            return "Privacy page"
 
         with self.app.app_context():
             db.create_all()
@@ -217,35 +224,7 @@ class TestLocalAuthIntegration(unittest.TestCase):
 
         # Register all necessary routes
         self.app.register_blueprint(local_auth_bp, url_prefix="/auth")
-
-        # Add basic routes that templates need
-        @self.app.route('/')
-        def index():
-            return "Index page"
-
-        @self.app.route('/dashboard')
-        def dashboard():
-            return "Dashboard page"
-
-        @self.app.route('/plans')
-        def plans():
-            return "Plans page"
-
-        @self.app.route('/profile')
-        def profile():
-            return "Profile page"
-
-        @self.app.route('/content')
-        def content():
-            return "Content page"
-
-        @self.app.route('/terms')
-        def terms():
-            return "Terms page"
-
-        @self.app.route('/privacy')
-        def privacy():
-            return "Privacy page"
+        self.app.register_blueprint(_create_main_stub_blueprint())
 
         with self.app.app_context():
             db.create_all()

--- a/test_server_history.py
+++ b/test_server_history.py
@@ -11,12 +11,10 @@ import os
 # Add the project root to Python path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# Mock app before importing routes
-with patch('routes.app') as mock_app:
-    mock_app.config = {'SECRET_KEY': 'test'}
-    from routes import get_server_definition_history
-    import json
-    from datetime import datetime, timezone
+# Import route helper for testing
+from routes import get_server_definition_history
+import json
+from datetime import datetime, timezone
 
 class TestServerHistory(unittest.TestCase):
     """Test server definition history functionality"""


### PR DESCRIPTION
## Summary
- harden AuthManager so the factory can run even when tests patch providers and fall back to the namespaced main routes
- add a reusable stub main blueprint in test_local_auth to satisfy url_for('main.*') usage during unit and integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb6be0530083318f4456ce89b954fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable app initialization with sensible defaults for database and session secret.
- Improvements
  - Consistent, namespaced navigation across the app; all buttons/links now route through the main section.
  - More reliable authentication flows, including improved Replit integration and login management.
  - Database setup runs reliably at startup; migrations and utilities align with the new initialization.
- Bug Fixes
  - Fixed broken/incorrect redirects and links in multiple pages and error screens.
- Refactor
  - Adopted an application factory and modular blueprint structure for better stability and scalability.
- Tests
  - Test suite updated to use the new factory pattern and streamlined route stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->