### PR TITLE
Show referer links for server events in history

### DIFF
--- a/server_templates/definitions/openrouter.py
+++ b/server_templates/definitions/openrouter.py
@@ -7,7 +7,7 @@ if not API_KEY:
     return { 'output': 'Missing OPENROUTER_API_KEY' }
 
 url = "https://openrouter.ai/api/v1/chat/completions"
-message = request.get('form_data).get('message')
+message = request.get('form_data').get('message')
 headers = {
     "Authorization": f"Bearer {API_KEY}",
     "Content-Type": "application/json",

--- a/templates/history.html
+++ b/templates/history.html
@@ -119,6 +119,14 @@
                                                     </a>
                                                 </div>
                                                 {% endif %}
+                                                {% if view.server_invocation_referer %}
+                                                <div class="mt-1">
+                                                    <a href="{{ view.server_invocation_referer }}" target="_blank" rel="noopener" class="small text-decoration-none text-break">
+                                                        <i class="fas fa-link me-1 text-secondary"></i>
+                                                        Referer: {{ view.server_invocation_referer }}
+                                                    </a>
+                                                </div>
+                                                {% endif %}
                                             </td>
                                             <td>
                                                 <span class="badge {% if view.method == 'GET' %}bg-primary{% elif view.method == 'POST' %}bg-success{% else %}bg-secondary{% endif %}">


### PR DESCRIPTION
## Summary
- load request referer data for server invocations shown on the history page
- render a referer link alongside each server event entry in the history table
- update the comprehensive history route test to cover the referer link

## Testing
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68cf0323fe2883318ce27f9661f95bd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - History page now displays a “Referer” link for relevant server invocations, providing the originating URL when available.
  - The link includes an icon, opens in a new tab, and uses safe linking attributes with improved text wrapping.

- Tests
  - Added test coverage to verify that the Referer URL is correctly associated with server invocations and rendered on the history page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->