### PR TITLE
Add upload templates and integrate upload form templates

### DIFF
--- a/routes/uploads.py
+++ b/routes/uploads.py
@@ -12,6 +12,7 @@ from cid_utils import (
 )
 from db_access import create_cid_record, get_cid_by_path, get_user_uploads
 from forms import FileUploadForm
+from upload_templates import get_upload_templates
 
 from . import main_bp
 
@@ -21,6 +22,7 @@ from . import main_bp
 def upload():
     """File upload page with IPFS CID storage."""
     form = FileUploadForm()
+    upload_templates = get_upload_templates()
 
     if form.validate_on_submit():
         try:
@@ -35,7 +37,7 @@ def upload():
                 file_content, detected_mime_type = process_url_upload(form)
         except ValueError as exc:
             flash(str(exc), 'error')
-            return render_template('upload.html', form=form)
+            return render_template('upload.html', form=form, upload_templates=upload_templates)
 
         cid = generate_cid(file_content)
 
@@ -66,7 +68,7 @@ def upload():
             view_url_extension=view_url_extension,
         )
 
-    return render_template('upload.html', form=form)
+    return render_template('upload.html', form=form, upload_templates=upload_templates)
 
 
 @main_bp.route('/uploads')

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -64,6 +64,36 @@
 
                         <!-- Text Input Section -->
                         <div id="textUploadSection" class="upload-section" style="display: none;">
+                            {% if upload_templates is defined and upload_templates %}
+                            <div class="mb-3">
+                                <label for="upload-template-select" class="form-label">Start from a Template</label>
+                                <div class="input-group">
+                                    <select id="upload-template-select" class="form-select" aria-label="Select an upload template">
+                                        <option value="">Choose a template...</option>
+                                        {% for template in upload_templates %}
+                                            <option value="{{ template.id }}">{{ template.name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <button type="button" class="btn btn-outline-secondary" id="apply-upload-template">
+                                        <i class="fas fa-file-import me-1"></i>Use Template
+                                    </button>
+                                </div>
+                                <div class="form-text">
+                                    Selecting a template will replace the text content field below. You can edit the content after loading a template.
+                                </div>
+                                <div class="mt-3">
+                                    {% for template in upload_templates %}
+                                    <details class="border rounded p-3 mb-2 bg-light">
+                                        <summary class="fw-semibold">{{ template.name }}</summary>
+                                        {% if template.description %}
+                                        <p class="text-muted small mb-2">{{ template.description }}</p>
+                                        {% endif %}
+                                        <pre class="mb-0" style="white-space: pre-wrap;">{{ template.content }}</pre>
+                                    </details>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                            {% endif %}
                             <div class="mb-3">
                                 {{ form.text_content.label(class="form-label") }}
                                 {{ form.text_content(class="form-control") }}
@@ -143,6 +173,45 @@ function toggleUploadMethod() {
 // Initialize the correct section on page load
 document.addEventListener('DOMContentLoaded', function() {
     toggleUploadMethod();
+    {% if upload_templates is defined and upload_templates %}
+    const templateSelect = document.getElementById('upload-template-select');
+    const applyButton = document.getElementById('apply-upload-template');
+    const textField = document.getElementById('{{ form.text_content.id }}');
+    const templates = {{ upload_templates|tojson }};
+
+    if (templateSelect && applyButton && textField) {
+        const templateMap = {};
+        templates.forEach(function(template) {
+            templateMap[template.id] = template.content;
+        });
+
+        applyButton.addEventListener('click', function() {
+            const selectedTemplate = templateSelect.value;
+            if (!selectedTemplate) {
+                return;
+            }
+
+            const templateContent = templateMap[selectedTemplate];
+            if (typeof templateContent === 'undefined') {
+                return;
+            }
+
+            if (textField.value && !window.confirm('Replace the current text content with the selected template?')) {
+                return;
+            }
+
+            const textRadio = document.getElementById('upload_type_text');
+            if (textRadio && !textRadio.checked) {
+                textRadio.checked = true;
+                toggleUploadMethod();
+            }
+
+            textField.value = templateContent;
+            textField.dispatchEvent(new Event('input', { bubbles: true }));
+            textField.focus();
+        });
+    }
+    {% endif %}
 });
 </script>
 {% endblock %}

--- a/upload_templates/__init__.py
+++ b/upload_templates/__init__.py
@@ -1,0 +1,40 @@
+"""Upload templates package for the Viewer application.
+
+This package contains predefined content templates that can be used when uploading
+new files. Each template describes metadata and the actual content to upload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable
+import json
+
+
+def get_upload_templates() -> list[dict[str, Any]]:
+    """Return copies of all available upload templates."""
+    return list(iter_upload_templates())
+
+
+def iter_upload_templates() -> Iterable[Dict[str, Any]]:
+    """Yield upload templates one-by-one without exposing internal state."""
+    base_dir = Path(__file__).parent
+    template_dir = base_dir / "templates"
+
+    for template_file in template_dir.glob("*.json"):
+        with open(template_file, "r", encoding="utf-8") as f:
+            template = json.load(f)
+
+        if "content_file" in template:
+            content_path = base_dir / template["content_file"]
+            try:
+                with open(content_path, "r", encoding="utf-8") as content_file:
+                    template["content"] = content_file.read()
+            except OSError as exc:
+                print(f"Warning: Could not load content file {content_path}: {exc}")
+                continue
+
+        yield dict(template)
+
+
+__all__ = ["get_upload_templates", "iter_upload_templates"]

--- a/upload_templates/contents/echo_form.html
+++ b/upload_templates/contents/echo_form.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Echo Form</title>
+</head>
+<body>
+    <main>
+        <h1>Submit Data to /echo</h1>
+        <p>Use this form to send a POST request to the /echo route.</p>
+        <form action="/echo" method="post">
+            <label for="message">Message</label>
+            <input id="message" name="message" type="text" placeholder="Enter a message" required>
+            <button type="submit">Send to /echo</button>
+        </form>
+    </main>
+</body>
+</html>

--- a/upload_templates/contents/hello_world.html
+++ b/upload_templates/contents/hello_world.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Hello World</title>
+</head>
+<body>
+    <main>
+        <h1>Hello, world!</h1>
+        <p>This page was generated from the Viewer upload template system.</p>
+    </main>
+</body>
+</html>

--- a/upload_templates/templates/echo_form.json
+++ b/upload_templates/templates/echo_form.json
@@ -1,0 +1,7 @@
+{
+  "id": "echo-form-html",
+  "name": "Form that posts to /echo",
+  "description": "An HTML page with a form that submits a message to the /echo route.",
+  "content_file": "contents/echo_form.html",
+  "suggested_filename": "echo-form.html"
+}

--- a/upload_templates/templates/hello_world.json
+++ b/upload_templates/templates/hello_world.json
@@ -1,0 +1,7 @@
+{
+  "id": "hello-world-html",
+  "name": "Hello World HTML page",
+  "description": "A minimal HTML page that renders a friendly greeting.",
+  "content_file": "contents/hello_world.html",
+  "suggested_filename": "hello-world.html"
+}


### PR DESCRIPTION
## Summary
- add a new `upload_templates` package that loads reusable upload content definitions
- include Hello World and /echo form HTML templates for quick uploading
- update the upload route and page to surface template selection and autofill behaviour

## Testing
- `pytest test_upload_extensions.py`


------
https://chatgpt.com/codex/tasks/task_b_68cee3fcdbb48331b9bb6349f54e541e