### PR TITLE
Support explicit markdown rendering via md.html routes

### DIFF
--- a/cid_utils.py
+++ b/cid_utils.py
@@ -633,9 +633,15 @@ def serve_cid_content(cid_content, path):
     content_type = get_mime_type_from_extension(path)
     filename_part = path.rsplit('/', 1)[-1]
     has_extension = '.' in filename_part
+    explicit_markdown_request = filename_part.lower().endswith('.md.html')
 
     response_body = cid_content.file_data
-    if content_type == 'application/octet-stream':
+    if explicit_markdown_request:
+        text = _decode_text_safely(response_body)
+        if text is not None:
+            response_body = _render_markdown_document(text).encode('utf-8')
+            content_type = 'text/html'
+    elif content_type == 'application/octet-stream':
         response_body, rendered = _maybe_render_markdown(response_body, path_has_extension=has_extension)
         if rendered:
             content_type = 'text/html'

--- a/test_serve_cid_content.py
+++ b/test_serve_cid_content.py
@@ -154,6 +154,20 @@ class TestServeCidContent(unittest.TestCase):
         self.assertIn('<h1>Heading</h1>', body)
         self.assertIn('<li>item one</li>', body)
 
+    def test_explicit_markdown_html_extension_renders_markdown(self):
+        path = "/bafybeihelloworld123456789012345678901234567890123456.notes.md.html"
+        markdown_content = SimpleNamespace(
+            file_data=b"Plain text rendered as markdown",
+            created_at=self.cid_content.created_at,
+        )
+
+        response = self._serve(path, content=markdown_content)
+        self.assertIsNotNone(response)
+        self.assertEqual(response.headers.get('Content-Type'), 'text/html')
+        body = response.get_data(as_text=True)
+        self.assertIn('<main class="markdown-body">', body)
+        self.assertIn('Plain text rendered as markdown', body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- render CID responses as HTML when the request path ends with `.md.html`
- keep heuristic markdown detection for extensionless paths
- cover the new behavior with unit tests for explicit markdown rendering

## Testing
- pytest test_serve_cid_content.py


------
https://chatgpt.com/codex/tasks/task_b_68d538e279e88331b097cc1f53183441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Paths ending with .md.html now render Markdown as a standalone HTML page with the correct text/html content type. Safer decoding ensures reliable display. Existing behavior for other file types remains unchanged.
- Tests
  - Added coverage to verify that .md.html requests return HTML with rendered Markdown content and the correct content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->