### PR TITLE
Refactor server execution helpers

### DIFF
--- a/test_server_execution_output_encoding.py
+++ b/test_server_execution_output_encoding.py
@@ -42,22 +42,22 @@ mock_runner = types.ModuleType("text_function_runner")
 mock_runner.run_text_function = lambda code, args: {"output": "", "content_type": "text/html"}
 sys.modules.setdefault("text_function_runner", mock_runner)
 
-# Import the function under test after setting up mocks
-from server_execution import _encode_output  # noqa: E402
+# Import the module under test after setting up mocks
+import server_execution  # noqa: E402
 
 
 class TestServerExecutionOutputEncoding(unittest.TestCase):
     def test_encode_bytes_passthrough(self):
         data = b"hello"
-        self.assertEqual(_encode_output(data), data)
+        self.assertEqual(server_execution._encode_output(data), data)
 
     def test_encode_str_to_utf8(self):
         s = "hello"
-        self.assertEqual(_encode_output(s), b"hello")
+        self.assertEqual(server_execution._encode_output(s), b"hello")
 
     def test_encode_list_of_ints_to_bytes(self):
         data = [104, 101, 108, 108, 111]  # 'hello'
-        self.assertEqual(_encode_output(data), b"hello")
+        self.assertEqual(server_execution._encode_output(data), b"hello")
 
     def test_encode_list_of_strings_join_then_utf8(self):
         # This represents a realistic server output where pieces of text are built as a list
@@ -66,7 +66,89 @@ class TestServerExecutionOutputEncoding(unittest.TestCase):
         expected = b"hello world"
         # This currently raises TypeError: 'str' object cannot be interpreted as an integer
         # Reproduces the bug in _encode_output
-        self.assertEqual(_encode_output(parts), expected)
+        self.assertEqual(server_execution._encode_output(parts), expected)
+
+
+class TestExecuteServerCodeSharedFlow(unittest.TestCase):
+    def setUp(self):
+        self.original_run_text_function = server_execution.run_text_function
+        self.original_build_request_args = server_execution.build_request_args
+        self.original_create_invocation = server_execution.create_server_invocation_record
+        self.original_make_response = server_execution.make_response
+        self.original_redirect = server_execution.redirect
+        self.original_create_cid_record = server_execution.create_cid_record
+        self.original_get_cid_by_path = server_execution.get_cid_by_path
+        self.original_generate_cid = server_execution.generate_cid
+        self.original_get_extension = server_execution.get_extension_from_mime_type
+        self.original_current_user = server_execution.current_user
+        server_execution.current_user = types.SimpleNamespace(
+            is_authenticated=True, id="user-123"
+        )
+        server_execution.build_request_args = lambda: {
+            "request": {"path": "/mock"},
+            "context": {"variables": {}, "secrets": {}, "servers": {}},
+        }
+        server_execution.create_server_invocation_record = lambda *a, **k: None
+        server_execution.create_cid_record = lambda *a, **k: None
+        server_execution.get_cid_by_path = lambda *a, **k: None
+        server_execution.generate_cid = lambda b: "deadbeef"
+        server_execution.get_extension_from_mime_type = (
+            lambda ct: "html" if ct == "text/html" else ""
+        )
+        server_execution.make_response = lambda text: types.SimpleNamespace(
+            headers={}, status_code=200, data=text
+        )
+        server_execution.redirect = lambda url: ("redirect", url)
+
+    def tearDown(self):
+        server_execution.run_text_function = self.original_run_text_function
+        server_execution.build_request_args = self.original_build_request_args
+        server_execution.create_server_invocation_record = self.original_create_invocation
+        server_execution.make_response = self.original_make_response
+        server_execution.redirect = self.original_redirect
+        server_execution.create_cid_record = self.original_create_cid_record
+        server_execution.get_cid_by_path = self.original_get_cid_by_path
+        server_execution.generate_cid = self.original_generate_cid
+        server_execution.get_extension_from_mime_type = self.original_get_extension
+        server_execution.current_user = self.original_current_user
+
+    def test_execute_functions_share_success_flow(self):
+        calls = []
+
+        def fake_runner(code, args):
+            calls.append((code, args))
+            return {"output": "hello", "content_type": "text/plain"}
+
+        server_execution.run_text_function = fake_runner
+
+        server = types.SimpleNamespace(definition="print('hello')")
+
+        first_result = server_execution.execute_server_code(server, "greet")
+        second_result = server_execution.execute_server_code_from_definition("print('hello')", "greet")
+
+        self.assertEqual(first_result, ("redirect", "/deadbeef"))
+        self.assertEqual(second_result, first_result)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], server.definition)
+        self.assertEqual(calls[1][0], "print('hello')")
+        self.assertEqual(calls[0][1], calls[1][1])
+
+    def test_execute_functions_share_error_flow(self):
+        def failing_runner(code, args):
+            raise ValueError("boom")
+
+        server_execution.run_text_function = failing_runner
+
+        server = types.SimpleNamespace(definition="print('fail')")
+
+        first_response = server_execution.execute_server_code(server, "fail")
+        second_response = server_execution.execute_server_code_from_definition("print('fail')", "fail")
+
+        self.assertEqual(first_response.status_code, 500)
+        self.assertEqual(second_response.status_code, 500)
+        self.assertEqual(first_response.headers["Content-Type"], "text/plain")
+        self.assertEqual(second_response.headers["Content-Type"], "text/plain")
+        self.assertEqual(first_response.data, second_response.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extract common server execution flow into shared helpers to reduce duplication
- add tests that exercise execute_server_code and execute_server_code_from_definition across success and error paths

## Testing
- `pytest test_server_execution_output_encoding.py`
- `./test`


------
https://chatgpt.com/codex/tasks/task_b_68d1f3ef7aac8331a016a87365f06dc9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More consistent redirects and error responses during server code execution.
- Refactor
  - Unified the execution flow to improve reliability and consistency without changing expected outcomes.
- Bug Fixes
  - Improved resilience of logging and error handling to avoid disruptions if logging fails.
- Tests
  - Expanded coverage to validate shared execution paths for success and error scenarios, ensuring both entry points behave identically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->