### PR TITLE
Add alias routing support

### DIFF
--- a/alias_routing.py
+++ b/alias_routing.py
@@ -1,0 +1,61 @@
+"""Helpers for serving named alias redirects."""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from flask import redirect, request
+from flask_login import current_user
+
+from db_access import get_alias_by_name
+
+
+def _extract_alias_name(path: str) -> Optional[str]:
+    """Return the first path segment if present."""
+    if not path or not path.startswith("/"):
+        return None
+
+    remainder = path[1:]
+    if not remainder:
+        return None
+
+    return remainder.split("/", 1)[0]
+
+
+def is_potential_alias_path(path: str, existing_routes: Iterable[str]) -> bool:
+    """Return True when the request path could map to an alias."""
+    alias_name = _extract_alias_name(path)
+    if not alias_name:
+        return False
+
+    if f"/{alias_name}" in existing_routes:
+        return False
+
+    return True
+
+
+def try_alias_redirect(path: str):
+    """Return a redirect response for an alias if one matches the path."""
+    if not getattr(current_user, "is_authenticated", False):
+        return None
+
+    alias_name = _extract_alias_name(path)
+    if not alias_name:
+        return None
+
+    alias = get_alias_by_name(current_user.id, alias_name)
+    if not alias:
+        return None
+
+    target = getattr(alias, "target_path", None)
+    if not target:
+        return None
+
+    query = request.query_string.decode("utf-8")
+    if query:
+        separator = "&" if "?" in target else "?"
+        target = f"{target}{separator}{query}"
+
+    return redirect(target)
+
+
+__all__ = ["is_potential_alias_path", "try_alias_redirect"]

--- a/alias_routing.py
+++ b/alias_routing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Iterable, Optional
 
+from urllib.parse import urlsplit
+
 from flask import redirect, request
 from flask_login import current_user
 
@@ -33,6 +35,36 @@ def is_potential_alias_path(path: str, existing_routes: Iterable[str]) -> bool:
     return True
 
 
+def _is_relative_target(target: str) -> bool:
+    """Return True when the alias target stays on this server."""
+    if not target:
+        return False
+
+    if target.startswith("//"):
+        return False
+
+    parsed = urlsplit(target)
+    return not parsed.scheme and not parsed.netloc
+
+
+def _append_query_string(target: str, query: str) -> str:
+    """Attach the provided query string while respecting fragments."""
+    if not query:
+        return target
+
+    base, has_fragment, fragment = target.partition("#")
+
+    if "?" in base:
+        separator = "" if base.endswith("?") else "&"
+    else:
+        separator = "?"
+
+    combined_base = f"{base}{separator}{query}" if base else f"?{query}"
+    if has_fragment:
+        return f"{combined_base}#{fragment}"
+    return combined_base
+
+
 def try_alias_redirect(path: str):
     """Return a redirect response for an alias if one matches the path."""
     if not getattr(current_user, "is_authenticated", False):
@@ -47,13 +79,12 @@ def try_alias_redirect(path: str):
         return None
 
     target = getattr(alias, "target_path", None)
-    if not target:
+    if not target or not _is_relative_target(target):
         return None
 
     query = request.query_string.decode("utf-8")
     if query:
-        separator = "&" if "?" in target else "?"
-        target = f"{target}{separator}{query}"
+        target = _append_query_string(target, query)
 
     return redirect(target)
 

