### PR TITLE
Add stack trace source links on error page

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
+<div class="container py-4">
     <div class="row justify-content-center">
-        <div class="col-md-6 text-center">
-            <div class="card">
+        <div class="col-lg-10">
+            <div class="card mb-4 text-center">
                 <div class="card-body p-5">
                     <i class="fas fa-exclamation-circle text-danger mb-3" style="font-size: 4rem;"></i>
                     <h1 class="card-title">500 - Internal Server Error</h1>
@@ -16,6 +16,33 @@
                     </a>
                 </div>
             </div>
+
+            {% if stack_trace %}
+                <div class="card">
+                    <div class="card-header bg-light">
+                        <strong>Exception:</strong> {{ exception_type }}{% if exception_message %}: {{ exception_message }}{% endif %}
+                    </div>
+                    <div class="card-body">
+                        <ol class="mb-0 ps-3">
+                            {% for frame in stack_trace %}
+                                <li class="mb-3">
+                                    <div class="mb-1">
+                                        {% if frame.source_link %}
+                                            <a href="{{ frame.source_link }}"><code>{{ frame.display_path }}</code></a>
+                                        {% else %}
+                                            <code>{{ frame.display_path }}</code>
+                                        {% endif %}
+                                        <span class="text-muted">in {{ frame.function }} at line {{ frame.lineno }}</span>
+                                    </div>
+                                    {% if frame.code %}
+                                        <pre class="bg-light p-2 rounded"><code>{{ frame.code | e }}</code></pre>
+                                    {% endif %}
+                                </li>
+                            {% endfor %}
+                        </ol>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/test_error_pages.py
+++ b/test_error_pages.py
@@ -1,0 +1,40 @@
+import unittest
+
+from app import create_app
+from database import db
+from routes.core import internal_error
+
+
+class TestInternalServerErrorPage(unittest.TestCase):
+    """Tests for the customized 500 error page with stack trace links."""
+
+    def setUp(self):
+        self.app = create_app(
+            {
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+                'WTF_CSRF_ENABLED': False,
+            }
+        )
+        self.app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_error_page_includes_source_links(self):
+        with self.app.test_request_context('/broken'):
+            try:
+                raise RuntimeError('Intentional failure for testing')
+            except RuntimeError as exc:
+                response, status = internal_error(exc)
+
+        self.assertEqual(status, 500)
+
+        body = response
+        self.assertIn('RuntimeError', body)
+        self.assertIn('Intentional failure for testing', body)
+        self.assertIn('href="/source/test_error_pages.py"', body)
+        self.assertIn('<code>test_error_pages.py</code>', body)
+


### PR DESCRIPTION
## Summary
- collect stack trace metadata in the 500 error handler and attach /source links when files are tracked
- show the exception details and a linked stack trace on the internal error template
- cover the new behaviour with a unit test that exercises the error handler directly

## Testing
- ./test
- pytest test_error_pages.py -q

------
https://chatgpt.com/codex/tasks/task_b_68d56d281c988331929e70236939ba8c