### PR TITLE
Add import/export workflows for user configuration

### DIFF
--- a/encryption.py
+++ b/encryption.py
@@ -1,0 +1,105 @@
+"""Utility helpers for encrypting and decrypting secret values."""
+from __future__ import annotations
+
+import base64
+import os
+from hashlib import sha256
+from hmac import compare_digest, new as hmac_new
+
+_SECRET_IV_SIZE = 16
+_SECRET_MAC_SIZE = 32
+SECRET_ENCRYPTION_SCHEME = "xor-hmac-sha256"
+
+
+def _derive_keystream(key_material: bytes, iv: bytes, length: int) -> bytes:
+    """Derive a pseudo-random keystream using repeated SHA-256 hashing.
+
+    The keystream is deterministic for a given key and IV so the same
+    parameters can decrypt previously encrypted values.
+    """
+    if length <= 0:
+        return b""
+
+    stream = bytearray()
+    counter = 0
+    while len(stream) < length:
+        counter_bytes = counter.to_bytes(4, "big", signed=False)
+        digest = sha256(key_material + iv + counter_bytes).digest()
+        stream.extend(digest)
+        counter += 1
+    return bytes(stream[:length])
+
+
+def encrypt_secret_value(plaintext: str, key: str) -> str:
+    """Encrypt a plaintext secret using the provided key.
+
+    Args:
+        plaintext: The secret value to encrypt.
+        key: A user-supplied passphrase.
+
+    Returns:
+        A base64-url encoded ciphertext that includes the IV and HMAC for
+        authentication.
+
+    Raises:
+        ValueError: If the key is empty.
+    """
+    if not key:
+        raise ValueError("Encryption key is required")
+
+    key_material = sha256(key.encode("utf-8")).digest()
+    iv = os.urandom(_SECRET_IV_SIZE)
+    data = plaintext.encode("utf-8")
+    keystream = _derive_keystream(key_material, iv, len(data))
+    ciphertext = bytes(a ^ b for a, b in zip(data, keystream))
+    mac = hmac_new(key_material, iv + ciphertext, sha256).digest()
+    payload = iv + ciphertext + mac
+    return base64.urlsafe_b64encode(payload).decode("utf-8")
+
+
+def decrypt_secret_value(ciphertext_token: str, key: str) -> str:
+    """Decrypt a ciphertext produced by :func:`encrypt_secret_value`.
+
+    Args:
+        ciphertext_token: The encoded ciphertext returned from encryption.
+        key: The user-supplied passphrase.
+
+    Returns:
+        The decrypted plaintext string.
+
+    Raises:
+        ValueError: If the token is malformed or the key is incorrect.
+    """
+    if not key:
+        raise ValueError("Decryption key is required")
+
+    try:
+        raw = base64.urlsafe_b64decode(ciphertext_token.encode("utf-8"))
+    except Exception as exc:  # pragma: no cover - base64 handles specifics
+        raise ValueError("Invalid encrypted secret payload") from exc
+
+    if len(raw) < _SECRET_IV_SIZE + _SECRET_MAC_SIZE:
+        raise ValueError("Invalid encrypted secret payload")
+
+    iv = raw[:_SECRET_IV_SIZE]
+    mac = raw[-_SECRET_MAC_SIZE:]
+    ciphertext = raw[_SECRET_IV_SIZE:-_SECRET_MAC_SIZE]
+
+    key_material = sha256(key.encode("utf-8")).digest()
+    expected_mac = hmac_new(key_material, iv + ciphertext, sha256).digest()
+    if not compare_digest(mac, expected_mac):
+        raise ValueError("Invalid encryption key")
+
+    keystream = _derive_keystream(key_material, iv, len(ciphertext))
+    plaintext_bytes = bytes(a ^ b for a, b in zip(ciphertext, keystream))
+    try:
+        return plaintext_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError("Invalid encrypted secret payload") from exc
+
+
+__all__ = [
+    "SECRET_ENCRYPTION_SCHEME",
+    "decrypt_secret_value",
+    "encrypt_secret_value",
+]

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -11,5 +11,6 @@ from . import variables  # noqa: F401,E402
 from . import secrets  # noqa: F401,E402
 from . import history  # noqa: F401,E402
 from . import aliases  # noqa: F401,E402
