### PR TITLE
Add git-tracked source browser routes

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -12,5 +12,6 @@ from . import secrets  # noqa: F401,E402
 from . import history  # noqa: F401,E402
 from . import aliases  # noqa: F401,E402
 from . import import_export  # noqa: F401,E402
+from . import source  # noqa: F401,E402
 
 __all__ = ["main_bp"]

--- a/routes/source.py
+++ b/routes/source.py
@@ -1,0 +1,143 @@
+"""Routes for browsing repository source files."""
+from __future__ import annotations
+
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from flask import abort, current_app, render_template, send_file
+
+from . import main_bp
+
+
+@lru_cache(maxsize=4)
+def _get_tracked_paths(root_path: str) -> frozenset[str]:
+    """Return the git-tracked file paths relative to the repository root."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return frozenset()
+
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return frozenset(files)
+
+
+def _build_breadcrumbs(path: str) -> List[Tuple[str, str]]:
+    """Create breadcrumbs for the requested path."""
+    breadcrumbs: List[Tuple[str, str]] = [("", "Source")]
+    if not path:
+        return breadcrumbs
+
+    parts = path.split("/")
+    for index in range(len(parts)):
+        crumb_path = "/".join(parts[: index + 1])
+        breadcrumbs.append((crumb_path, parts[index]))
+    return breadcrumbs
+
+
+def _directory_listing(path: str, tracked_paths: Iterable[str]) -> Tuple[List[str], List[str]]:
+    """Return immediate subdirectories and files for a directory path."""
+    prefix = f"{path}/" if path else ""
+    directories: set[str] = set()
+    files: List[str] = []
+
+    for tracked in tracked_paths:
+        if prefix and not tracked.startswith(prefix):
+            continue
+
+        remainder = tracked[len(prefix) :] if prefix else tracked
+        if not remainder:
+            continue
+
+        if "/" in remainder:
+            directories.add(remainder.split("/", 1)[0])
+        else:
+            files.append(remainder)
+
+    return sorted(directories), sorted(files)
+
+
+def _render_directory(path: str, tracked_paths: frozenset[str]):
+    """Render the directory listing template."""
+    directories, files = _directory_listing(path, tracked_paths)
+    breadcrumbs = _build_breadcrumbs(path)
+
+    return render_template(
+        "source_browser.html",
+        breadcrumbs=breadcrumbs,
+        current_path=path,
+        directories=directories,
+        files=files,
+        file_content=None,
+        is_file=False,
+        path_prefix=f"{path}/" if path else "",
+    )
+
+
+def _render_file(path: str, root_path: Path):
+    """Render a file from the repository, falling back to download for binary data."""
+    repository_root = root_path.resolve()
+    file_path = (repository_root / path).resolve()
+
+    if not file_path.is_file() or repository_root not in file_path.parents:
+        abort(404)
+
+    try:
+        file_content = file_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return send_file(file_path)
+
+    breadcrumbs = _build_breadcrumbs(path)
+
+    return render_template(
+        "source_browser.html",
+        breadcrumbs=breadcrumbs,
+        current_path=path,
+        directories=[],
+        files=[],
+        file_content=file_content,
+        is_file=True,
+        path_prefix=f"{path}/" if path else "",
+    )
+
+
+def _is_tracked_directory(path: str, tracked_paths: frozenset[str]) -> bool:
+    """Determine if the requested path corresponds to a tracked directory."""
+    prefix = f"{path}/"
+    return any(tracked.startswith(prefix) for tracked in tracked_paths)
+
+
+@main_bp.route("/source", defaults={"requested_path": ""}, strict_slashes=False)
+@main_bp.route("/source/<path:requested_path>")
+def source_browser(requested_path: str):
+    """Browse repository source files tracked by git."""
+    tracked_paths = _get_tracked_paths(current_app.root_path)
+    if not tracked_paths:
+        # When git is unavailable or no files are tracked, show an empty view.
+        return _render_directory("", tracked_paths)
+
+    normalized = requested_path.strip("/")
+    if not normalized:
+        return _render_directory("", tracked_paths)
+
+    safe_path = Path(normalized)
+    if safe_path.is_absolute() or ".." in safe_path.parts:
+        abort(404)
+
+    relative_path = safe_path.as_posix()
+    repository_root = Path(current_app.root_path)
+
+    if relative_path in tracked_paths:
+        return _render_file(relative_path, repository_root)
+
+    if _is_tracked_directory(relative_path, tracked_paths):
+        return _render_directory(relative_path, tracked_paths)
+
+    abort(404)

--- a/templates/source_browser.html
+++ b/templates/source_browser.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Source Browser{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="mb-0"><i class="fas fa-code me-2"></i>Source Browser</h2>
+    </div>
+
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            {% for crumb_path, crumb_label in breadcrumbs %}
+                {% if loop.last %}
+                    <li class="breadcrumb-item active" aria-current="page">{{ crumb_label }}</li>
+                {% else %}
+                    {% if crumb_path %}
+                        <li class="breadcrumb-item"><a href="{{ url_for('main.source_browser', requested_path=crumb_path) }}">{{ crumb_label }}</a></li>
+                    {% else %}
+                        <li class="breadcrumb-item"><a href="{{ url_for('main.source_browser') }}">{{ crumb_label }}</a></li>
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        </ol>
+    </nav>
+
+    {% if file_content is not none %}
+        <div class="card">
+            <div class="card-header bg-light">
+                <strong>{{ current_path }}</strong>
+            </div>
+            <div class="card-body">
+                <pre class="mb-0"><code>{{ file_content | e }}</code></pre>
+            </div>
+        </div>
+    {% else %}
+        <div class="card">
+            <div class="card-body">
+                {% if directories %}
+                    <h5>Directories</h5>
+                    <ul class="list-unstyled mb-4">
+                        {% for directory in directories %}
+                            <li>
+                                <i class="fas fa-folder me-2 text-warning"></i>
+                                <a href="{{ url_for('main.source_browser', requested_path=path_prefix + directory) }}">{{ directory }}/</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+
+                {% if files %}
+                    <h5>Files</h5>
+                    <ul class="list-unstyled mb-0">
+                        {% for file in files %}
+                            <li>
+                                <i class="fas fa-file-code me-2 text-primary"></i>
+                                <a href="{{ url_for('main.source_browser', requested_path=path_prefix + file) }}">{{ file }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+
+                {% if not directories and not files %}
+                    <p class="text-muted mb-0">No tracked files in this directory.</p>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a `/source` browser that only exposes git-tracked files and directories
- render tracked file listings and file contents via a dedicated template
- cover the new behavior with comprehensive route tests

## Testing
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68d429ef29c483318d98c76b5a7802e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Source Browser accessible at /source to navigate project files and directories.
  * Breadcrumb navigation for easy path tracking.
  * View file contents directly in the app; binary files are offered for download.
  * Secure handling of paths with 404 responses for invalid or untracked items.

* **Tests**
  * Added comprehensive tests covering directory listing, file viewing, and rejection of untracked files and path traversal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->