### PR TITLE
Adopt pytest runner for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The project includes simple helper scripts so you can get up and running quickly
 ./install   # set up a virtual environment and install dependencies
 ./doctor    # verify your environment
 ./run       # start the development server on http://localhost:5000
-./test      # run the full test suite with pytest
+./test      # run the full test suite
 ```
 
 The `install` script copies `.env.sample` to `.env` if it does not exist.  By default the application uses a local SQLite

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The project includes simple helper scripts so you can get up and running quickly
 ./install   # set up a virtual environment and install dependencies
 ./doctor    # verify your environment
 ./run       # start the development server on http://localhost:5000
+./test      # run the full test suite with pytest
 ```
 
 The `install` script copies `.env.sample` to `.env` if it does not exist.  By default the application uses a local SQLite
@@ -19,6 +20,7 @@ file called `secureapp.db`.  Edit `.env` to change the configuration or to point
 * `install` – create a virtual environment and install the required Python packages.
 * `run` – activate the environment and run the application.
 * `doctor` – check for common installation issues and suggest how to fix them.
+* `test` – execute the automated test suite via pytest.
 
 ## Requirements
 
@@ -29,3 +31,6 @@ file called `secureapp.db`.  Edit `.env` to change the configuration or to point
 
 After changing the configuration or dependencies re‑run `./doctor` to ensure your setup is healthy.  Use `Ctrl+C` to stop
  the development server started with `./run`.
+
+Run `pytest` (or the `./test` wrapper) before opening a pull request so you catch regressions locally.  The test runner will
+ execute every `test_*.py` module in the repository.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+pythonpath = .
+testpaths = .
+python_files = test_*.py
+norecursedirs = .git build dist venv run install doctor static templates

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 pythonpath = .
 testpaths = .
 python_files = test_*.py
-norecursedirs = .git build dist venv run install doctor static templates
+norecursedirs = .git build dist venv install run doctor static templates

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ werkzeug>=3.1.3
 python-dotenv>=1.0.0
 coverage>=7.0.0
 requests>=2.31.0
-pytest>=8.3.0
+pytest>=8.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ werkzeug>=3.1.3
 python-dotenv>=1.0.0
 coverage>=7.0.0
 requests>=2.31.0
+pytest>=8.3.0

--- a/test
+++ b/test
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""Thin wrapper that delegates to pytest."""
-
-from __future__ import annotations
+"""Run the project's test suite via pytest."""
 
 import os
 import subprocess