+from . import import_export  # noqa: F401,E402
 
 __all__ = ["main_bp"]

--- a/routes/core.py
+++ b/routes/core.py
@@ -310,6 +310,7 @@ def get_existing_routes():
         '/plans', '/terms', '/privacy', '/upload', '/invitations', '/create-invitation',
         '/require-invitation', '/uploads', '/history', '/servers', '/variables',
         '/secrets', '/settings', '/aliases', '/aliases/new',
+        '/export', '/import',
     }
 
 

--- a/routes/import_export.py
+++ b/routes/import_export.py
@@ -1,0 +1,391 @@
+"""Routes for exporting and importing user configuration data."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Iterable, Tuple
+
+import requests
+from flask import current_app, flash, redirect, render_template, url_for
+from flask_login import current_user
+
+from auth_providers import require_login
+from cid_utils import save_server_definition_as_cid
+from db_access import (
+    get_alias_by_name,
+    get_secret_by_name,
+    get_server_by_name,
+    get_user_aliases,
+    get_user_secrets,
+    get_user_servers,
+    get_user_variables,
+    get_variable_by_name,
+    save_entity,
+)
+from encryption import SECRET_ENCRYPTION_SCHEME, decrypt_secret_value, encrypt_secret_value
+from forms import ExportForm, ImportForm
+from models import Alias, Secret, Server, Variable
+
+from . import main_bp
+from .core import get_existing_routes
+from .secrets import update_secret_definitions_cid
+from .servers import update_server_definitions_cid
+from .variables import update_variable_definitions_cid
+
+
+def _load_import_payload(form: ImportForm) -> str | None:
+    """Return JSON content based on the selected import source."""
+    source = form.import_source.data
+
+    if source == 'file':
+        file_storage = form.import_file.data
+        if not file_storage:
+            form.import_file.errors.append('Choose a JSON file to upload.')
+            return None
+        try:
+            raw_bytes = file_storage.read()
+        except Exception:
+            form.import_file.errors.append('Unable to read the uploaded file.')
+            return None
+        if not raw_bytes:
+            form.import_file.errors.append('Uploaded file was empty.')
+            return None
+        try:
+            return raw_bytes.decode('utf-8')
+        except UnicodeDecodeError:
+            form.import_file.errors.append('Uploaded file must be UTF-8 encoded JSON.')
+            return None
+
+    if source == 'text':
+        return form.import_text.data.strip()
+
+    if source == 'url':
+        url = form.import_url.data.strip()
+        try:
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+        except requests.RequestException:
+            form.import_url.errors.append('Failed to download JSON from the provided URL.')
+            return None
+        if not response.text.strip():
+            form.import_url.errors.append('Downloaded file was empty.')
+            return None
+        return response.text
+
+    return None
+
+
+def _import_aliases(user_id: str, raw_aliases: Any) -> Tuple[int, list[str]]:
+    """Import alias definitions from JSON data."""
+    if raw_aliases is None:
+        return 0, ['No alias data found in import file.']
+    if not isinstance(raw_aliases, list):
+        return 0, ['Aliases in import file must be a list.']
+
+    errors: list[str] = []
+    imported = 0
+    reserved_routes = get_existing_routes()
+
+    for entry in raw_aliases:
+        if not isinstance(entry, dict):
+            errors.append('Alias entries must be objects with name and target_path.')
+            continue
+
+        name = entry.get('name')
+        target_path = entry.get('target_path')
+        if not name or not target_path:
+            errors.append('Alias entry must include both name and target_path.')
+            continue
+
+        if f'/{name}' in reserved_routes:
+            errors.append(f'Alias "{name}" conflicts with an existing route and was skipped.')
+            continue
+
+        existing = get_alias_by_name(user_id, name)
+        if existing:
+            existing.target_path = target_path
+            existing.updated_at = datetime.now(timezone.utc)
+            save_entity(existing)
+        else:
+            alias = Alias(name=name, target_path=target_path, user_id=user_id)
+            save_entity(alias)
+        imported += 1
+
+    return imported, errors
+
+
+def _import_servers(user_id: str, raw_servers: Any) -> Tuple[int, list[str]]:
+    """Import server definitions from JSON data."""
+    if raw_servers is None:
+        return 0, ['No server data found in import file.']
+    if not isinstance(raw_servers, list):
+        return 0, ['Servers in import file must be a list.']
+
+    errors: list[str] = []
+    imported = 0
+
+    for entry in raw_servers:
+        if not isinstance(entry, dict):
+            errors.append('Server entries must be objects with name and definition.')
+            continue
+
+        name = entry.get('name')
+        definition = entry.get('definition')
+        if not name or definition is None:
+            errors.append('Server entry must include both name and definition.')
+            continue
+
+        definition_cid = save_server_definition_as_cid(definition, user_id)
+        existing = get_server_by_name(user_id, name)
+        if existing:
+            existing.definition = definition
+            existing.definition_cid = definition_cid
+            existing.updated_at = datetime.now(timezone.utc)
+            save_entity(existing)
+        else:
+            server = Server(
+                name=name,
+                definition=definition,
+                user_id=user_id,
+                definition_cid=definition_cid,
+            )
+            save_entity(server)
+        imported += 1
+
+    if imported:
+        update_server_definitions_cid(user_id)
+
+    return imported, errors
+
+
+def _import_variables(user_id: str, raw_variables: Any) -> Tuple[int, list[str]]:
+    """Import variable definitions from JSON data."""
+    if raw_variables is None:
+        return 0, ['No variable data found in import file.']
+    if not isinstance(raw_variables, list):
+        return 0, ['Variables in import file must be a list.']
+
+    errors: list[str] = []
+    imported = 0
+
+    for entry in raw_variables:
+        if not isinstance(entry, dict):
+            errors.append('Variable entries must be objects with name and definition.')
+            continue
+
+        name = entry.get('name')
+        definition = entry.get('definition')
+        if not name or definition is None:
+            errors.append('Variable entry must include both name and definition.')
+            continue
+
+        existing = get_variable_by_name(user_id, name)
+        if existing:
+            existing.definition = definition
+            existing.updated_at = datetime.now(timezone.utc)
+            save_entity(existing)
+        else:
+            variable = Variable(name=name, definition=definition, user_id=user_id)
+            save_entity(variable)
+        imported += 1
+
+    if imported:
+        update_variable_definitions_cid(user_id)
+
+    return imported, errors
+
+
+def _normalise_secret_items(raw_secrets: Any) -> Iterable[dict[str, Any]] | None:
+    if raw_secrets is None:
+        return None
+    if isinstance(raw_secrets, dict):
+        items = raw_secrets.get('items')
+    else:
+        items = raw_secrets
+    if not isinstance(items, list):
+        return None
+    return items
+
+
+def _import_secrets(user_id: str, raw_secrets: Any, key: str) -> Tuple[int, list[str]]:
+    """Import secret definitions from JSON data."""
+    items = _normalise_secret_items(raw_secrets)
+    if items is None:
+        return 0, ['No secret data found in import file.']
+
+    errors: list[str] = []
+    imported = 0
+
+    try:
+        for entry in items:
+            if not isinstance(entry, dict):
+                errors.append('Secret entries must be objects with name and encrypted value.')
+                continue
+
+            name = entry.get('name')
+            ciphertext = entry.get('ciphertext') or entry.get('definition')
+            if not name or not ciphertext:
+                errors.append('Secret entries must include name and encrypted value.')
+                continue
+
+            plaintext = decrypt_secret_value(ciphertext, key)
+            existing = get_secret_by_name(user_id, name)
+            if existing:
+                existing.definition = plaintext
+                existing.updated_at = datetime.now(timezone.utc)
+                save_entity(existing)
+            else:
+                secret = Secret(name=name, definition=plaintext, user_id=user_id)
+                save_entity(secret)
+            imported += 1
+    except ValueError:
+        return 0, ['Invalid decryption key for secrets.']
+
+    if imported:
+        update_secret_definitions_cid(user_id)
+
+    return imported, errors
+
+
+@main_bp.route('/export', methods=['GET', 'POST'])
+@require_login
+def export_data():
+    """Allow users to export selected data collections as JSON."""
+    form = ExportForm()
+    if form.validate_on_submit():
+        payload: dict[str, Any] = {
+            'version': 1,
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+        }
+
+        if form.include_aliases.data:
+            payload['aliases'] = [
+                {
+                    'name': alias.name,
+                    'target_path': alias.target_path,
+                }
+                for alias in get_user_aliases(current_user.id)
+            ]
+
+        if form.include_servers.data:
+            payload['servers'] = [
+                {
+                    'name': server.name,
+                    'definition': server.definition,
+                }
+                for server in get_user_servers(current_user.id)
+            ]
+
+        if form.include_variables.data:
+            payload['variables'] = [
+                {
+                    'name': variable.name,
+                    'definition': variable.definition,
+                }
+                for variable in get_user_variables(current_user.id)
+            ]
+
+        if form.include_secrets.data:
+            key = form.secret_key.data.strip()
+            payload['secrets'] = {
+                'encryption': SECRET_ENCRYPTION_SCHEME,
+                'items': [
+                    {
+                        'name': secret.name,
+                        'ciphertext': encrypt_secret_value(secret.definition, key),
+                    }
+                    for secret in get_user_secrets(current_user.id)
+                ],
+            }
+
+        json_payload = json.dumps(payload, indent=2, sort_keys=True)
+        response = current_app.response_class(json_payload, mimetype='application/json')
+        response.headers['Content-Disposition'] = 'attachment; filename=secureapp-export.json'
+        return response
+
+    return render_template('export.html', form=form)
+
+
+@main_bp.route('/import', methods=['GET', 'POST'])
+@require_login
+def import_data():
+    """Allow users to import data collections from JSON content."""
+    form = ImportForm()
+    if form.validate_on_submit():
+        raw_payload = _load_import_payload(form)
+        if raw_payload is None:
+            return render_template('import.html', form=form)
+
+        raw_payload = raw_payload.strip()
+        if not raw_payload:
+            flash('Import data was empty.', 'danger')
+            return render_template('import.html', form=form)
+
+        try:
+            data = json.loads(raw_payload)
+        except json.JSONDecodeError as exc:
+            flash(f'Failed to parse JSON: {exc}', 'danger')
+            return render_template('import.html', form=form)
+
+        if not isinstance(data, dict):
+            flash('Import file must contain a JSON object.', 'danger')
+            return render_template('import.html', form=form)
+
+        user_id = current_user.id
+        errors: list[str] = []
+        summaries: list[str] = []
+
+        imported_aliases = 0
+        alias_errors: list[str] = []
+        if form.include_aliases.data:
+            imported_aliases, alias_errors = _import_aliases(user_id, data.get('aliases'))
+            errors.extend(alias_errors)
+            if imported_aliases:
+                label = 'aliases' if imported_aliases != 1 else 'alias'
+                summaries.append(f'{imported_aliases} {label}')
+
+        imported_servers = 0
+        server_errors: list[str] = []
+        if form.include_servers.data:
+            imported_servers, server_errors = _import_servers(user_id, data.get('servers'))
+            errors.extend(server_errors)
+            if imported_servers:
+                label = 'servers' if imported_servers != 1 else 'server'
+                summaries.append(f'{imported_servers} {label}')
+
+        imported_variables = 0
+        variable_errors: list[str] = []
+        if form.include_variables.data:
+            imported_variables, variable_errors = _import_variables(user_id, data.get('variables'))
+            errors.extend(variable_errors)
+            if imported_variables:
+                label = 'variables' if imported_variables != 1 else 'variable'
+                summaries.append(f'{imported_variables} {label}')
+
+        imported_secrets = 0
+        secret_errors: list[str] = []
+        if form.include_secrets.data:
+            imported_secrets, secret_errors = _import_secrets(
+                user_id,
+                data.get('secrets'),
+                form.secret_key.data.strip(),
+            )
+            errors.extend(secret_errors)
+            if imported_secrets:
+                label = 'secrets' if imported_secrets != 1 else 'secret'
+                summaries.append(f'{imported_secrets} {label}')
+
+        for message in errors:
+            flash(message, 'danger')
+
+        if summaries:
+            summary_text = ', '.join(summaries)
+            flash(f'Imported {summary_text}.', 'success')
+
+        if errors or summaries:
+            return redirect(url_for('main.import_data'))
+
+    return render_template('import.html', form=form)
+
+
+__all__ = ['export_data', 'import_data']

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,16 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('main.export_data') }}">
+                                <i class="fas fa-download me-1"></i>Export
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('main.import_data') }}">
+                                <i class="fas fa-file-import me-1"></i>Import
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('main.settings') }}">
                                 <i class="fas fa-cog me-1"></i>Settings
                             </a>

--- a/templates/export.html
+++ b/templates/export.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{% block title %}Export Data{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-download me-2"></i>Export Data</h2>
+                <a href="{{ url_for('main.settings') }}" class="btn btn-secondary">
+                    <i class="fas fa-arrow-left me-1"></i>Back to Settings
+                </a>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Select Data to Export</h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST">
+                        {{ form.hidden_tag() }}
+
+                        <p class="text-muted">Choose the collections you want to include in the exported JSON file.</p>
+
+                        {% if form.include_aliases.errors %}
+                        <div class="alert alert-danger">
+                            {% for error in form.include_aliases.errors %}
+                                <div>{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+
+                        <div class="form-check mb-2">
+                            {{ form.include_aliases(class="form-check-input", id="include-aliases") }}
+                            <label class="form-check-label" for="include-aliases">
+                                <i class="fas fa-link me-1 text-info"></i>{{ form.include_aliases.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="form-check mb-2">
+                            {{ form.include_servers(class="form-check-input", id="include-servers") }}
+                            <label class="form-check-label" for="include-servers">
+                                <i class="fas fa-server me-1 text-primary"></i>{{ form.include_servers.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="form-check mb-2">
+                            {{ form.include_variables(class="form-check-input", id="include-variables") }}
+                            <label class="form-check-label" for="include-variables">
+                                <i class="fas fa-code me-1 text-success"></i>{{ form.include_variables.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="form-check mb-3">
+                            {{ form.include_secrets(class="form-check-input", id="include-secrets") }}
+                            <label class="form-check-label" for="include-secrets">
+                                <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="mb-4">
+                            {{ form.secret_key.label(class="form-label") }}
+                            {{ form.secret_key(class="form-control" + (" is-invalid" if form.secret_key.errors else "")) }}
+                            {% if form.secret_key.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.secret_key.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">Secrets will be encrypted using this key. Keep it safe to decrypt them later.</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex justify-content-between">
+                            <a href="{{ url_for('main.settings') }}" class="btn btn-outline-secondary">
+                                <i class="fas fa-times me-1"></i>Cancel
+                            </a>
+                            {{ form.submit(class="btn btn-primary") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="alert alert-info mt-4" role="alert">
+                <i class="fas fa-lock me-2"></i>Secrets are encrypted with the key you provide. Share the key securely with anyone importing this export.
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/import.html
+++ b/templates/import.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+
+{% block title %}Import Data{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h2><i class="fas fa-file-import me-2"></i>Import Data</h2>
+                <a href="{{ url_for('main.settings') }}" class="btn btn-secondary">
+                    <i class="fas fa-arrow-left me-1"></i>Back to Settings
+                </a>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Provide Import Source</h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST" enctype="multipart/form-data">
+                        {{ form.hidden_tag() }}
+
+                        <p class="text-muted">Upload a previously exported JSON file, paste JSON directly, or fetch the data from a URL.</p>
+
+                        <div class="mb-3">
+                            <label class="form-label">{{ form.import_source.label.text }}</label>
+                            {% for option in form.import_source %}
+                                <div class="form-check">
+                                    {{ option(class="form-check-input", id=option.id) }}
+                                    <label class="form-check-label" for="{{ option.id }}">{{ option.label.text }}</label>
+                                </div>
+                            {% endfor %}
+                            {% if form.import_source.errors %}
+                                <div class="text-danger small mt-1">
+                                    {% for error in form.import_source.errors %}
+                                        <div>{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            {{ form.import_file.label(class="form-label") }}
+                            {{ form.import_file(class="form-control" + (" is-invalid" if form.import_file.errors else "")) }}
+                            {% if form.import_file.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.import_file.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">Upload a JSON export file from SecureApp.</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            {{ form.import_text.label(class="form-label") }}
+                            {{ form.import_text(class="form-control" + (" is-invalid" if form.import_text.errors else ""), style="font-family: monospace;") }}
+                            {% if form.import_text.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.import_text.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">Paste JSON content directly if you do not have a file.</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-4">
+                            {{ form.import_url.label(class="form-label") }}
+                            {{ form.import_url(class="form-control" + (" is-invalid" if form.import_url.errors else "")) }}
+                            {% if form.import_url.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.import_url.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">Provide a URL that returns a SecureApp JSON export.</div>
+                            {% endif %}
+                        </div>
+
+                        {% if form.include_aliases.errors %}
+                        <div class="alert alert-danger">
+                            {% for error in form.include_aliases.errors %}
+                                <div>{{ error }}</div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+
+                        <h5 class="mb-3">Select Data to Import</h5>
+                        <div class="form-check mb-2">
+                            {{ form.include_aliases(class="form-check-input", id="import-aliases") }}
+                            <label class="form-check-label" for="import-aliases">
+                                <i class="fas fa-link me-1 text-info"></i>{{ form.include_aliases.label.text }}
+                            </label>
+                        </div>
+                        <div class="form-check mb-2">
+                            {{ form.include_servers(class="form-check-input", id="import-servers") }}
+                            <label class="form-check-label" for="import-servers">
+                                <i class="fas fa-server me-1 text-primary"></i>{{ form.include_servers.label.text }}
+                            </label>
+                        </div>
+                        <div class="form-check mb-2">
+                            {{ form.include_variables(class="form-check-input", id="import-variables") }}
+                            <label class="form-check-label" for="import-variables">
+                                <i class="fas fa-code me-1 text-success"></i>{{ form.include_variables.label.text }}
+                            </label>
+                        </div>
+                        <div class="form-check mb-3">
+                            {{ form.include_secrets(class="form-check-input", id="import-secrets") }}
+                            <label class="form-check-label" for="import-secrets">
+                                <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="mb-4">
+                            {{ form.secret_key.label(class="form-label") }}
+                            {{ form.secret_key(class="form-control" + (" is-invalid" if form.secret_key.errors else "")) }}
+                            {% if form.secret_key.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.secret_key.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">Use the same key that was used to encrypt secrets during export.</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex justify-content-between">
+                            <a href="{{ url_for('main.settings') }}" class="btn btn-outline-secondary">
+                                <i class="fas fa-times me-1"></i>Cancel
+                            </a>
+                            {{ form.submit(class="btn btn-primary") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="alert alert-warning mt-4" role="alert">
+                <i class="fas fa-exclamation-triangle me-2"></i>Existing items with the same name will be updated during import.
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -122,6 +122,32 @@
             </div>
 
             <div class="row">
+                <div class="col-lg-6 col-md-8 mb-4">
+                    <div class="card h-100">
+                        <div class="card-header">
+                            <h5 class="card-title mb-0">
+                                <i class="fas fa-exchange-alt me-2 text-secondary"></i>Data Import &amp; Export
+                            </h5>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">Download your configuration as JSON or import shared data files. Choose what to include and supply an encryption key for secrets.</p>
+                            <div class="d-grid gap-2 d-md-flex">
+                                <a href="{{ url_for('main.export_data') }}" class="btn btn-outline-secondary">
+                                    <i class="fas fa-download me-1"></i>Export JSON
+                                </a>
+                                <a href="{{ url_for('main.import_data') }}" class="btn btn-secondary">
+                                    <i class="fas fa-file-import me-1"></i>Import JSON
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-footer text-muted">
+                            <small>Secrets are encrypted with your passphrase to keep them safe in transit.</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
                 <div class="col-12">
                     <div class="card">
                         <div class="card-header">

--- a/test_import_export.py
+++ b/test_import_export.py
@@ -1,0 +1,181 @@
+import json
+import unittest
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+from app import create_app, db
+from encryption import SECRET_ENCRYPTION_SCHEME, decrypt_secret_value, encrypt_secret_value
+from models import Alias, Secret, Server, User, Variable
+
+
+class ImportExportRoutesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+            'WTF_CSRF_ENABLED': False,
+        })
+        self.client = self.app.test_client()
+
+        with self.app.app_context():
+            db.create_all()
+            self.user_id = 'user-123'
+            user = User(
+                id=self.user_id,
+                email='user@example.com',
+                first_name='Test',
+                last_name='User',
+            )
+            db.session.add(user)
+            db.session.commit()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def _login_patch(self, mock_current_user):
+        mock_current_user.id = self.user_id
+        mock_current_user.is_authenticated = True
+        return mock_current_user
+
+    @contextmanager
+    def logged_in(self):
+        with ExitStack() as stack:
+            route_user = stack.enter_context(patch('routes.import_export.current_user'))
+            auth_user = stack.enter_context(patch('auth_providers.current_user'))
+            for mock_user in (route_user, auth_user):
+                self._login_patch(mock_user)
+            yield
+
+    def test_export_includes_selected_collections(self):
+        with self.app.app_context():
+            alias = Alias(name='alias-one', target_path='/demo', user_id=self.user_id)
+            server = Server(name='server-one', definition='print("hi")', user_id=self.user_id)
+            variable = Variable(name='var-one', definition='value', user_id=self.user_id)
+            secret = Secret(name='secret-one', definition='super-secret', user_id=self.user_id)
+            db.session.add_all([alias, server, variable, secret])
+            db.session.commit()
+
+        with self.logged_in():
+            response = self.client.post('/export', data={
+                'include_aliases': 'y',
+                'include_servers': 'y',
+                'include_variables': 'y',
+                'include_secrets': 'y',
+                'secret_key': 'passphrase',
+                'submit': True,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.data)
+        self.assertEqual(payload['version'], 1)
+        self.assertIn('generated_at', payload)
+
+        aliases = payload.get('aliases', [])
+        self.assertEqual(len(aliases), 1)
+        self.assertEqual(aliases[0]['name'], 'alias-one')
+
+        servers = payload.get('servers', [])
+        self.assertEqual(servers[0]['definition'], 'print("hi")')
+
+        variables = payload.get('variables', [])
+        self.assertEqual(variables[0]['definition'], 'value')
+
+        secrets_section = payload.get('secrets', {})
+        self.assertEqual(secrets_section.get('encryption'), SECRET_ENCRYPTION_SCHEME)
+        ciphertext = secrets_section['items'][0]['ciphertext']
+        self.assertEqual(decrypt_secret_value(ciphertext, 'passphrase'), 'super-secret')
+
+    def test_import_reports_missing_selected_content(self):
+        payload = json.dumps({'aliases': [{'name': 'alias-a', 'target_path': '/path'}]})
+
+        with self.logged_in():
+            response = self.client.post('/import', data={
+                'import_source': 'text',
+                'import_text': payload,
+                'include_servers': 'y',
+                'submit': True,
+            }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'No server data found in import file.', response.data)
+
+    def test_import_rejects_invalid_secret_key(self):
+        encrypted = encrypt_secret_value('secret', 'correct-key')
+        payload = json.dumps({
+            'secrets': {
+                'encryption': SECRET_ENCRYPTION_SCHEME,
+                'items': [
+                    {
+                        'name': 'secret-one',
+                        'ciphertext': encrypted,
+                    }
+                ],
+            }
+        })
+
+        with self.logged_in():
+            response = self.client.post('/import', data={
+                'import_source': 'text',
+                'import_text': payload,
+                'include_secrets': 'y',
+                'secret_key': 'wrong-key',
+                'submit': True,
+            }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Invalid decryption key for secrets.', response.data)
+
+    def test_successful_import_creates_entries(self):
+        encrypted_secret = encrypt_secret_value('value', 'passphrase')
+        payload = json.dumps({
+            'aliases': [{'name': 'alias-b', 'target_path': '/demo'}],
+            'servers': [{'name': 'server-b', 'definition': 'print("hello")'}],
+            'variables': [{'name': 'var-b', 'definition': '42'}],
+            'secrets': {
+                'encryption': SECRET_ENCRYPTION_SCHEME,
+                'items': [
+                    {'name': 'secret-b', 'ciphertext': encrypted_secret}
+                ],
+            },
+        })
+
+        with self.logged_in():
+            response = self.client.post('/import', data={
+                'import_source': 'text',
+                'import_text': payload,
+                'include_aliases': 'y',
+                'include_servers': 'y',
+                'include_variables': 'y',
+                'include_secrets': 'y',
+                'secret_key': 'passphrase',
+                'submit': True,
+            }, follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Imported 1 alias', response.data)
+        self.assertIn(b'1 server', response.data)
+        self.assertIn(b'1 variable', response.data)
+        self.assertIn(b'1 secret', response.data)
+
+        with self.app.app_context():
+            alias = Alias.query.filter_by(user_id=self.user_id, name='alias-b').first()
+            self.assertIsNotNone(alias)
+            self.assertEqual(alias.target_path, '/demo')
+
+            server = Server.query.filter_by(user_id=self.user_id, name='server-b').first()
+            self.assertIsNotNone(server)
+            self.assertEqual(server.definition, 'print("hello")')
+
+            variable = Variable.query.filter_by(user_id=self.user_id, name='var-b').first()
+            self.assertIsNotNone(variable)
+            self.assertEqual(variable.definition, '42')
+
+            secret = Secret.query.filter_by(user_id=self.user_id, name='secret-b').first()
+            self.assertIsNotNone(secret)
+            self.assertEqual(secret.definition, 'value')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reusable helpers to encrypt and decrypt exported secrets
- implement /export and /import endpoints with form validation, selective content, and JSON handling
- add navigation, templates, and settings entry points for the new data management pages alongside regression tests

## Testing
- ./test


------
https://chatgpt.com/codex/tasks/task_b_68cf2deefc50833183ab47efe94d4ef2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Export your data (aliases, servers, variables, secrets) to a downloadable JSON file.
  - Import data from file, pasted text, or URL with per-category selection.
  - Secrets are encrypted during export and can be decrypted on import using your key.
  - Clear validation and summaries for successful imports and errors.

- UI
  - New “Export” and “Import” options in the navigation.
  - Settings page includes a “Data Import & Export” card with action buttons.
  - Dedicated Export and Import forms with helpful guidance and inline validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->