### PR TITLE
Add dedicated server events page

### DIFF
--- a/routes/uploads.py
+++ b/routes/uploads.py
@@ -19,6 +19,13 @@ from . import main_bp
 from .history import _load_request_referers
 
 
+def _shorten_cid(cid, length=6):
+    """Return a shortened CID label for display."""
+    if not cid:
+        return None
+    return f"{cid[:length]}..."
+
+
 @main_bp.route('/upload', methods=['GET', 'POST'])
 @require_login
 def upload():
@@ -126,24 +133,36 @@ def server_events():
             if getattr(invocation, 'invocation_cid', None)
             else None
         )
+        invocation.invocation_label = _shorten_cid(
+            getattr(invocation, 'invocation_cid', None)
+        )
         invocation.request_details_link = (
-            f"/{invocation.request_details_cid}"
+            f"/{invocation.request_details_cid}.json"
             if getattr(invocation, 'request_details_cid', None)
             else None
         )
+        invocation.request_details_label = _shorten_cid(
+            getattr(invocation, 'request_details_cid', None)
+        )
         invocation.result_link = (
-            f"/{invocation.result_cid}"
+            f"/{invocation.result_cid}.txt"
             if getattr(invocation, 'result_cid', None)
             else None
+        )
+        invocation.result_label = _shorten_cid(
+            getattr(invocation, 'result_cid', None)
         )
         invocation.server_link = url_for(
             'main.view_server',
             server_name=invocation.server_name,
         )
         invocation.servers_cid_link = (
-            f"/{invocation.servers_cid}"
+            f"/{invocation.servers_cid}.json"
             if getattr(invocation, 'servers_cid', None)
             else None
+        )
+        invocation.servers_cid_label = _shorten_cid(
+            getattr(invocation, 'servers_cid', None)
         )
         request_cid = getattr(invocation, 'request_details_cid', None)
         invocation.request_referer = referer_by_request.get(request_cid) if request_cid else None

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,11 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('main.server_events') }}">
+                                <i class="fas fa-server me-1"></i>Server Events
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('main.aliases') }}">
                                 <i class="fas fa-link me-1"></i>Aliases
                             </a>

--- a/templates/server_events.html
+++ b/templates/server_events.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+
+{% block title %}Server Events{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-server me-2"></i>Server Events</h2>
+                <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">
+                    <i class="fas fa-code me-1"></i>Manage Servers
+                </a>
+            </div>
+
+            <div class="row mb-4">
+                <div class="col-md-6 col-lg-4">
+                    <div class="card bg-secondary text-white">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div>
+                                    <h5 class="card-title mb-1">Total Events</h5>
+                                    <h3 class="mb-0">{{ total_events }}</h3>
+                                </div>
+                                <div class="align-self-center">
+                                    <i class="fas fa-history fa-2x opacity-75"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {% if events %}
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Invocation History</h5>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Invoked</th>
+                                    <th>Server</th>
+                                    <th>Invocation JSON</th>
+                                    <th>Request Details</th>
+                                    <th>Result CID</th>
+                                    <th>Servers CID</th>
+                                    <th>Referer</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for event in events %}
+                                <tr>
+                                    <td>
+                                        {% if event.invoked_at %}
+                                            {{ event.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ event.server_link }}" class="text-decoration-none">
+                                            {{ event.server_name }}
+                                        </a>
+                                    </td>
+                                    <td>
+                                        {% if event.invocation_link %}
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                View JSON
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.request_details_link %}
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ event.request_details_cid }}
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.result_link %}
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                <code class="small">{{ event.result_cid }}</code>
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.servers_cid_link %}
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ event.servers_cid }}
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-break">
+                                        {% if event.request_referer %}
+                                            <a href="{{ event.request_referer }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ event.request_referer }}
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+            <div class="card">
+                <div class="card-body text-center py-5">
+                    <i class="fas fa-robot text-muted mb-3" style="font-size: 3rem;"></i>
+                    <h4>No Server Events Yet</h4>
+                    <p class="text-muted">Run a server to see its invocation history here.</p>
+                    <a href="{{ url_for('main.servers') }}" class="btn btn-primary">
+                        <i class="fas fa-code me-1"></i>Create or Run a Server
+                    </a>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/server_events.html
+++ b/templates/server_events.html
@@ -67,8 +67,8 @@
                                     </td>
                                     <td>
                                         {% if event.invocation_link %}
