### PR TITLE
Refine GitHub-style link normalization

### DIFF
--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -175,3 +175,41 @@ class TestFormIdeasAndDividers:
         assert "<hr>" in fragment
         assert fragment.index("First section") < fragment.index("<hr>") < fragment.index("Second section")
 
+
+class TestGithubStyleLinks:
+    def test_relative_link_renders_with_normalized_path(self):
+        fragment = _render_fragment("Navigate to [[About]] for details.")
+
+        assert '<a href="/about/">About</a>' in fragment
+
+    def test_relative_link_with_custom_label_uses_pipe_syntax(self):
+        fragment = _render_fragment("Refer to [[Guides/Getting Started|the quickstart guide]].")
+
+        assert '<a href="/guides/getting-started/">the quickstart guide</a>' in fragment
+
+    def test_relative_link_with_anchor_slugifies_target_heading(self):
+        fragment = _render_fragment("See [[Guides/Getting Started#Deep Dive|the deep dive section]].")
+
+        assert '<a href="/guides/getting-started/#deep-dive">the deep dive section</a>' in fragment
+
+    def test_relative_anchor_only_link_targets_heading_on_same_page(self):
+        fragment = _render_fragment("Jump to [[#Usage Notes]] for details.")
+
+        assert '<a href="#usage-notes">#Usage Notes</a>' in fragment
+
+    def test_relative_link_to_markdown_file_preserves_extension(self):
+        fragment = _render_fragment("Read [[Docs/API.md|API reference]].")
+
+        assert '<a href="/docs/api.md">API reference</a>' in fragment
+
+    def test_multiple_relative_links_convert_independently(self):
+        fragment = _render_fragment("See [[About]] alongside [[Guides/Overview|the overview]].")
+
+        assert '<a href="/about/">About</a>' in fragment
+        assert '<a href="/guides/overview/">the overview</a>' in fragment
+
+    def test_invalid_relative_link_is_left_unchanged(self):
+        fragment = _render_fragment("Avoid [[   |blank]] targets.")
+
+        assert '[[   |blank]]' in fragment
+


### PR DESCRIPTION
## Summary
- adopt version 2 normalization for GitHub-style wiki links before rendering Markdown, including support for heading anchors and sanitized slugs
- extend the markdown rendering tests to cover anchors, multiple wiki links, markdown file targets, and invalid wiki syntax

## Testing
- pytest test_markdown_rendering.py

------
https://chatgpt.com/codex/tasks/task_b_68d5eef90d388331a720720fe511085d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for GitHub-style relative links in Markdown (e.g., [[path]] and [[path|label]]).
  - Normalizes paths and anchors (including on-page headings) and converts them to standard Markdown links.
  - Preserves file extensions; invalid or empty targets are left as plain text.

- Tests
  - Introduced a comprehensive test suite covering normalization, custom labels, anchor handling, on-page anchors, multiple links, extension preservation, and invalid link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->