### PR TITLE
Align test runners for local and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,18 +57,15 @@ jobs:
       - name: Run tests with coverage
         id: run_tests
         run: |
-          python -m coverage run -m unittest discover -v
+          python run_coverage.py --xml --html --summary-file coverage-report.txt
         continue-on-error: true
 
-      - name: Generate coverage reports
+      - name: Publish coverage summary
         id: coverage
         if: always()
         run: |
-          if [ -f ".coverage" ]; then
-            python -m coverage report > coverage-report.txt
+          if [ -f "coverage-report.txt" ]; then
             cat coverage-report.txt
-            python -m coverage xml
-            python -m coverage html
             {
               echo "### Coverage summary"
               echo '```'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The project includes simple helper scripts so you can get up and running quickly
 ./doctor    # verify your environment
 ./run       # start the development server on http://localhost:5000
 ./test      # run the full test suite
+python run_coverage.py --xml --html  # run tests with coverage reports (optional)
 ```
 
 The `install` script copies `.env.sample` to `.env` if it does not exist.  By default the application uses a local SQLite
@@ -21,6 +22,7 @@ file called `secureapp.db`.  Edit `.env` to change the configuration or to point
 * `run` – activate the environment and run the application.
 * `doctor` – check for common installation issues and suggest how to fix them.
 * `test` – execute the automated test suite via pytest.
+* `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
 
 ## Requirements
 

--- a/test
+++ b/test
@@ -1,23 +1,41 @@
 #!/usr/bin/env python3
 """Run the project's test suite via pytest."""
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parent
 DEFAULT_ENV = {
     "DATABASE_URL": "sqlite:///:memory:",
     "SESSION_SECRET": "test-secret-key",
+    "TESTING": "True",
 }
 
 
-def main(args: list[str]) -> int:
+def build_environment() -> dict[str, str]:
+    """Return a copy of the current environment with sensible defaults."""
+
     env = os.environ.copy()
+    # Ensure the repository root is on the Python path so pytest can import modules.
+    python_path = env.get("PYTHONPATH")
+    if python_path:
+        env["PYTHONPATH"] = os.pathsep.join([str(ROOT_DIR), python_path])
+    else:
+        env["PYTHONPATH"] = str(ROOT_DIR)
+
     for key, value in DEFAULT_ENV.items():
         env.setdefault(key, value)
 
+    return env
+
+
+def main(args: Sequence[str]) -> int:
+    env = build_environment()
     cmd = [sys.executable, "-m", "pytest", *args]
     return subprocess.call(cmd, cwd=str(ROOT_DIR), env=env)
 


### PR DESCRIPTION
## Summary
- replace the bespoke coverage runner with a pytest-based implementation that mirrors local usage
- update the CI workflow to invoke the shared coverage script and reuse its summary output
- refresh the pytest wrapper and README instructions so defaults and documentation match the new flow

## Testing
- ./test
- python run_coverage.py --xml --html --summary-file coverage-report.txt


------
https://chatgpt.com/codex/tasks/task_b_68cc8e241a64833197d7990c6263c813