### PR TITLE
Document auth test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,8 @@
 - `python run_coverage.py --xml --html`: (Optional) Run the test suite with coverage reporting, producing XML and HTML outputs for review.
 
 Pytest automatically discovers and runs all `test_*.py` modules located under the repository root while skipping any directories listed in the `norecursedirs` setting of `pytest.ini`.
+
+## Authentication tests
+
+- `run_auth_tests.py` executes the authentication-specific suites (`test_auth_providers`, `test_local_auth`, `test_auth_integration`, and `test_auth_templates`) outside of the standard pytest run so Flask-Login initialization does not interfere with unrelated tests.
+- The runner configures an in-memory SQLite database (`DATABASE_URL=sqlite:///:memory:`) and sets a deterministic `SESSION_SECRET=test-secret-key`. Mirror these environment variables if you need to reproduce the segregated authentication setup manually.


### PR DESCRIPTION
## Summary
- describe the dedicated authentication test runner and which suites it covers
- document the SQLite in-memory database and session secret used by the runner so others can mirror the setup

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_b_68ceea1120b88331bfa9162172f4a527