### PR TITLE
Expand meta route diagnostics coverage

### DIFF
--- a/test_analytics.py
+++ b/test_analytics.py
@@ -1,0 +1,189 @@
+import os
+import unittest
+from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SESSION_SECRET", "test-secret-key")
+
+from flask import session
+
+from app import app, db
+from analytics import (
+    create_page_view_record,
+    get_paginated_page_views,
+    get_user_history_statistics,
+    make_session_permanent,
+    should_track_page_view,
+    track_page_view,
+)
+from models import PageView, User
+
+
+class TestAnalytics(unittest.TestCase):
+    """Exercise analytics helpers against an in-memory database."""
+
+    def setUp(self):
+        app.config.update(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+            WTF_CSRF_ENABLED=False,
+        )
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.user = User(
+            id="analytics-user",
+            email="analytics@example.com",
+            is_paid=True,
+            current_terms_accepted=True,
+        )
+        db.session.add(self.user)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_make_session_permanent_marks_session(self):
+        with app.test_request_context("/"):
+            session.permanent = False
+            make_session_permanent()
+            self.assertTrue(session.permanent)
+
+    def test_should_track_page_view_requires_authenticated_user(self):
+        with app.test_request_context("/dashboard"):
+            response = app.response_class(status=200)
+            with patch("analytics.current_user", new=SimpleNamespace(is_authenticated=False)):
+                self.assertFalse(should_track_page_view(response))
+
+    def test_should_track_page_view_requires_success_status(self):
+        with app.test_request_context("/dashboard"):
+            response = app.response_class(status=404)
+            with patch("analytics.current_user", new=SimpleNamespace(is_authenticated=True)):
+                self.assertFalse(should_track_page_view(response))
+
+    def test_should_track_page_view_skips_static_and_ajax_requests(self):
+        with app.test_request_context("/static/logo.png"):
+            response = app.response_class(status=200)
+            with patch("analytics.current_user", new=SimpleNamespace(is_authenticated=True)):
+                self.assertFalse(should_track_page_view(response))
+
+        with app.test_request_context(
+            "/dashboard",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        ):
+            response = app.response_class(status=200)
+            with patch("analytics.current_user", new=SimpleNamespace(is_authenticated=True)):
+                self.assertFalse(should_track_page_view(response))
+
+    def test_should_track_page_view_accepts_standard_requests(self):
+        with app.test_request_context(
+            "/history",
+            headers={"User-Agent": "Browser", "X-Requested-With": ""},
+        ):
+            response = app.response_class(status=200)
+            with patch(
+                "analytics.current_user",
+                new=SimpleNamespace(is_authenticated=True),
+            ):
+                self.assertTrue(should_track_page_view(response))
+
+    def test_track_page_view_persists_record(self):
+        long_user_agent = "Agent" * 200  # exceeds 500 characters when repeated
+        environ_overrides = {"REMOTE_ADDR": "203.0.113.10"}
+        with app.test_request_context(
+            "/servers",
+            headers={"User-Agent": long_user_agent},
+            environ_overrides=environ_overrides,
+        ):
+            response = app.response_class(status=200)
+            with patch(
+                "analytics.current_user",
+                new=SimpleNamespace(is_authenticated=True, id=self.user.id),
+            ):
+                result = track_page_view(response)
+
+        self.assertIs(result, response)
+        stored = PageView.query.filter_by(user_id=self.user.id).one()
+        self.assertEqual(stored.path, "/servers")
+        self.assertEqual(stored.method, "GET")
+        self.assertEqual(stored.user_agent, long_user_agent[:500])
+        self.assertEqual(stored.ip_address, "203.0.113.10")
+
+    def test_track_page_view_rolls_back_on_error(self):
+        with app.test_request_context("/servers"):
+            response = app.response_class(status=200)
+            with patch(
+                "analytics.current_user",
+                new=SimpleNamespace(is_authenticated=True, id=self.user.id),
+            ), patch("analytics.should_track_page_view", return_value=True), patch(
+                "analytics.create_page_view_record",
+                side_effect=RuntimeError("boom"),
+            ), patch.object(db.session, "rollback") as rollback:
+                result = track_page_view(response)
+
+        self.assertIs(result, response)
+        rollback.assert_called_once()
+        self.assertEqual(PageView.query.count(), 0)
+
+    def test_create_page_view_record_reflects_request_details(self):
+        with app.test_request_context(
+            "/notes",
+            method="POST",
+            headers={"User-Agent": "AgentX"},
+            environ_overrides={"REMOTE_ADDR": "198.51.100.1"},
+        ):
+            with patch(
+                "analytics.current_user",
+                new=SimpleNamespace(id=self.user.id),
+            ):
+                record = create_page_view_record()
+
+        self.assertEqual(record.user_id, self.user.id)
+        self.assertEqual(record.path, "/notes")
+        self.assertEqual(record.method, "POST")
+        self.assertEqual(record.user_agent, "AgentX")
+        self.assertEqual(record.ip_address, "198.51.100.1")
+
+    def test_get_user_history_statistics(self):
+        now = datetime.now(timezone.utc)
+        views = [
+            PageView(user_id=self.user.id, path="/a", viewed_at=now),
+            PageView(user_id=self.user.id, path="/a", viewed_at=now + timedelta(minutes=1)),
+            PageView(user_id=self.user.id, path="/b", viewed_at=now + timedelta(minutes=2)),
+            PageView(user_id="other", path="/a", viewed_at=now + timedelta(minutes=3)),
+        ]
+        db.session.add_all(views)
+        db.session.commit()
+
+        stats = get_user_history_statistics(self.user.id)
+        self.assertEqual(stats["total_views"], 3)
+        self.assertEqual(stats["unique_paths"], 2)
+        self.assertEqual(stats["popular_paths"][0].path, "/a")
+        self.assertEqual(stats["popular_paths"][0].count, 2)
+
+    def test_get_paginated_page_views_orders_recent_first(self):
+        base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        for offset, path in enumerate(["/first", "/second", "/third"], start=1):
+            db.session.add(
+                PageView(
+                    user_id=self.user.id,
+                    path=path,
+                    viewed_at=base_time + timedelta(hours=offset),
+                )
+            )
+        db.session.commit()
+
+        page = get_paginated_page_views(self.user.id, page=1, per_page=2)
+        self.assertEqual(page.total, 3)
+        self.assertEqual(len(page.items), 2)
+        self.assertEqual([item.path for item in page.items], ["/third", "/second"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_db_access.py
+++ b/test_db_access.py
@@ -109,8 +109,8 @@ class TestDBAccess(unittest.TestCase):
         self.assertEqual([cid.path for cid in dotted_matches], ['/alpha.one', '/alpha.two'])
 
     def test_get_user_uploads_returns_latest_first(self):
-        first = create_cid_record('first', b'1', self.user.id)
-        second = create_cid_record('second', b'2', self.user.id)
+        create_cid_record('first', b'1', self.user.id)
+        create_cid_record('second', b'2', self.user.id)
 
         uploads = get_user_uploads(self.user.id)
         self.assertEqual([cid.path for cid in uploads], ['/second', '/first'])

--- a/test_db_access.py
+++ b/test_db_access.py
@@ -21,6 +21,8 @@ from db_access import (
     create_server_invocation,
     create_cid_record,
     get_cid_by_path,
+    find_cids_by_prefix,
+    get_user_uploads,
 )
 
 
@@ -89,6 +91,30 @@ class TestDBAccess(unittest.TestCase):
         self.assertIsNotNone(get_cid_by_path('/cid1'))
         invocation = create_server_invocation(self.user.id, 'srv', 'cid1')
         self.assertIsNotNone(invocation.id)
+
+    def test_find_cids_by_prefix_filters_and_orders_matches(self):
+        # Prefix queries should ignore empty input and leading punctuation
+        self.assertEqual(find_cids_by_prefix(''), [])
+        self.assertEqual(find_cids_by_prefix('/'), [])
+
+        create_cid_record('alpha.one', b'a', self.user.id)
+        create_cid_record('alpha.two', b'b', self.user.id)
+        create_cid_record('beta.one', b'c', self.user.id)
+
+        matches = find_cids_by_prefix('alpha')
+        self.assertEqual([cid.path for cid in matches], ['/alpha.one', '/alpha.two'])
+
+        # Prefix lookups should stop at the dot separator when present
+        dotted_matches = find_cids_by_prefix('alpha.extra')
+        self.assertEqual([cid.path for cid in dotted_matches], ['/alpha.one', '/alpha.two'])
+
+    def test_get_user_uploads_returns_latest_first(self):
+        first = create_cid_record('first', b'1', self.user.id)
+        second = create_cid_record('second', b'2', self.user.id)
+
+        uploads = get_user_uploads(self.user.id)
+        self.assertEqual([cid.path for cid in uploads], ['/second', '/first'])
+        self.assertEqual(uploads[0].file_size, len(b'2'))
 
 
 if __name__ == '__main__':

--- a/test_encryption.py
+++ b/test_encryption.py
@@ -1,0 +1,58 @@
+"""Coverage-oriented tests for the encryption helpers."""
+import base64
+from hashlib import sha256
+from hmac import new as hmac_new
+
+import pytest
+
+from encryption import (
+    _derive_keystream,
+    decrypt_secret_value,
+    encrypt_secret_value,
+)
+
+
+def test_encrypt_handles_empty_plaintext_roundtrip():
+    token = encrypt_secret_value("", "key")
+    assert isinstance(token, str)
+    assert decrypt_secret_value(token, "key") == ""
+
+
+def test_encrypt_requires_non_empty_key():
+    with pytest.raises(ValueError):
+        encrypt_secret_value("secret", "")
+
+
+def test_decrypt_requires_non_empty_key():
+    token = encrypt_secret_value("secret", "key")
+    with pytest.raises(ValueError):
+        decrypt_secret_value(token, "")
+
+
+def test_decrypt_rejects_incorrect_key():
+    token = encrypt_secret_value("secret", "correct")
+    with pytest.raises(ValueError):
+        decrypt_secret_value(token, "incorrect")
+
+
+def test_decrypt_surfaces_invalid_payload_encoding():
+    key = "encoding-key"
+    key_material = sha256(key.encode("utf-8")).digest()
+    iv = bytes(range(16))
+
+    # Choose plaintext bytes that are not valid UTF-8 so the decode step fails
+    plaintext_bytes = b"\xff"
+    keystream = _derive_keystream(key_material, iv, len(plaintext_bytes))
+    ciphertext = bytes(a ^ b for a, b in zip(plaintext_bytes, keystream))
+    mac = hmac_new(key_material, iv + ciphertext, sha256).digest()
+
+    payload = iv + ciphertext + mac
+    token = base64.urlsafe_b64encode(payload).decode("utf-8")
+
+    with pytest.raises(ValueError):
+        decrypt_secret_value(token, key)
+
+
+def test_decrypt_rejects_truncated_payload():
+    with pytest.raises(ValueError):
+        decrypt_secret_value(base64.urlsafe_b64encode(b"short").decode("utf-8"), "key")

--- a/test_meta_route.py
+++ b/test_meta_route.py
@@ -1,8 +1,11 @@
 import json
 import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
 
 from app import app, db
-from models import CID, ServerInvocation, User
+from models import Alias, CID, Server, ServerInvocation, User
+from werkzeug.routing import RequestRedirect
 
 
 class TestMetaRoute(unittest.TestCase):
@@ -49,6 +52,23 @@ class TestMetaRoute(unittest.TestCase):
         db.session.add(record)
         db.session.commit()
         return record
+
+    def _create_alias(self, user: User, name: str = 'docs', target: str = '/docs'):
+        alias = Alias(name=name, target_path=target, user_id=user.id)
+        db.session.add(alias)
+        db.session.commit()
+        return alias
+
+    def _create_server(self, user: User, name: str = 'demo-server', definition: str = 'print("hi")'):
+        server = Server(name=name, definition=definition, user_id=user.id)
+        db.session.add(server)
+        db.session.commit()
+        return server
+
+    def _login(self, user: User):
+        with self.client.session_transaction() as session:
+            session['_user_id'] = user.id
+            session['_fresh'] = True
 
     def test_meta_route_reports_route_information(self):
         with self.app.app_context():
@@ -131,6 +151,158 @@ class TestMetaRoute(unittest.TestCase):
             body = response.data.decode('utf-8')
             self.assertIn('<a href="/settings"><code>/settings</code></a>', body)
             self.assertIn('<a href="/source/templates/settings.html"><code>/source/templates/settings.html</code></a>', body)
+
+    def test_meta_route_reports_alias_redirect_metadata(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._create_alias(user, name='shortcut', target='/servers#overview')
+            self._login(user)
+
+            response = self.client.get('/meta/shortcut?source=meta')
+            self.assertEqual(response.status_code, 200)
+
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 302)
+            self.assertEqual(data['resolution']['type'], 'alias_redirect')
+            self.assertEqual(data['resolution']['alias'], 'shortcut')
+            self.assertTrue(data['resolution']['available'])
+            self.assertEqual(data['resolution']['target_path'], '/servers#overview')
+            self.assertIn('source=meta', data['resolution']['redirect_location'])
+            self.assertIn('/source/alias_routing.py', data['source_links'])
+
+    def test_meta_route_reports_server_execution_requirements(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._create_server(user, name='process-data')
+            self._login(user)
+
+            response = self.client.get('/meta/process-data')
+            self.assertEqual(response.status_code, 200)
+
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 302)
+            self.assertEqual(data['resolution']['type'], 'server_execution')
+            self.assertEqual(data['resolution']['server_name'], 'process-data')
+            self.assertTrue(data['resolution']['available'])
+            self.assertTrue(data['resolution']['requires_authentication'])
+
+    def test_meta_route_handles_versioned_server_without_match(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._create_server(user, name='reporting')
+            self._login(user)
+
+            with patch('routes.servers.get_server_definition_history', return_value=[]):
+                response = self.client.get('/meta/reporting/unknown')
+
+            self.assertEqual(response.status_code, 404)
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 404)
+            self.assertFalse(data['resolution']['available'])
+            self.assertEqual(data['resolution']['matches'], [])
+
+    def test_meta_route_handles_versioned_server_multiple_matches(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._create_server(user, name='analytics')
+            self._login(user)
+
+            history = [
+                {
+                    'definition_cid': 'abc123',
+                    'snapshot_cid': 'snap-1',
+                    'created_at': datetime(2024, 1, 5, tzinfo=timezone.utc),
+                },
+                {
+                    'definition_cid': 'abc999',
+                    'snapshot_cid': 'snap-2',
+                    'created_at': None,
+                },
+            ]
+
+            with patch('routes.servers.get_server_definition_history', return_value=history):
+                response = self.client.get('/meta/analytics/abc')
+
+            self.assertEqual(response.status_code, 400)
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 400)
+            self.assertFalse(data['resolution']['available'])
+            matches = data['resolution']['matches']
+            self.assertEqual(len(matches), 2)
+            self.assertEqual(matches[0]['definition_cid'], 'abc123')
+            self.assertEqual(matches[0]['snapshot_cid'], 'snap-1')
+            self.assertIn('T00:00:00+00:00', matches[0]['created_at'])
+            self.assertIsNone(matches[1]['created_at'])
+
+    def test_meta_route_handles_versioned_server_single_match(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._create_server(user, name='pipeline')
+            self._login(user)
+
+            history = [
+                {
+                    'definition_cid': 'xyz789',
+                    'snapshot_cid': 'snap-final',
+                    'created_at': datetime(2024, 2, 1, 12, 30, tzinfo=timezone.utc),
+                }
+            ]
+
+            with patch('routes.servers.get_server_definition_history', return_value=history):
+                response = self.client.get('/meta/pipeline/xyz789')
+
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 302)
+            self.assertTrue(data['resolution']['available'])
+            self.assertEqual(data['resolution']['definition_cid'], 'xyz789')
+            self.assertEqual(data['resolution']['snapshot_cid'], 'snap-final')
+            self.assertIn('2024-02-01T12:30:00+00:00', data['resolution']['created_at'])
+
+    def test_meta_route_reports_redirect_metadata_for_trailing_slash(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._login(user)
+
+            class FakeAdapter:
+                def match(self, path, method=None, return_rule=False):
+                    raise RequestRedirect('http://localhost/settings')
+
+            with patch.object(self.app.url_map, 'bind', return_value=FakeAdapter()):
+                response = self.client.get('/meta/needs-redirect')
+            self.assertEqual(response.status_code, 200)
+
+            data = json.loads(response.data)
+            self.assertEqual(data['resolution']['type'], 'redirect')
+            self.assertEqual(data['status_code'], 308)
+            self.assertIn('/settings', data['resolution']['location'])
+
+    def test_meta_route_reports_method_not_allowed_metadata(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._login(user)
+
+            response = self.client.get('/meta/variables/example/delete')
+            self.assertEqual(response.status_code, 200)
+
+            data = json.loads(response.data)
+            self.assertEqual(data['status_code'], 405)
+            self.assertEqual(data['resolution']['type'], 'method_not_allowed')
+            self.assertIn('POST', data['resolution']['allowed_methods'])
+            self.assertIn('POST', data['resolution']['methods'])
+            self.assertIn('/source/routes/meta.py', data['source_links'])
+
+    def test_meta_route_normalizes_blank_requested_path(self):
+        with self.app.app_context():
+            user = self._create_test_user()
+            self._login(user)
+
+            response = self.client.get('/meta')
+            self.assertEqual(response.status_code, 200)
+
+            data = json.loads(response.data)
+            self.assertEqual(data['path'], '/')
+            self.assertEqual(data['status_code'], 200)
 
 
 if __name__ == '__main__':

--- a/test_process_url_upload.py
+++ b/test_process_url_upload.py
@@ -1,0 +1,81 @@
+"""Regression tests for URL upload helpers."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import ANY, Mock, patch
+
+import requests
+
+from cid_utils import process_url_upload
+
+
+class TestProcessUrlUpload(TestCase):
+    """Exercise streaming, validation, and error handling for URL uploads."""
+
+    def _make_form(self, url: str):
+        return SimpleNamespace(url=SimpleNamespace(data=url))
+
+    @patch('cid_utils.requests.get')
+    def test_process_url_upload_streams_chunks_and_detects_mime(self, mock_get):
+        form = self._make_form(' https://example.com/download ')
+
+        response = Mock()
+        response.headers = {
+            'content-type': 'text/plain; charset=utf-8',
+        }
+        response.iter_content.return_value = [b'Hello ', b'World']
+        response.raise_for_status.return_value = None
+        mock_get.return_value = response
+
+        content, mime_type = process_url_upload(form)
+
+        self.assertEqual(content, b'Hello World')
+        self.assertEqual(mime_type, 'text/plain')
+        mock_get.assert_called_once_with(
+            'https://example.com/download',
+            timeout=30,
+            headers=ANY,
+            stream=True,
+        )
+        self.assertIn('Mozilla/5.0', mock_get.call_args.kwargs['headers']['User-Agent'])
+
+    @patch('cid_utils.requests.get')
+    def test_process_url_upload_rejects_files_over_100_mb(self, mock_get):
+        form = self._make_form('https://example.com/too-big.bin')
+
+        response = Mock()
+        response.headers = {
+            'content-type': 'application/octet-stream',
+            'content-length': str(101 * 1024 * 1024),
+        }
+        response.raise_for_status.return_value = None
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(ValueError, 'File too large'):
+            process_url_upload(form)
+
+    @patch('cid_utils.requests.get')
+    def test_process_url_upload_wraps_request_exceptions(self, mock_get):
+        form = self._make_form('https://example.com/fail')
+        mock_get.side_effect = requests.exceptions.RequestException('boom')
+
+        with self.assertRaisesRegex(ValueError, 'Failed to download from URL: boom'):
+            process_url_upload(form)
+
+    @patch('cid_utils.requests.get')
+    def test_process_url_upload_wraps_generic_errors(self, mock_get):
+        form = self._make_form('https://example.com/error')
+
+        response = Mock()
+        response.headers = {'content-type': 'text/plain'}
+        response.raise_for_status.return_value = None
+
+        def explode(**_kwargs):
+            raise RuntimeError('iter failure')
+
+        response.iter_content.side_effect = explode
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(ValueError, 'Error processing URL: iter failure'):
+            process_url_upload(form)
+

--- a/test_serve_cid_content.py
+++ b/test_serve_cid_content.py
@@ -132,6 +132,28 @@ class TestServeCidContent(unittest.TestCase):
         self.assertEqual(response.status_code, 304)
         self.assertEqual(response.headers.get("ETag"), etag_value)
 
+    def test_conditional_request_uses_if_modified_since_header(self):
+        path = "/bafybeihelloworld123456789012345678901234567890123456.note"
+        response = self._serve(path, headers={'If-Modified-Since': 'Wed, 21 Oct 2015 07:28:00 GMT'})
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 304)
+        self.assertIn('Last-Modified', response.headers)
+        self.assertIn('ETag', response.headers)
+
+    def test_markdown_without_extension_renders_html_document(self):
+        path = "/bafybeihelloworld123456789012345678901234567890123456"
+        markdown_content = SimpleNamespace(
+            file_data=b"# Heading\n\n- item one\n- item two\n",
+            created_at=self.cid_content.created_at,
+        )
+
+        response = self._serve(path, content=markdown_content)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.headers.get('Content-Type'), 'text/html')
+        body = response.get_data(as_text=True)
+        self.assertIn('<h1>Heading</h1>', body)
+        self.assertIn('<li>item one</li>', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `test_meta_route.py` with helpers for creating users, aliases, and servers in the in-memory database
- add regression tests covering alias redirects, server execution metadata, versioned server matching outcomes, redirect handling, method-not-allowed metadata, and root normalization in the meta inspector

## Testing
- ./test
- python run_coverage.py --xml --html

------
https://chatgpt.com/codex/tasks/task_b_68d4933dc160833182d966f25c37d94e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Browse uploads newest-first and quick lookup by content ID prefix.
  - Enhanced analytics: accurate page-view tracking, user history stats, and paginated recent views.
  - Markdown without an extension renders as HTML.
  - URL upload handling: streaming download with MIME detection and size-limit enforcement.

- Bug Fixes
  - More reliable alias redirects (trailing-slash, auth, method-not-allowed).
  - Prevents partial analytics records on failure; stronger encryption/error handling.
  - More robust text saving: better user-ID handling and input coercion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->