### PR TITLE
Annotate uploads with creation sources

### DIFF
--- a/templates/uploads.html
+++ b/templates/uploads.html
@@ -69,6 +69,7 @@
                                 <tr>
                                     <th>Size</th>
                                     <th>Uploaded</th>
+                                    <th>Created Via</th>
                                     <th>CID</th>
                                     <th>Content Preview</th>
                                     <th>Actions</th>
@@ -97,6 +98,21 @@
                                             {{ upload.created_at.strftime('%Y-%m-%d %H:%M') }}
                                         {% else %}
                                             -
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if upload.creation_method == 'server_event' %}
+                                            <div class="d-flex flex-column gap-1">
+                                                <span class="badge text-bg-secondary align-self-start">Server Event</span>
+                                                {% if upload.server_invocation_server_name %}
+                                                    <span class="small text-muted">Server: {{ upload.server_invocation_server_name }}</span>
+                                                {% endif %}
+                                                {% if upload.server_invocation_link %}
+                                                    <a href="{{ upload.server_invocation_link }}" class="small">View event JSON</a>
+                                                {% endif %}
+                                            </div>
+                                        {% else %}
+                                            <span class="badge text-bg-primary">Upload</span>
                                         {% endif %}
                                     </td>
                                     <td>


### PR DESCRIPTION
## Summary
- annotate uploaded CID records with their creation source and any related server invocation
- update the uploads table to show when an item was generated by a server event with a link to the invocation JSON
- add a regression test to cover the new uploads view behaviour

## Testing
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68cf19cf3ddc83318ed9e2e500177f6a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Created Via” column to the uploads list, indicating whether each file came from a direct upload or a server event.
  * For server events, shows a “Server Event” badge, server name (when available), and a link to view the event JSON.
  * For manual uploads, displays an “Upload” badge.

* **Tests**
  * Added tests to verify the new creation source indicators and event JSON link render correctly on the uploads page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->