### PR TITLE
Add save helper to text function runner

### DIFF
--- a/text_function_runner.py
+++ b/text_function_runner.py
@@ -3,6 +3,50 @@ import hashlib
 import textwrap
 from typing import Dict
 
+from cid_utils import store_cid_from_bytes
+from flask_login import current_user
+
+
+def _coerce_to_bytes(value) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+def _get_current_user_id():
+    try:
+        user = current_user
+    except Exception:
+        return None
+
+    user_id = getattr(user, "id", None)
+    if callable(user_id):
+        try:
+            user_id = user_id()
+        except TypeError:
+            user_id = None
+
+    if not user_id:
+        getter = getattr(user, "get_id", None)
+        if callable(getter):
+            user_id = getter()
+
+    if user_id is None:
+        return None
+
+    return str(user_id)
+
+
+def _save_content(value):
+    user_id = _get_current_user_id()
+    if not user_id:
+        raise RuntimeError("save() requires an authenticated user with an id")
+
+    content = _coerce_to_bytes(value)
+    return store_cid_from_bytes(content, user_id)
+
 def run_text_function(
     body_text: str,
     arg_map: Dict[str, object],
@@ -32,8 +76,8 @@ def run_text_function(
     # Compose the source
     src = f"def {fn_name}({', '.join(param_names)}):\n{textwrap.indent(body_text, '    ')}"
 
-    # Global namespace with all builtins available
-    ns = {"__builtins__": builtins}
+    # Global namespace with all builtins available plus helper utilities
+    ns = {"__builtins__": builtins, "save": _save_content}
 
     # Define and run
     exec(src, ns, ns)  # defines ns[fn_name]


### PR DESCRIPTION
## Summary
- provide a save helper in the text function runner that stores bytes via `store_cid_from_bytes`
- expose the helper to executed server definitions so they can persist content
- add a unit test verifying that `save` stores the expected bytes for the current user

## Testing
- pytest test_text_function_runner.py
- pytest test_server_execution_output_encoding.py

------
https://chatgpt.com/codex/tasks/task_b_68d1fcad336883319a2cc17032c1fa6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enable content persistence from custom text functions during execution.
  - Saved content is tied to the signed-in user and requires authentication.
  - Accepts text or binary content; conversion is handled automatically.
  - Accessible within the function execution environment alongside existing helpers.
- Tests
  - Added tests confirming saved content is stored and associated with the active user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->