### PR TITLE
Add CID editing route with templates and tests

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from database import db
 from models import (
@@ -162,6 +162,24 @@ def create_server_invocation(
 
 def get_cid_by_path(path: str) -> Optional[CID]:
     return CID.query.filter_by(path=path).first()
+
+
+def find_cids_by_prefix(prefix: str) -> List[CID]:
+    """Return CID records whose path matches the given CID prefix."""
+    if not prefix:
+        return []
+
+    normalized = prefix.split('.')[0].lstrip('/')
+    if not normalized:
+        return []
+
+    pattern = f"/{normalized}%"
+    return (
+        CID.query
+        .filter(CID.path.like(pattern))
+        .order_by(CID.path.asc())
+        .all()
+    )
 
 
 def create_cid_record(cid: str, file_content: bytes, user_id: str) -> CID:

--- a/forms.py
+++ b/forms.py
@@ -55,6 +55,15 @@ class FileUploadForm(FlaskForm):
 
         return True
 
+
+class EditCidForm(FlaskForm):
+    text_content = TextAreaField(
+        'CID Content',
+        validators=[DataRequired()],
+        render_kw={'rows': 15, 'placeholder': 'Update the CID content here...'},
+    )
+    submit = SubmitField('Save Changes')
+
 class InvitationForm(FlaskForm):
     email = StringField('Email (optional)', validators=[Optional()])
     submit = SubmitField('Create Invitation')

--- a/routes/core.py
+++ b/routes/core.py
@@ -310,6 +310,7 @@ def get_existing_routes():
         '/plans', '/terms', '/privacy', '/upload', '/invitations', '/create-invitation',
         '/require-invitation', '/uploads', '/history', '/servers', '/variables',
         '/secrets', '/settings', '/aliases', '/aliases/new',
+        '/edit',
         '/export', '/import',
     }
 

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block title %}Edit CID{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">
+                        <i class="fas fa-edit me-2"></i>Edit CID Content
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">
+                        You are editing the content stored for CID:
+                        <span class="font-monospace">{{ cid }}</span>
+                    </p>
+                    <form method="POST">
+                        {{ form.hidden_tag() }}
+                        <div class="mb-3">
+                            {{ form.text_content.label(class="form-label") }}
+                            {{ form.text_content(class="form-control font-monospace") }}
+                            {% if form.text_content.errors %}
+                                <div class="text-danger mt-1">
+                                    {% for error in form.text_content.errors %}
+                                        <small>{{ error }}</small>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                            <small class="form-text text-muted">
+                                Update the text below and click "Save Changes" to store the edited content as a new CID entry.
+                            </small>
+                        </div>
+                        <div class="d-flex gap-2">
+                            {{ form.submit(class="btn btn-primary") }}
+                            <a href="/{{ cid }}" class="btn btn-outline-secondary" target="_blank">
+                                <i class="fas fa-external-link-alt me-1"></i>View Original
+                            </a>
+                        </div>
+                    </form>
+                </div>
+                <div class="card-footer">
+                    <small class="text-muted">
+                        <i class="fas fa-info-circle me-1"></i>
+                        Saving changes will create a new CID using the edited content, just like uploading text through the upload page.
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/edit_cid_choices.html
+++ b/templates/edit_cid_choices.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block title %}Select CID to Edit{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">
+                        <i class="fas fa-search me-2"></i>Multiple Matches Found
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">
+                        More than one CID matches the prefix
+                        <span class="font-monospace">{{ cid_prefix }}</span>.
+                        Select the CID you want to edit.
+                    </p>
+                    <ul class="list-group">
+                        {% for match in matches %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <span class="font-monospace">{{ match }}</span>
+                            <a class="btn btn-outline-primary btn-sm" href="{{ url_for('main.edit_cid', cid_prefix=match) }}">
+                                <i class="fas fa-edit me-1"></i>Edit
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                <div class="card-footer">
+                    <a href="{{ url_for('main.uploads') }}" class="btn btn-outline-secondary btn-sm">
+                        <i class="fas fa-arrow-left me-1"></i>Back to Uploads
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add an edit form and database helper for looking up CID prefixes
- implement an authenticated `/edit/<cid>` flow with templates for editing or resolving ambiguous matches
- cover the new behaviour with route tests for matching, saving, and duplicate handling

## Testing
- pytest test_routes_comprehensive.py::TestCidEditingRoutes

------
https://chatgpt.com/codex/tasks/task_b_68cf60e2637c8331ac7576fe7a45db6b