--- a/db_access.py
+++ b/db_access.py
@@ -9,6 +9,7 @@ from models import (
     CURRENT_TERMS_VERSION,
     User,
     Server,
+    Alias,
     Variable,
     Secret,
     ServerInvocation,
@@ -84,6 +85,14 @@ def get_server_by_name(user_id: str, name: str):
     return Server.query.filter_by(user_id=user_id, name=name).first()
 
 
+def get_user_aliases(user_id: str):
+    return Alias.query.filter_by(user_id=user_id).order_by(Alias.name).all()
+
+
+def get_alias_by_name(user_id: str, name: str):
+    return Alias.query.filter_by(user_id=user_id, name=name).first()
+
+
 def get_user_variables(user_id: str):
     return Variable.query.filter_by(user_id=user_id).order_by(Variable.name).all()
 
@@ -102,6 +111,10 @@ def get_secret_by_name(user_id: str, name: str):
 
 def count_user_servers(user_id: str) -> int:
     return Server.query.filter_by(user_id=user_id).count()
+
+
+def count_user_aliases(user_id: str) -> int:
+    return Alias.query.filter_by(user_id=user_id).count()
 
 
 def count_user_variables(user_id: str) -> int:

--- a/models.py
+++ b/models.py
@@ -160,6 +160,24 @@ class Server(db.Model):
     def __repr__(self):
         return f'<Server {self.name} by {self.user_id}>'
 
+
+class Alias(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, index=True)
+    target_path = db.Column(db.String(255), nullable=False)
+    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    # Relationships
+    user = db.relationship('User', backref='aliases')
+
+    __table_args__ = (db.UniqueConstraint('user_id', 'name', name='unique_user_alias_name'),)
+
+    def __repr__(self):
+        return f'<Alias {self.name} -> {self.target_path}>'
+
+
 class Variable(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False, index=True)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -10,5 +10,6 @@ from . import servers  # noqa: F401,E402
 from . import variables  # noqa: F401,E402
 from . import secrets  # noqa: F401,E402
 from . import history  # noqa: F401,E402
+from . import aliases  # noqa: F401,E402
 
 __all__ = ["main_bp"]

--- a/routes/core.py
+++ b/routes/core.py
@@ -12,6 +12,7 @@ from flask_login import current_user
 from auth_providers import require_login, auth_manager, save_user_from_claims
 from database import db
 from db_access import (
+    count_user_aliases,
     count_user_secrets,
     count_user_servers,
     count_user_variables,
@@ -238,14 +239,15 @@ def accept_invitation(invitation_code):
 @main_bp.route('/settings')
 @require_login
 def settings():
-    """Settings page with links to servers, variables, and secrets."""
+    """Settings page with links to servers, variables, aliases, and secrets."""
     counts = get_user_settings_counts(current_user.id)
     return render_template('settings.html', **counts)
 
 
 def get_user_settings_counts(user_id):
-    """Get counts of user's servers, variables, and secrets for settings display."""
+    """Get counts of a user's saved resources for settings display."""
     return {
+        'alias_count': count_user_aliases(user_id),
         'server_count': count_user_servers(user_id),
         'variable_count': count_user_variables(user_id),
         'secret_count': count_user_secrets(user_id),
@@ -307,7 +309,7 @@ def get_existing_routes():
         '/', '/dashboard', '/profile', '/subscribe', '/accept-terms', '/content',
         '/plans', '/terms', '/privacy', '/upload', '/invitations', '/create-invitation',
         '/require-invitation', '/uploads', '/history', '/servers', '/variables',
-        '/secrets', '/settings',
+        '/secrets', '/settings', '/aliases', '/aliases/new',
     }
 
 

--- a/routes/core.py
+++ b/routes/core.py
@@ -36,6 +36,7 @@ from server_execution import (
     try_server_execution_with_partial,
 )
 from cid_utils import serve_cid_content
+from alias_routing import is_potential_alias_path, try_alias_redirect
 
 from . import main_bp
 
@@ -315,6 +316,11 @@ def not_found_error(error):
     """Custom 404 handler that checks CID table and server names for content."""
     path = request.path
     existing_routes = get_existing_routes()
+
+    if is_potential_alias_path(path, existing_routes):
+        alias_result = try_alias_redirect(path)
+        if alias_result is not None:
+            return alias_result
 
     if is_potential_versioned_server_path(path, existing_routes):
         from .servers import get_server_definition_history

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-6">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-link me-2"></i>{{ title }}</h2>
+                <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
+                    <i class="fas fa-arrow-left me-1"></i>Back to Aliases
+                </a>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Alias Configuration</h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST">
+                        {{ form.hidden_tag() }}
+
+                        <div class="mb-3">
+                            {{ form.name.label(class="form-label") }}
+                            {{ form.name(class="form-control" + (" is-invalid" if form.name.errors else "")) }}
+                            {% if form.name.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.name.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">
+                                    Alias names can only contain letters, numbers, dots, hyphens, and underscores. This is the path visitors type: <code>/{{ form.name.data or 'alias-name' }}</code>.
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            {{ form.target_path.label(class="form-label") }}
+                            {{ form.target_path(class="form-control" + (" is-invalid" if form.target_path.errors else "")) }}
+                            {% if form.target_path.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.target_path.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">
+                                    Provide a relative URL on this server. Examples: <code>/{{ alias.name if alias else 'cid123' }}</code>, <code>/servers/example</code>, or <code>/dashboard?view=latest</code>.
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex justify-content-between">
+                            <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
+                                <i class="fas fa-times me-1"></i>Cancel
+                            </a>
+                            {{ form.submit(class="btn btn-primary") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            {% if alias %}
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Current Alias</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <strong>Name:</strong><br>
+                            <code>{{ alias.name }}</code>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>Last Updated:</strong><br>
+                            {{ alias.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}Alias: {{ alias.name }}{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-link me-2"></i>{{ alias.name }}</h2>
+                <div class="btn-group">
+                    <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
+                        <i class="fas fa-arrow-left me-1"></i>Back to Aliases
+                    </a>
+                    <a href="{{ url_for('main.edit_alias', alias_name=alias.name) }}" class="btn btn-primary">
+                        <i class="fas fa-edit me-1"></i>Edit Alias
+                    </a>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Alias Details</h5>
+                </div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-3">Alias Name</dt>
+                        <dd class="col-sm-9"><code>{{ alias.name }}</code></dd>
+
+                        <dt class="col-sm-3">Redirect Path</dt>
+                        <dd class="col-sm-9"><code>{{ alias.target_path }}</code></dd>
+
+                        <dt class="col-sm-3">Public URL</dt>
+                        <dd class="col-sm-9"><code>{{ request.url_root }}{{ alias.name }}</code></dd>
+                    </dl>
+                </div>
+                <div class="card-footer text-muted">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <small>
+                                <i class="fas fa-calendar-plus me-1"></i>
+                                Created: {{ alias.created_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                            </small>
+                        </div>
+                        <div class="col-md-6 text-md-end">
+                            <small>
+                                <i class="fas fa-calendar-edit me-1"></i>
+                                Last Updated: {{ alias.updated_at.strftime('%Y-%m-%d %H:%M:%S') if alias.updated_at else alias.created_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                            </small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">How it Works</h5>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted mb-3">
+                        Visiting <code>{{ request.url_root }}{{ alias.name }}</code> redirects browsers to <code>{{ alias.target_path }}</code>.
+                        Any query string on the incoming request is preserved and merged with query parameters already present on the target URL.
+                    </p>
+                    <p class="mb-0">
+                        Aliases are perfect for publishing stable URLs to frequently changing content like the latest CID or a dashboard route on your server.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/aliases.html
+++ b/templates/aliases.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}My Aliases{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-link me-2"></i>My Aliases</h2>
+                <a href="{{ url_for('main.new_alias') }}" class="btn btn-primary">
+                    <i class="fas fa-plus me-1"></i>Create New Alias
+                </a>
+            </div>
+
+            {% if aliases %}
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Name</th>
+                            <th scope="col">Target</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for alias in aliases %}
+                        <tr>
+                            <td class="fw-semibold">
+                                <span class="badge bg-secondary me-2">/{{ alias.name }}</span>
+                                {{ alias.name }}
+                            </td>
+                            <td><code>{{ alias.target_path }}</code></td>
+                            <td class="text-end">
+                                <a href="{{ url_for('main.view_alias', alias_name=alias.name) }}" class="btn btn-outline-primary btn-sm">
+                                    <i class="fas fa-eye me-1"></i>View
+                                </a>
+                                <a href="{{ url_for('main.edit_alias', alias_name=alias.name) }}" class="btn btn-outline-secondary btn-sm ms-2">
+                                    <i class="fas fa-edit me-1"></i>Edit
+                                </a>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="card">
+                <div class="card-body py-5 text-center">
+                    <i class="fas fa-link text-muted mb-3" style="font-size: 3rem;"></i>
+                    <h4>No Aliases Configured</h4>
+                    <p class="text-muted">Create your first alias to start redirecting friendly URLs.</p>
+                    <a href="{{ url_for('main.new_alias') }}" class="btn btn-primary">
+                        <i class="fas fa-plus me-1"></i>Create Your First Alias
+                    </a>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,11 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('main.aliases') }}">
+                                <i class="fas fa-link me-1"></i>Aliases
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('main.history') }}">
                                 <i class="fas fa-history me-1"></i>History
                             </a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,11 +8,38 @@
         <div class="col-12">
             <div class="mb-4">
                 <h2><i class="fas fa-cog me-2"></i>Settings</h2>
-                <p class="text-muted">Manage your servers, variables, secrets, and other configurations.</p>
+                <p class="text-muted">Manage your aliases, servers, variables, secrets, and other configurations.</p>
             </div>
 
             <div class="row">
-                <div class="col-lg-4 mb-4">
+                <div class="col-lg-3 col-md-6 mb-4">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">
+                                <i class="fas fa-link me-2 text-info"></i>Aliases
+                            </h5>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">Create memorable shortcuts that redirect to content hosted on this server.</p>
+                            <div class="mb-3">
+                                <span class="badge bg-info text-dark fs-6">{{ alias_count }} alias{{ 'es' if alias_count != 1 else '' }}</span>
+                            </div>
+                            <div class="d-grid gap-2">
+                                <a href="{{ url_for('main.aliases') }}" class="btn btn-info text-white">
+                                    <i class="fas fa-list me-1"></i>View All Aliases
+                                </a>
+                                <a href="{{ url_for('main.new_alias') }}" class="btn btn-outline-info">
+                                    <i class="fas fa-plus me-1"></i>Create New Alias
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-footer text-muted">
+                            <small>Serve aliases directly at: <code>/{name}</code></small>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-3 col-md-6 mb-4">
                     <div class="card h-100">
                         <div class="card-header">
                             <h5 class="card-title mb-0">
@@ -39,7 +66,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-4 mb-4">
+                <div class="col-lg-3 col-md-6 mb-4">
                     <div class="card h-100">
                         <div class="card-header">
                             <h5 class="card-title mb-0">
@@ -66,7 +93,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-4 mb-4">
+                <div class="col-lg-3 col-md-6 mb-4">
                     <div class="card h-100">
                         <div class="card-header">
                             <h5 class="card-title mb-0">
@@ -106,21 +133,21 @@
                             <div class="row">
                                 <div class="col-md-4">
                                     <h6>URL-Safe Naming</h6>
-                                    <p class="small text-muted">All server, variable, and secret names must contain only letters, numbers, dots, hyphens, and underscores to ensure they work properly in URLs.</p>
+                                    <p class="small text-muted">All alias, server, variable, and secret names must contain only letters, numbers, dots, hyphens, and underscores to ensure they work properly in URLs.</p>
                                 </div>
                                 <div class="col-md-4">
-                                    <h6>Multi-line Definitions</h6>
-                                    <p class="small text-muted">Servers, variables, and secrets support multi-line text definitions, making them perfect for configurations, scripts, or any text content.</p>
+                                    <h6>Alias Targets</h6>
+                                    <p class="small text-muted">Aliases redirect to relative URLs on this application. Point them at CIDs, servers, or any other on-site resource without leaving the platform.</p>
                                 </div>
                                 <div class="col-md-4">
                                     <h6>Direct Access</h6>
-                                    <p class="small text-muted">Access your items directly via URLs: <code>/servers/{name}</code>, <code>/variables/{name}</code>, and <code>/secrets/{name}</code></p>
+                                    <p class="small text-muted">Access your items directly via URLs: <code>/{name}</code> for aliases, <code>/servers/{name}</code>, <code>/variables/{name}</code>, and <code>/secrets/{name}</code>.</p>
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6">
                                     <h6>Personal Libraries</h6>
-                                    <p class="small text-muted">Each user maintains their own separate collections of servers, variables, and secrets with no conflicts.</p>
+                                    <p class="small text-muted">Each user maintains their own separate collections of aliases, servers, variables, and secrets with no conflicts.</p>
                                 </div>
                                 <div class="col-md-6">
                                     <h6>Secure Storage</h6>

--- a/test_alias_routing.py
+++ b/test_alias_routing.py
@@ -1,0 +1,88 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('SESSION_SECRET', 'test-secret-key')
+
+from app import app, db
+from models import Alias, User
+from alias_routing import is_potential_alias_path, try_alias_redirect
+from routes.core import get_existing_routes, not_found_error
+
+
+class TestAliasRouting(unittest.TestCase):
+    """Tests for alias matching and redirect behaviour."""
+
+    def setUp(self):
+        app.config['TESTING'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.test_user = User(
+            id='alias-user',
+            email='alias@example.com',
+            is_paid=True,
+            current_terms_accepted=True,
+        )
+        db.session.add(self.test_user)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def create_alias(self, name='latest', target='/target'):
+        alias = Alias(name=name, target_path=target, user_id=self.test_user.id)
+        db.session.add(alias)
+        db.session.commit()
+        return alias
+
+    def test_is_potential_alias_path(self):
+        routes = get_existing_routes()
+        self.assertFalse(is_potential_alias_path('/', routes))
+        self.assertTrue(is_potential_alias_path('/latest', routes))
+        self.assertTrue(is_potential_alias_path('/latest/abc', routes))
+        self.assertFalse(is_potential_alias_path('/servers/history', routes))
+
+    def test_try_alias_redirect_requires_authentication(self):
+        self.create_alias()
+        with app.test_request_context('/latest'):
+            with patch('alias_routing.current_user', new=SimpleNamespace(is_authenticated=False)):
+                result = try_alias_redirect('/latest')
+                self.assertIsNone(result)
+
+    def test_try_alias_redirect_success(self):
+        self.create_alias(target='/cid123')
+        with app.test_request_context('/latest'):
+            with patch('alias_routing.current_user', new=SimpleNamespace(is_authenticated=True, id=self.test_user.id)):
+                response = try_alias_redirect('/latest')
+                self.assertIsNotNone(response)
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(response.location, '/cid123')
+
+    def test_try_alias_redirect_preserves_query(self):
+        self.create_alias(target='/cid123')
+        with app.test_request_context('/latest?download=1&format=html'):
+            with patch('alias_routing.current_user', new=SimpleNamespace(is_authenticated=True, id=self.test_user.id)):
+                response = try_alias_redirect('/latest')
+                self.assertIsNotNone(response)
+                self.assertEqual(response.location, '/cid123?download=1&format=html')
+
+    def test_not_found_handler_uses_alias(self):
+        self.create_alias(target='/cid123')
+        with app.test_request_context('/latest/anything'):
+            with patch('alias_routing.current_user', new=SimpleNamespace(is_authenticated=True, id=self.test_user.id)):
+                response = not_found_error(Exception('not found'))
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(response.location, '/cid123')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an Alias model and supporting data access helpers for user-configured redirects
- implement alias routing utilities and integrate them into the 404 handler so matching paths redirect to their targets
- add unit tests covering alias detection, redirect behaviour, and 404 handling

## Testing
- pytest test_alias_routing.py
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68cf0a357bc88331ac30bac80b18df29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user path aliases with UI to list, create, view, and edit aliases.
  * Aliases added to navigation and Settings (counts and usage guidance).
  * 404 handling now attempts an alias redirect before showing not-found.

* **Behavior**
  * Redirects preserve query strings and fragments; absolute/external targets are rejected.

* **Tests**
  * Comprehensive tests for alias detection, auth gating, redirects, UI flows, and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->