### PR TITLE
Document environment setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ The project includes simple helper scripts so you can get up and running quickly
 python run_coverage.py --xml --html  # run tests with coverage reports (optional)
 ```
 
-The `install` script copies `.env.sample` to `.env` if it does not exist.  By default the application uses a local SQLite
-file called `secureapp.db`.  Edit `.env` to change the configuration or to point at a PostgreSQL instance for production use.
+## Environment
+
+* Running `./install` copies `.env.sample` to `.env` the first time so you have a starting point for local configuration.
+* The default configuration uses a SQLite database stored in `secureapp.db` in the project root so you can test without
+  additional services.
+* To switch to PostgreSQL, update `DATABASE_URL` in `.env` to point at your PostgreSQL instance (for example,
+  `postgresql://username:password@localhost/database_name`) and install the appropriate driver such as `psycopg`.
+* Useful environment variables for local development include:
+  * `DATABASE_URL` – controls the database connection string.  Defaults to the bundled SQLite file but can target
+    PostgreSQL or another database supported by SQLAlchemy.
+  * `SESSION_SECRET` – Flask's secret key used to sign sessions.  Replace the sample value with a secure random string
+    for any shared or production deployment.
 
 ## Scripts
 
@@ -26,7 +36,7 @@ file called `secureapp.db`.  Edit `.env` to change the configuration or to point
 
 ## Requirements
 
-* Python 3.8 or newer
+* Python 3.12 or newer
 * Optional: PostgreSQL if you do not want to use the default SQLite database
 
 ## Developing


### PR DESCRIPTION
## Summary
- add an Environment section that explains the .env copy behavior, default SQLite database file, and how to target PostgreSQL
- document local environment variables such as DATABASE_URL and SESSION_SECRET and update the Python version guidance to 3.12+

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68ceeafffeb08331ba96a6a5066c634c