@@ -25,4 +23,4 @@ def main(args: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    raise SystemExit(main(sys.argv[1:]))

--- a/test
+++ b/test
@@ -1,179 +1,28 @@
 #!/usr/bin/env python3
-"""
-Comprehensive test runner for all tests in the project.
-Runs all test files and exits with error code 1 if any tests fail.
-"""
+"""Thin wrapper that delegates to pytest."""
+
+from __future__ import annotations
+
 import os
-import sys
-import unittest
 import subprocess
+import sys
 from pathlib import Path
 
-# Activate virtual environment if it exists
-venv_path = Path(__file__).parent / 'venv'
-if venv_path.exists():
-    # Add venv to Python path - try multiple Python versions
-    python_versions = ['python3.12', 'python3.11', 'python3.10', 'python3.9']
-    for py_version in python_versions:
-        venv_site_packages = venv_path / 'lib' / py_version / 'site-packages'
-        if venv_site_packages.exists():
-            sys.path.insert(0, str(venv_site_packages))
-            break
-    
-    # Also add the venv bin directory for any executables
-    venv_bin = venv_path / 'bin'
-    if venv_bin.exists():
-        os.environ['PATH'] = str(venv_bin) + ':' + os.environ.get('PATH', '')
+ROOT_DIR = Path(__file__).resolve().parent
+DEFAULT_ENV = {
+    "DATABASE_URL": "sqlite:///:memory:",
+    "SESSION_SECRET": "test-secret-key",
+}
 
-# Set up environment for testing
-os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'test-secret-key'
-# Don't set REPL_ID to test local auth by default
 
-def discover_test_files():
-    """Discover all test files in the project."""
-    test_files = []
-    project_root = Path(__file__).parent
+def main(args: list[str]) -> int:
+    env = os.environ.copy()
+    for key, value in DEFAULT_ENV.items():
+        env.setdefault(key, value)
 
-    # Auth tests that should only run with run_auth_tests.py due to Flask-Login conflicts
-    auth_only_tests = {
-        'test_auth_integration',
-        'test_auth_providers', 
-        'test_local_auth',
-        'test_auth_templates'
-    }
+    cmd = [sys.executable, "-m", "pytest", *args]
+    return subprocess.call(cmd, cwd=str(ROOT_DIR), env=env)
 
-    # Find all test_*.py files
-    for test_file in project_root.glob('test_*.py'):
-        if test_file.name != 'test':  # Don't include this script itself
-            # Skip auth-only tests that have Flask-Login conflicts
-            if test_file.stem not in auth_only_tests:
-                test_files.append(test_file.stem)
 
-    return sorted(test_files)
-
-def run_tests():
-    """Run all tests and return success status."""
-    print("🧪 Running comprehensive test suite...\n")
-
-    # Discover test files
-    test_files = discover_test_files()
-
-    if not test_files:
-        print("❌ No test files found!")
-        return False
-
-    print(f"📋 Found {len(test_files)} test files:")
-    for test_file in test_files:
-        print(f"   - {test_file}.py")
-    
-    print(f"\n📝 Note: Auth tests are segregated and run separately with run_auth_tests.py:")
-    auth_tests = ['test_auth_integration', 'test_auth_providers', 'test_local_auth', 'test_auth_templates']
-    for auth_test in auth_tests:
-        print(f"   - {auth_test}.py")
-    print()
-
-    # Create test suite
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite()
-
-    total_tests = 0
-    failed_imports = []
-
-    # Load all test modules
-    for test_file in test_files:
-        try:
-            module = __import__(test_file)
-            tests = loader.loadTestsFromModule(module)
-            test_count = tests.countTestCases()
-            suite.addTests(tests)
-            total_tests += test_count
-            print(f"✅ Loaded {test_file}: {test_count} tests")
-        except ImportError as e:
-            print(f"❌ Failed to import {test_file}: {e}")
-            failed_imports.append(test_file)
-        except Exception as e:
-            print(f"❌ Error loading {test_file}: {e}")
-            failed_imports.append(test_file)
-
-    if failed_imports:
-        print(f"\n⚠️  Failed to load {len(failed_imports)} test files:")
-        for test_file in failed_imports:
-            print(f"   - {test_file}.py")
-        print()
-
-    if total_tests == 0:
-        print("❌ No tests could be loaded!")
-        return False
-
-    print(f"\n🚀 Running {total_tests} tests...\n")
-
-    # Run tests
-    runner = unittest.TextTestRunner(
-        verbosity=2,
-        stream=sys.stdout,
-        descriptions=True,
-        failfast=False
-    )
-
-    result = runner.run(suite)
-
-    # Print detailed summary
-    print(f"\n📊 Test Summary:")
-    print(f"   Tests run: {result.testsRun}")
-    print(f"   Failures: {len(result.failures)}")
-    print(f"   Errors: {len(result.errors)}")
-    print(f"   Skipped: {len(result.skipped) if hasattr(result, 'skipped') else 0}")
-
-    if result.failures:
-        print(f"\n❌ Failures ({len(result.failures)}):")
-        for i, (test, traceback) in enumerate(result.failures, 1):
-            print(f"   {i}. {test}")
-            # Extract the assertion error message
-            lines = traceback.split('\n')
-            for line in lines:
-                if 'AssertionError:' in line:
-                    print(f"      {line.strip()}")
-                    break
-
-    if result.errors:
-        print(f"\n💥 Errors ({len(result.errors)}):")
-        for i, (test, traceback) in enumerate(result.errors, 1):
-            print(f"   {i}. {test}")
-            # Extract the error message
-            lines = traceback.split('\n')
-            for line in reversed(lines):
-                if line.strip() and not line.startswith(' '):
-                    print(f"      {line.strip()}")
-                    break
-
-    # Determine overall success
-    success = len(result.failures) == 0 and len(result.errors) == 0
-
-    if success:
-        print(f"\n🎉 All tests passed!")
-    else:
-        print(f"\n💥 Test suite failed!")
-        if result.failures:
-            print(f"   - {len(result.failures)} test(s) failed")
-        if result.errors:
-            print(f"   - {len(result.errors)} test(s) had errors")
-
-    return success
-
-def main():
-    """Main entry point."""
-    try:
-        success = run_tests()
-        sys.exit(0 if success else 1)
-    except KeyboardInterrupt:
-        print("\n\n⚠️  Test run interrupted by user")
-        sys.exit(1)
-    except Exception as e:
-        print(f"\n💥 Unexpected error during test run: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
-
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test_auth_integration.py
+++ b/test_auth_integration.py
@@ -30,8 +30,6 @@ class TestAuthIntegration(unittest.TestCase):
             db.drop_all()
         # Reset auth manager state to prevent test interference
         auth_manager._active_provider = None
-        # Reset auth manager state to prevent test interference
-        auth_manager._active_provider = None
 
     def test_auth_manager_detection_local(self):
         """Test that auth manager detects local environment correctly."""

--- a/test_auth_integration.py
+++ b/test_auth_integration.py
@@ -15,11 +15,6 @@ class TestAuthIntegration(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         # Use the actual app but with test database
         self.app = app
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
@@ -51,11 +46,6 @@ class TestAuthIntegration(unittest.TestCase):
 
     def test_auth_manager_detection_replit(self):
         """Test that auth manager detects Replit environment correctly."""
-        # Skip test if running with unittest discover due to Flask-Login conflicts
-        import sys
-        if 'unittest' in sys.modules and hasattr(sys.modules['unittest'], '_main_module'):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         with patch.dict(os.environ, {
             'REPL_ID': 'test-repl-123',
             'REPL_OWNER': 'test-user',
@@ -174,11 +164,6 @@ class TestAuthProviderSwitching(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         self.app = app
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
         self.app.config['TESTING'] = True
@@ -196,11 +181,6 @@ class TestAuthProviderSwitching(unittest.TestCase):
 
     def test_switch_from_local_to_replit(self):
         """Test switching from local to Replit authentication."""
-        # Skip test if running with unittest discover due to Flask-Login conflicts
-        import sys
-        if 'unittest' in sys.modules and hasattr(sys.modules['unittest'], '_main_module'):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         # Start with local environment (no REPL_ID)
         with patch.dict(os.environ, {}, clear=True):
             auth_manager._active_provider = None
@@ -221,11 +201,6 @@ class TestAuthProviderSwitching(unittest.TestCase):
 
     def test_switch_from_replit_to_local(self):
         """Test switching from Replit to local authentication."""
-        # Skip test if running with unittest discover due to Flask-Login conflicts
-        import sys
-        if 'unittest' in sys.modules and hasattr(sys.modules['unittest'], '_main_module'):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         # Start with Replit environment
         with patch.dict(os.environ, {
             'REPL_ID': 'test-repl-789',

--- a/test_auth_providers.py
+++ b/test_auth_providers.py
@@ -6,7 +6,7 @@ import os
 import unittest
 from unittest.mock import patch, MagicMock
 from flask import Flask
-from app import db
+from app import db, create_app
 from auth_providers import (
     AuthProvider, ReplitAuthProvider, LocalAuthProvider, AuthManager,
     create_local_user, save_user_from_claims, require_login
@@ -281,24 +281,19 @@ class TestRequireLoginDecorator(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment."""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        from app import app
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
+        self.environ_patch = patch.dict(os.environ, {}, clear=True)
+        self.environ_patch.start()
+        self.addCleanup(self.environ_patch.stop)
 
-        # Use the actual app
-        self.app = app
-        self.app.config['TESTING'] = True
-        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.app = create_app({
+            'TESTING': True,
+            'WTF_CSRF_ENABLED': False,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+            'SECRET_KEY': 'test-secret',
+        })
 
     def test_require_login_authenticated_user(self):
         """Test require_login with authenticated user."""
-        # Skip test if running with unittest discover due to Flask-Login conflicts
-        import sys
-        if 'unittest' in sys.modules and hasattr(sys.modules['unittest'], '_main_module'):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         with self.app.test_request_context('/'):
             with patch('auth_providers.current_user') as mock_current_user:
                 # Mock authenticated user
@@ -314,11 +309,6 @@ class TestRequireLoginDecorator(unittest.TestCase):
 
     def test_require_login_unauthenticated_user(self):
         """Test require_login with unauthenticated user."""
-        # Skip test if running with unittest discover due to Flask-Login conflicts
-        import sys
-        if 'unittest' in sys.modules and hasattr(sys.modules['unittest'], '_main_module'):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         with self.app.test_request_context('/'):
             with patch('auth_providers.current_user') as mock_current_user:
                 # Mock unauthenticated user

--- a/test_cid_functionality.py
+++ b/test_cid_functionality.py
@@ -13,11 +13,6 @@ class TestCIDFunctionality(unittest.TestCase):
     
     def setUp(self):
         """Set up test environment"""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-        
         self.app = app
         self.app.config['TESTING'] = True
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'

--- a/test_echo_functionality.py
+++ b/test_echo_functionality.py
@@ -18,11 +18,6 @@ class TestEchoFunctionality(unittest.TestCase):
     
     def setUp(self):
         """Set up test environment"""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-        
         app.config['TESTING'] = True
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
         app.config['WTF_CSRF_ENABLED'] = False

--- a/test_meta_cid_route.py
+++ b/test_meta_cid_route.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-from unittest.mock import Mock
 from app import app, db
 from models import CID, User
 
@@ -10,10 +9,6 @@ class TestMetaCIDRoute(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        # Skip test if app is mocked (running with unittest discover)
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-
         self.app = app
         self.app.config['TESTING'] = True
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'

--- a/test_models.py
+++ b/test_models.py
@@ -19,11 +19,6 @@ class TestModels(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-        
         self.app = app
         self.app.config['TESTING'] = True
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'

--- a/test_secret_definitions_cid.py
+++ b/test_secret_definitions_cid.py
@@ -4,7 +4,7 @@ import unittest
 import tempfile
 import os
 import json
-from app import app, db
+from app import create_app, db
 from models import User, Secret, CID
 from cid_utils import (
     generate_all_secret_definitions_json,
@@ -16,19 +16,20 @@ from routes import update_secret_definitions_cid
 class TestSecretDefinitionsCID(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures before each test method."""
-        # Skip test if app is mocked (running with unittest discover)
-        from unittest.mock import Mock
-        if isinstance(app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-        
         # Create a temporary database
-        self.db_fd, app.config['DATABASE'] = tempfile.mkstemp()
-        app.config['TESTING'] = True
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + app.config['DATABASE']
-        app.config['WTF_CSRF_ENABLED'] = False
-        
-        self.app = app.test_client()
-        self.app_context = app.app_context()
+        self.db_fd, temp_db_path = tempfile.mkstemp()
+        self.db_path = temp_db_path
+        config = {
+            'DATABASE': temp_db_path,
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{temp_db_path}',
+            'WTF_CSRF_ENABLED': False,
+        }
+
+        flask_app = create_app(config)
+
+        self.app = flask_app.test_client()
+        self.app_context = flask_app.app_context()
         self.app_context.push()
         
         db.create_all()
@@ -59,7 +60,7 @@ class TestSecretDefinitionsCID(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
         os.close(self.db_fd)
-        os.unlink(app.config['DATABASE'])
+        os.unlink(self.db_path)
 
     def test_generate_all_secret_definitions_json_with_secrets(self):
         """Test JSON generation with existing secrets"""

--- a/test_serve_cid_content.py
+++ b/test_serve_cid_content.py
@@ -1,118 +1,50 @@
 import unittest
-from unittest.mock import Mock, patch
 from datetime import datetime, timezone
-import sys
-import os
+from types import SimpleNamespace
 
-# Add the current directory to the path so we can import modules
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from flask import Flask
 
-# Mock all the dependencies
-sys.modules['app'] = Mock()
-sys.modules['models'] = Mock()
-sys.modules['forms'] = Mock()
-sys.modules['auth_providers'] = Mock()
-sys.modules['text_function_runner'] = Mock()
-
-# Mock Flask imports
-flask_mock = Mock()
-flask_mock.render_template = Mock()
-flask_mock.flash = Mock()
-flask_mock.redirect = Mock()
-flask_mock.url_for = Mock()
-flask_mock.request = Mock()
-flask_mock.session = Mock()
-flask_mock.make_response = Mock()
-flask_mock.abort = Mock()
-sys.modules['flask'] = flask_mock
-
-# Mock flask_login
-flask_login_mock = Mock()
-sys.modules['flask_login'] = flask_login_mock
-
-# Now we can import the function we want to test
-from cid_utils import serve_cid_content  # noqa: E402
-
-
-# Mock the Flask app and other dependencies before importing cid_utils
-class MockApp:
-    def __init__(self):
-        self.config = {'TESTING': True}
-    
-    def test_request_context(self, path, **kwargs):
-        return MockRequestContext(path, **kwargs)
-
-class MockRequestContext:
-    def __init__(self, path, headers=None):
-        self.path = path
-        self.headers = headers or {}
-    
-    def __enter__(self):
-        # Mock the request object
-        import cid_utils
-        cid_utils.request = Mock()
-        cid_utils.request.path = self.path
-        cid_utils.request.headers = Mock()
-        cid_utils.request.headers.get = lambda key, default=None: self.headers.get(key, default)
-        return self
-    
-    def __exit__(self, *args):
-        pass
+from cid_utils import serve_cid_content
 
 
 class TestServeCidContent(unittest.TestCase):
-    """Test suite for serve_cid_content function content disposition header behavior"""
+    """Tests for content disposition and caching behavior when serving CID data."""
+
+    _DEFAULT_CONTENT = object()
 
     def setUp(self):
-        """Set up test fixtures"""
-        self.app = MockApp()
+        self.app = Flask(__name__)
         self.app.config['TESTING'] = True
-        
-        # Create mock CID content object
-        self.mock_cid_content = Mock()
-        self.mock_cid_content.file_data = b"test content"
-        self.mock_cid_content.created_at = datetime.now(timezone.utc)
-        
+        self.cid_content = SimpleNamespace(
+            file_data=b"test content",
+            created_at=datetime.now(timezone.utc),
+        )
+
+    def _serve(self, path, *, headers=None, content=_DEFAULT_CONTENT):
+        with self.app.test_request_context(path, headers=headers or {}):
+            payload = self.cid_content if content is self._DEFAULT_CONTENT else content
+            return serve_cid_content(payload, path)
+
     def test_cid_only_no_content_disposition(self):
-        """Test /{CID} - should not set content disposition header"""
         path = "/bafybeihelloworld123456789012345678901234567890123456"
-        
-        with self.app.test_request_context(path):
-            with patch('cid_utils.make_response') as mock_make_response:
-                mock_response = Mock()
-                mock_response.headers = {}
-                mock_make_response.return_value = mock_response
-                
-                serve_cid_content(self.mock_cid_content, path)
-                
-                # Should not have Content-Disposition header
-                self.assertNotIn('Content-Disposition', mock_response.headers)
-                
+        response = self._serve(path)
+        self.assertIsNotNone(response)
+        self.assertNotIn("Content-Disposition", response.headers)
+
     def test_cid_with_extension_no_content_disposition(self):
-        """Test /{CID}.{ext} - should not set content disposition header"""
-        test_cases = [
+        for path in [
             "/bafybeihelloworld123456789012345678901234567890123456.txt",
             "/bafybeihelloworld123456789012345678901234567890123456.html",
             "/bafybeihelloworld123456789012345678901234567890123456.json",
             "/bafybeihelloworld123456789012345678901234567890123456.pdf",
-        ]
-        
-        for path in test_cases:
+        ]:
             with self.subTest(path=path):
-                with self.app.test_request_context(path):
-                    with patch('cid_utils.make_response') as mock_make_response:
-                        mock_response = Mock()
-                        mock_response.headers = {}
-                        mock_make_response.return_value = mock_response
-                        
-                        serve_cid_content(self.mock_cid_content, path)
-                        
-                        # Should not have Content-Disposition header
-                        self.assertNotIn('Content-Disposition', mock_response.headers)
+                response = self._serve(path)
+                self.assertIsNotNone(response)
+                self.assertNotIn("Content-Disposition", response.headers)
 
     def test_cid_with_filename_sets_content_disposition(self):
-        """Test /{CID}.{filename}.{ext} - should set content disposition header with filename"""
-        test_cases = [
+        cases = [
             ("/bafybeihelloworld123456789012345678901234567890123456.document.txt", "document.txt"),
             ("/bafybeihelloworld123456789012345678901234567890123456.report.pdf", "report.pdf"),
             ("/bafybeihelloworld123456789012345678901234567890123456.data.json", "data.json"),
@@ -120,144 +52,86 @@ class TestServeCidContent(unittest.TestCase):
             ("/bafybeihelloworld123456789012345678901234567890123456.my-file.csv", "my-file.csv"),
             ("/bafybeihelloworld123456789012345678901234567890123456.test_file.py", "test_file.py"),
         ]
-        
-        for path, expected_filename in test_cases:
-            with self.subTest(path=path, filename=expected_filename):
-                with self.app.test_request_context(path):
-                    with patch('cid_utils.make_response') as mock_make_response:
-                        mock_response = Mock()
-                        mock_response.headers = {}
-                        mock_make_response.return_value = mock_response
-                        
-                        serve_cid_content(self.mock_cid_content, path)
-                        
-                        # Should have Content-Disposition header with correct filename
-                        expected_header = f'attachment; filename="{expected_filename}"'
-                        self.assertEqual(mock_response.headers.get('Content-Disposition'), expected_header)
+
+        for path, expected_filename in cases:
+            with self.subTest(path=path):
+                response = self._serve(path)
+                self.assertIsNotNone(response)
+                expected_header = f'attachment; filename="{expected_filename}"'
+                self.assertEqual(response.headers.get("Content-Disposition"), expected_header)
 
     def test_cid_with_multiple_dots_in_filename(self):
-        """Test /{CID}.{filename.with.dots}.{ext} - should handle filenames with multiple dots"""
-        test_cases = [
+        cases = [
             ("/bafybeihelloworld123456789012345678901234567890123456.my.data.file.txt", "my.data.file.txt"),
             ("/bafybeihelloworld123456789012345678901234567890123456.version.1.2.3.json", "version.1.2.3.json"),
             ("/bafybeihelloworld123456789012345678901234567890123456.backup.2024.01.15.sql", "backup.2024.01.15.sql"),
         ]
-        
-        for path, expected_filename in test_cases:
-            with self.subTest(path=path, filename=expected_filename):
-                with self.app.test_request_context(path):
-                    with patch('cid_utils.make_response') as mock_make_response:
-                        mock_response = Mock()
-                        mock_response.headers = {}
-                        mock_make_response.return_value = mock_response
-                        
-                        serve_cid_content(self.mock_cid_content, path)
-                        
-                        # Should have Content-Disposition header with correct filename
-                        expected_header = f'attachment; filename="{expected_filename}"'
-                        self.assertEqual(mock_response.headers.get('Content-Disposition'), expected_header)
+
+        for path, expected_filename in cases:
+            with self.subTest(path=path):
+                response = self._serve(path)
+                self.assertIsNotNone(response)
+                expected_header = f'attachment; filename="{expected_filename}"'
+                self.assertEqual(response.headers.get("Content-Disposition"), expected_header)
 
     def test_edge_cases(self):
-        """Test edge cases for path parsing"""
-        # Test very short CID-like paths
-        test_cases = [
-            ("/abc.txt", None),  # Too short to be CID, no filename
-            ("/abc.document.txt", "document.txt"),  # Short but has filename pattern
-            ("/a.b.c", "b.c"),  # Multiple dots, should extract filename
+        cases = [
+            ("/abc.txt", None),
+            ("/abc.document.txt", "document.txt"),
+            ("/a.b.c", "b.c"),
         ]
-        
-        for path, expected_filename in test_cases:
-            with self.subTest(path=path, filename=expected_filename):
-                with self.app.test_request_context(path):
-                    with patch('cid_utils.make_response') as mock_make_response:
-                        mock_response = Mock()
-                        mock_response.headers = {}
-                        mock_make_response.return_value = mock_response
-                        
-                        serve_cid_content(self.mock_cid_content, path)
-                        
-                        if expected_filename:
-                            expected_header = f'attachment; filename="{expected_filename}"'
-                            self.assertEqual(mock_response.headers.get('Content-Disposition'), expected_header)
-                        else:
-                            self.assertNotIn('Content-Disposition', mock_response.headers)
+
+        for path, expected_filename in cases:
+            with self.subTest(path=path):
+                response = self._serve(path)
+                self.assertIsNotNone(response)
+                if expected_filename:
+                    expected_header = f'attachment; filename="{expected_filename}"'
+                    self.assertEqual(response.headers.get("Content-Disposition"), expected_header)
+                else:
+                    self.assertNotIn("Content-Disposition", response.headers)
 
     def test_filename_with_special_characters(self):
-        """Test filenames with special characters are properly escaped"""
-        test_cases = [
+        cases = [
             ("/bafybeihelloworld123456789012345678901234567890123456.file with spaces.txt", "file with spaces.txt"),
             ("/bafybeihelloworld123456789012345678901234567890123456.file-with-dashes.txt", "file-with-dashes.txt"),
             ("/bafybeihelloworld123456789012345678901234567890123456.file_with_underscores.txt", "file_with_underscores.txt"),
         ]
-        
-        for path, expected_filename in test_cases:
-            with self.subTest(path=path, filename=expected_filename):
-                with self.app.test_request_context(path):
-                    with patch('cid_utils.make_response') as mock_make_response:
-                        mock_response = Mock()
-                        mock_response.headers = {}
-                        mock_make_response.return_value = mock_response
-                        
-                        serve_cid_content(self.mock_cid_content, path)
-                        
-                        # Should have Content-Disposition header with correct filename
-                        expected_header = f'attachment; filename="{expected_filename}"'
-                        self.assertEqual(mock_response.headers.get('Content-Disposition'), expected_header)
+
+        for path, expected_filename in cases:
+            with self.subTest(path=path):
+                response = self._serve(path)
+                self.assertIsNotNone(response)
+                expected_header = f'attachment; filename="{expected_filename}"'
+                self.assertEqual(response.headers.get("Content-Disposition"), expected_header)
 
     def test_none_content_returns_none(self):
-        """Test that None content returns None"""
         path = "/bafybeihelloworld123456789012345678901234567890123456.txt"
-        
-        with self.app.test_request_context(path):
-            result = serve_cid_content(None, path)
-            self.assertIsNone(result)
+        self.assertIsNone(self._serve(path, content=None))
 
     def test_content_with_none_file_data_returns_none(self):
-        """Test that content with None file_data returns None"""
         path = "/bafybeihelloworld123456789012345678901234567890123456.txt"
-        mock_content = Mock()
-        mock_content.file_data = None
-        
-        with self.app.test_request_context(path):
-            result = serve_cid_content(mock_content, path)
-            self.assertIsNone(result)
+        empty_content = SimpleNamespace(file_data=None)
+        self.assertIsNone(self._serve(path, content=empty_content))
 
     def test_caching_headers_still_work(self):
-        """Test that caching headers are still properly set"""
         path = "/bafybeihelloworld123456789012345678901234567890123456.document.txt"
-        
-        with self.app.test_request_context(path):
-            with patch('cid_utils.make_response') as mock_make_response:
-                mock_response = Mock()
-                mock_response.headers = {}
-                mock_make_response.return_value = mock_response
-                
-                serve_cid_content(self.mock_cid_content, path)
-                
-                # Should have caching headers
-                self.assertIn('ETag', mock_response.headers)
-                self.assertIn('Cache-Control', mock_response.headers)
-                self.assertIn('Last-Modified', mock_response.headers)
-                
-                # Should also have Content-Disposition
-                self.assertIn('Content-Disposition', mock_response.headers)
+        response = self._serve(path)
+        self.assertIsNotNone(response)
+        self.assertIn("ETag", response.headers)
+        self.assertIn("Cache-Control", response.headers)
+        self.assertIn("Last-Modified", response.headers)
+        self.assertIn("Content-Disposition", response.headers)
 
     def test_conditional_requests_with_filename(self):
-        """Test that conditional requests work properly even with filename paths"""
         path = "/bafybeihelloworld123456789012345678901234567890123456.document.txt"
-        
-        # Test If-None-Match
-        with self.app.test_request_context(path, headers={'If-None-Match': '"bafybeihelloworld123456789012345678901234567890123456"'}):
-            with patch('cid_utils.make_response') as mock_make_response:
-                mock_response = Mock()
-                mock_response.headers = {}
-                mock_make_response.return_value = mock_response
-                
-                serve_cid_content(self.mock_cid_content, path)
-                
-                # Should return 304 response
-                mock_make_response.assert_called_with('', 304)
+        cid = path.lstrip("/").split(".")[0]
+        etag_value = f'"{cid}"'
+        response = self._serve(path, headers={'If-None-Match': etag_value})
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 304)
+        self.assertEqual(response.headers.get("ETag"), etag_value)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test_serve_cid_integration.py
+++ b/test_serve_cid_integration.py
@@ -7,34 +7,11 @@ This test directly imports and tests the extract_filename_from_cid_path function
 import unittest
 import sys
 import os
-from unittest.mock import Mock
 
 # Add the current directory to the path so we can import modules
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# Mock all the dependencies before importing cid_utils
-# Mock Flask and other dependencies
-sys.modules['app'] = Mock()
-sys.modules['models'] = Mock()
-sys.modules['forms'] = Mock()
-sys.modules['auth_providers'] = Mock()
-sys.modules['text_function_runner'] = Mock()
-sys.modules['flask_login'] = Mock()
-
-# Mock Flask components
-flask_mock = Mock()
-flask_mock.render_template = Mock()
-flask_mock.flash = Mock()
-flask_mock.redirect = Mock()
-flask_mock.url_for = Mock()
-flask_mock.request = Mock()
-flask_mock.session = Mock()
-flask_mock.make_response = Mock()
-flask_mock.abort = Mock()
-sys.modules['flask'] = flask_mock
-
-# Now import the function we want to test
-from cid_utils import extract_filename_from_cid_path  # noqa: E402
+from cid_utils import extract_filename_from_cid_path
 
 
 class TestExtractFilenameFromCidPath(unittest.TestCase):

--- a/test_server_definitions_cid.py
+++ b/test_server_definitions_cid.py
@@ -1,42 +1,13 @@
 import unittest
 import json
-import sys
 from unittest.mock import Mock, patch
 
-# Mock all dependencies before importing
-sys.modules['app'] = Mock()
-sys.modules['models'] = Mock()
-sys.modules['forms'] = Mock()
-sys.modules['auth_providers'] = Mock()
-sys.modules['text_function_runner'] = Mock()
-
-# Mock Flask imports
-flask_mock = Mock()
-flask_mock.render_template = Mock()
-flask_mock.flash = Mock()
-flask_mock.redirect = Mock()
-flask_mock.url_for = Mock()
-flask_mock.request = Mock()
-flask_mock.session = Mock()
-flask_mock.make_response = Mock()
-flask_mock.abort = Mock()
-sys.modules['flask'] = flask_mock
-
-# Mock flask_login
-flask_login_mock = Mock()
-sys.modules['flask_login'] = flask_login_mock
-
-# Mock SQLAlchemy
-sqlalchemy_mock = Mock()
-sys.modules['sqlalchemy'] = sqlalchemy_mock
-
-# Now import the functions we want to test
-from cid_utils import (  # noqa: E402
+from cid_utils import (
     generate_all_server_definitions_json,
     store_server_definitions_cid,
     get_current_server_definitions_cid,
 )
-from routes import update_server_definitions_cid  # noqa: E402
+from routes import update_server_definitions_cid
 
 
 class TestServerDefinitionsCID(unittest.TestCase):

--- a/test_text_function_runner.py
+++ b/test_text_function_runner.py
@@ -1,33 +1,14 @@
+import importlib
 import unittest
-from unittest.mock import Mock
-import sys
-import os
-
-# Add the current directory to the path so we can import modules
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-# Mock dependencies before importing
-sys.modules['models'] = Mock()
-
-# Import the actual function to test it
 
 
 class TestRunTextFunction(unittest.TestCase):
     """Test suite for run_text_function."""
-    
+
     def setUp(self):
-        """Ensure we're testing the actual run_text_function, not a mock."""
-        # Force reimport of the module to bypass any global mocks
-        import sys
-        if 'text_function_runner' in sys.modules:
-            del sys.modules['text_function_runner']
-        
-        # Mock only the models dependency
-        sys.modules['models'] = Mock()
-        
-        # Import fresh copy of the module
-        import text_function_runner
-        self.run_text_function = text_function_runner.run_text_function
+        """Ensure we're testing the actual run_text_function implementation."""
+        module = importlib.import_module('text_function_runner')
+        self.run_text_function = importlib.reload(module).run_text_function
 
     def test_basic_functionality(self):
         """Test basic function execution with simple arguments."""

--- a/test_upload_extensions.py
+++ b/test_upload_extensions.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 import io
-from app import app, db
+from app import create_app, db
 from models import User
 from cid_utils import process_file_upload
 
@@ -9,14 +9,12 @@ from cid_utils import process_file_upload
 class TestUploadExtensions(unittest.TestCase):
     def setUp(self):
         """Set up test environment"""
-        self.app = app
-        
-        # Skip tests when running with unittest discover due to Flask-Login conflicts
-        if isinstance(self.app, Mock):
-            self.skipTest("Skipping test due to Flask-Login conflicts when running with unittest discover")
-        
-        self.app.config['TESTING'] = True
-        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+            'WTF_CSRF_ENABLED': False,
+        })
+
         self.client = self.app.test_client()
         
         with self.app.app_context():

--- a/test_variables_secrets_issue.py
+++ b/test_variables_secrets_issue.py
@@ -9,32 +9,8 @@ from unittest.mock import Mock, patch
 # Add current directory to path
 sys.path.insert(0, '.')
 
-# Mock all dependencies before importing
-sys.modules['app'] = Mock()
-sys.modules['models'] = Mock()
-sys.modules['forms'] = Mock()
-sys.modules['auth_providers'] = Mock()
-sys.modules['text_function_runner'] = Mock()
-
-# Mock Flask imports
-flask_mock = Mock()
-flask_mock.render_template = Mock()
-flask_mock.flash = Mock()
-flask_mock.redirect = Mock()
-flask_mock.url_for = Mock()
-flask_mock.request = Mock()
-flask_mock.session = Mock()
-flask_mock.make_response = Mock()
-flask_mock.abort = Mock()
-sys.modules['flask'] = flask_mock
-
-# Mock flask_login
-flask_login_mock = Mock()
-sys.modules['flask_login'] = flask_login_mock
-
-# Import the functions we want to test
-from routes import user_variables, user_secrets  # noqa: E402
-from server_execution import build_request_args  # noqa: E402
+from routes import user_variables, user_secrets
+from server_execution import build_request_args
 
 class TestVariablesSecretsIssue(unittest.TestCase):
     """Test cases to demonstrate the variables and secrets serialization issue"""


### PR DESCRIPTION
## Summary
- add a pytest dependency plus repository-wide configuration so the suite can be collected from the project root
- replace the legacy `./test` helper with a thin wrapper around `pytest` and update contributor docs accordingly
- refresh authentication- and CID-related tests to build real Flask apps, remove brittle mocks, and harden the auth provider helper against missing blueprints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc18418d248331a6dad1baae1e4c26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated Quick Start with instructions to run the automated test suite and a new public test script entry.
  - Added guidance to run tests before opening a pull request.

- Chores
  - Introduced Pytest configuration for standardized test discovery and execution.
  - Added Pytest as a dependency.

- Tests
  - Migrated from unittest scaffolding to a Pytest-based workflow.
  - Removed skip guards to ensure tests run consistently.
  - Adopted an application factory pattern with isolated, in-memory databases for reliability.
  - Expanded coverage for content serving, including headers, caching, and conditional requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->