### PR TITLE
Serve markdown HTML inline

### DIFF
--- a/cid_utils.py
+++ b/cid_utils.py
@@ -569,7 +569,7 @@ def serve_cid_content(cid_content, path):
     response.headers['Content-Length'] = len(response_body)
 
     filename = extract_filename_from_cid_path(path)
-    if filename:
+    if filename and not explicit_markdown_request:
         response.headers['Content-Disposition'] = f'attachment; filename="{filename}"'
 
     response.headers['ETag'] = etag

--- a/test_serve_cid_content.py
+++ b/test_serve_cid_content.py
@@ -164,6 +164,7 @@ class TestServeCidContent(unittest.TestCase):
         response = self._serve(path, content=markdown_content)
         self.assertIsNotNone(response)
         self.assertEqual(response.headers.get('Content-Type'), 'text/html')
+        self.assertNotIn('Content-Disposition', response.headers)
         body = response.get_data(as_text=True)
         self.assertIn('<main class="markdown-body">', body)
         self.assertIn('Plain text rendered as markdown', body)


### PR DESCRIPTION
## Summary
- ensure explicit markdown HTML requests are served without forcing attachment downloads
- cover the inline markdown HTML response with a regression test

## Testing
- pytest test_serve_cid_content.py *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_b_68d5eac720b48331ae0409b387661f35