### PR TITLE
Revamp server invocation history tables

### DIFF
--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -171,83 +171,87 @@
             </div>
             {% endif %}
 
-            {% if server_invocations and server_invocations.total_count and server_invocations.total_count > 0 %}
+            {% if server_invocation_count|default(0) > 0 %}
             <div class="card mt-4">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h5 class="card-title mb-0">
                         <i class="fas fa-terminal me-2"></i>Invocation History
-                        <span class="badge bg-secondary ms-2">{{ server_invocations.total_count }} total</span>
+                        <span class="badge bg-secondary ms-2">{{ server_invocation_count }} total</span>
                     </h5>
                 </div>
                 <div class="card-body">
-                    {% if server_invocations.all_invocations %}
-                        <div class="list-group">
-                            {% for inv in server_invocations.all_invocations %}
-                            <div class="list-group-item d-flex justify-content-between align-items-center">
-                                <div>
-                                    <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                </div>
-                                <div class="btn-group">
-                                    <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                        <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
-                                    </a>
-                                    {% if inv.invocation_cid %}
-                                    <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                        <i class="fas fa-code me-1"></i>Invocation JSON
-                                    </a>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <div class="row">
-                            <div class="col-md-6">
-                                <h6>First 3 Invocations</h6>
-                                <div class="list-group">
-                                    {% for inv in server_invocations.first_invocations %}
-                                    <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                        </div>
-                                        <div class="btn-group">
-                                            <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                                <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Invoked</th>
+                                    <th>Invocation JSON</th>
+                                    <th>Request Details</th>
+                                    <th>Result CID</th>
+                                    <th>Servers CID</th>
+                                    <th>Referer</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for event in server_invocations %}
+                                <tr>
+                                    <td>
+                                        {% if event.invoked_at %}
+                                            {{ event.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.invocation_link %}
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                                <code class="small">{{ event.invocation_label }}</code>
                                             </a>
-                                            {% if inv.invocation_cid %}
-                                            <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                                <i class="fas fa-code me-1"></i>Invocation JSON
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.request_details_link %}
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                                <code class="small">{{ event.request_details_label }}</code>
                                             </a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <h6>Last 3 Invocations</h6>
-                                <div class="list-group">
-                                    {% for inv in server_invocations.last_invocations %}
-                                    <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                        </div>
-                                        <div class="btn-group">
-                                            <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                                <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.result_link %}
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                                <code class="small">{{ event.result_label }}</code>
                                             </a>
-                                            {% if inv.invocation_cid %}
-                                            <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                                <i class="fas fa-code me-1"></i>Invocation JSON
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.servers_cid_link %}
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                                <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-break">
+                                        {% if event.request_referer %}
+                                            <a href="{{ event.request_referer }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ event.request_referer }}
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
             {% endif %}

--- a/templates/server_view.html
+++ b/templates/server_view.html
@@ -145,83 +145,87 @@
             </div>
             {% endif %}
 
-            {% if server_invocations and server_invocations.total_count and server_invocations.total_count > 0 %}
+            {% if server_invocation_count|default(0) > 0 %}
             <div class="card mt-4">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h5 class="card-title mb-0">
                         <i class="fas fa-terminal me-2"></i>Invocation History
-                        <span class="badge bg-secondary ms-2">{{ server_invocations.total_count }} total</span>
+                        <span class="badge bg-secondary ms-2">{{ server_invocation_count }} total</span>
                     </h5>
                 </div>
                 <div class="card-body">
-                    {% if server_invocations.all_invocations %}
-                        <div class="list-group">
-                            {% for inv in server_invocations.all_invocations %}
-                            <div class="list-group-item d-flex justify-content-between align-items-center">
-                                <div>
-                                    <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                </div>
-                                <div class="btn-group">
-                                    <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                        <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
-                                    </a>
-                                    {% if inv.invocation_cid %}
-                                    <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                        <i class="fas fa-code me-1"></i>Invocation JSON
-                                    </a>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            {% endfor %}
-                        </div>
-                    {% else %}
-                        <div class="row">
-                            <div class="col-md-6">
-                                <h6>First 3 Invocations</h6>
-                                <div class="list-group">
-                                    {% for inv in server_invocations.first_invocations %}
-                                    <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                        </div>
-                                        <div class="btn-group">
-                                            <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                                <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Invoked</th>
+                                    <th>Invocation JSON</th>
+                                    <th>Request Details</th>
+                                    <th>Result CID</th>
+                                    <th>Servers CID</th>
+                                    <th>Referer</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for event in server_invocations %}
+                                <tr>
+                                    <td>
+                                        {% if event.invoked_at %}
+                                            {{ event.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                                        {% else %}
+                                            -
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.invocation_link %}
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                                <code class="small">{{ event.invocation_label }}</code>
                                             </a>
-                                            {% if inv.invocation_cid %}
-                                            <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                                <i class="fas fa-code me-1"></i>Invocation JSON
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.request_details_link %}
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                                <code class="small">{{ event.request_details_label }}</code>
                                             </a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <h6>Last 3 Invocations</h6>
-                                <div class="list-group">
-                                    {% for inv in server_invocations.last_invocations %}
-                                    <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <strong>{{ inv.invoked_at.strftime('%Y-%m-%d %H:%M:%S') }}</strong>
-                                        </div>
-                                        <div class="btn-group">
-                                            <a href="/{{ inv.result_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
-                                                <i class="fas fa-external-link-alt me-1"></i>{{ inv.result_cid }}.txt
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.result_link %}
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                                <code class="small">{{ event.result_label }}</code>
                                             </a>
-                                            {% if inv.invocation_cid %}
-                                            <a href="/{{ inv.invocation_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm">
-                                                <i class="fas fa-code me-1"></i>Invocation JSON
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if event.servers_cid_link %}
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                                <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td class="text-break">
+                                        {% if event.request_referer %}
+                                            <a href="{{ event.request_referer }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ event.request_referer }}
+                                            </a>
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
             {% endif %}


### PR DESCRIPTION
## Summary
- replace the server detail invocation widget with the same tabular presentation used on the global server events page
- add a shared helper that decorates per-server invocations with the link metadata used by the table view
- update the server edit form to share the new table and add coverage that ensures the page renders the expected links without the server column

## Testing
- pytest test_routes_comprehensive.py::TestServerRoutes -q

------
https://chatgpt.com/codex/tasks/task_b_68cf541689e483319d1261ce7fd1d55b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reworked “Invocation History” into a single, responsive table for clearer viewing.
  * Added direct links and labels for Invocation JSON, Request Details, Result CID, Servers CID, and Referer.
  * Displayed a visible total invocation count badge.

* **Refactor**
  * Updated server pages to use a more complete invocation history source, improving ordering, details, and consistency.

* **Tests**
  * Added tests to verify the new table layout, link presence, referer display, and total count rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->