-                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                                View JSON
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                                <code class="small">{{ event.invocation_label }}</code>
                                             </a>
                                         {% else %}
                                             <span class="text-muted">-</span>
@@ -76,8 +76,8 @@
                                     </td>
                                     <td>
                                         {% if event.request_details_link %}
-                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                                {{ event.request_details_cid }}
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                                <code class="small">{{ event.request_details_label }}</code>
                                             </a>
                                         {% else %}
                                             <span class="text-muted">-</span>
@@ -85,8 +85,8 @@
                                     </td>
                                     <td>
                                         {% if event.result_link %}
-                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                                <code class="small">{{ event.result_cid }}</code>
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                                <code class="small">{{ event.result_label }}</code>
                                             </a>
                                         {% else %}
                                             <span class="text-muted">-</span>
@@ -94,8 +94,8 @@
                                     </td>
                                     <td>
                                         {% if event.servers_cid_link %}
-                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                                                {{ event.servers_cid }}
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                                <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
                                         {% else %}
                                             <span class="text-muted">-</span>

--- a/test_routes_comprehensive.py
+++ b/test_routes_comprehensive.py
@@ -485,11 +485,16 @@ class TestFileUploadRoutes(BaseTestCase):
 
         page = response.get_data(as_text=True)
         self.assertIn(f'/{invocation_cid}.json', page)
-        self.assertIn(f'/{request_cid}', page)
-        self.assertIn(f'/{result_cid}', page)
-        self.assertIn(f'/{servers_cid}', page)
+        self.assertIn(f'/{request_cid}.json', page)
+        self.assertIn(f'/{result_cid}.txt', page)
+        self.assertIn(f'/{servers_cid}.json', page)
         self.assertIn('/servers/test-server', page)
         self.assertIn('https://example.com/origin', page)
+
+        self.assertIn(f'{invocation_cid[:6]}...', page)
+        self.assertIn(f'{request_cid[:6]}...', page)
+        self.assertIn(f'{result_cid[:6]}...', page)
+        self.assertIn(f'{servers_cid[:6]}...', page)
 
 
 class TestInvitationRoutes(BaseTestCase):

--- a/test_versioned_server_invocation.py
+++ b/test_versioned_server_invocation.py
@@ -30,7 +30,7 @@ class TestVersionedServerInvocation(unittest.TestCase):
         self.server_name = 'my_server'
 
     def test_is_potential_versioned_server_path(self):
-        existing = {'/servers', '/uploads'}
+        existing = {'/servers', '/uploads', '/server_events'}
         self.assertTrue(is_potential_versioned_server_path('/foo/abc', existing))
         self.assertFalse(is_potential_versioned_server_path('/', existing))
         self.assertFalse(is_potential_versioned_server_path('/foo', existing))  # only one segment


### PR DESCRIPTION
## Summary
- stop showing server-invocation CIDs on /uploads
- add a /server_events view that links to invocation, request, result, definition, and referer data
- expose the server events page in the navigation and cover it with tests

## Testing
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68cf23fb3f948331b543392007991bce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server Events page showing per-user invocation history, total events summary, and a Manage Servers action; navigation item added for signed-in users.

* **Changes**
  * Uploads list now excludes items generated by server events so it shows only manual uploads.

* **Tests**
  * Added tests for the Server Events page and updated uploads-list tests to reflect the exclusion of server-event items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->