### PR TITLE
Resolve lint failures in server templates and tests

### DIFF
--- a/server_execution.py
+++ b/server_execution.py
@@ -155,7 +155,6 @@ def _encode_output(output: Any) -> bytes:
                 print(f"[server_execution] JSON encoding attempt failed: {type(json_err).__name__}: {json_err}")
                 print(f"[server_execution] Output type: {type(output).__name__}")
                 print(f"[server_execution] Items types: {[type(x).__name__ for x in items[:5]]}...")
-                import traceback
                 traceback.print_exc()
                 # Continue to try other encodings
             # List of ints -> bytes directly
@@ -195,7 +194,6 @@ def execute_server_code(server, server_name: str):
             )
         except Exception as debug_err:
             print(f"[server_execution] Debug output failed: {type(debug_err).__name__}: {debug_err}")
-            import traceback
             traceback.print_exc()
 
         output_bytes = _encode_output(output)
@@ -247,7 +245,6 @@ def execute_server_code_from_definition(definition_text: str, server_name: str):
             )
         except Exception as debug_err:
             print(f"[server_execution] Debug output failed in _from_definition: {type(debug_err).__name__}: {debug_err}")
-            import traceback
             traceback.print_exc()
 
         output_bytes = _encode_output(output)

--- a/server_templates/__init__.py
+++ b/server_templates/__init__.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import Iterable, Dict, Any
 import json
-import os
 from pathlib import Path
 
 def get_server_templates() -> list[dict[str, str]]:

--- a/server_templates/definitions/echo.py
+++ b/server_templates/definitions/echo.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F821, F706
+# This template executes inside the Viewer runtime where `request` and `context` are provided.
 from html import escape
 
 def dict_to_html_ul(data):

--- a/server_templates/definitions/openrouter.py
+++ b/server_templates/definitions/openrouter.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F821, F706
+# This template executes inside the Viewer runtime where `context` is provided.
 import requests
 
 API_KEY = context.get('secrets', {}).get("OPENROUTER_API_KEY")

--- a/test_cid_functionality.py
+++ b/test_cid_functionality.py
@@ -50,7 +50,6 @@ class TestCIDFunctionality(unittest.TestCase):
         
         # Verify CID format: 43-char base64url
         self.assertEqual(len(cid), 43)
-        import re
         self.assertRegex(cid, r'^[A-Za-z0-9_-]{43}$')
         
         # Verify CID is deterministic (same input = same output)

--- a/test_echo_functionality.py
+++ b/test_echo_functionality.py
@@ -156,7 +156,6 @@ class TestEchoFunctionality(unittest.TestCase):
                     # Validate CID format (base64url without padding, length 43)
                     cid_part = location.lstrip('/').split('.')[0]
                     self.assertEqual(len(cid_part), 43)
-                    import re
                     self.assertRegex(cid_part, r'^[A-Za-z0-9_-]{43}$')
 
 

--- a/test_server_execution_output_encoding.py
+++ b/test_server_execution_output_encoding.py
@@ -43,7 +43,7 @@ mock_runner.run_text_function = lambda code, args: {"output": "", "content_type"
 sys.modules.setdefault("text_function_runner", mock_runner)
 
 # Import the function under test after setting up mocks
-from server_execution import _encode_output
+from server_execution import _encode_output  # noqa: E402
 
 
 class TestServerExecutionOutputEncoding(unittest.TestCase):


### PR DESCRIPTION
## Summary
- remove redundant inline traceback imports in `server_execution` to satisfy linting while keeping error diagnostics
- mark server template definitions with scoped lint exemptions and drop an unused import from the template loader
- clean up test modules by removing unused imports and annotating the deferred `_encode_output` import

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cee1510ed08331b2cde157a8711907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant and unused imports to reduce noise and improve maintainability. No functional or API changes.

* **Style**
  * Added linting directives and clarifying header comments to templates to align with coding standards and document runtime context. No behavioral impact.

* **Tests**
  * Cleaned up unnecessary imports and added a minor lint exemption for import order. Test behavior and coverage remain unchanged.

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->