### PR TITLE
Fix GitHub-style wiki link normalization

### DIFF
--- a/cid_utils.py
+++ b/cid_utils.py
@@ -423,6 +423,7 @@ def _normalize_github_relative_link_target_v2(raw_target: str) -> str | None:
 
     normalized_path = ""
     if page_part:
+        preserve_trailing_slash = page_part.rstrip().endswith('/')
         prepared = re.sub(r"\s+", "-", page_part.strip())
         cleaned = _GITHUB_RELATIVE_LINK_PATH_SANITIZER.sub('', prepared)
         segments = [segment for segment in cleaned.split('/') if segment]
@@ -431,7 +432,7 @@ def _normalize_github_relative_link_target_v2(raw_target: str) -> str | None:
         else:
             normalized_segments = [segment.lower() for segment in segments]
             normalized_path = '/' + '/'.join(normalized_segments)
-            if '.' not in normalized_segments[-1]:
+            if preserve_trailing_slash:
                 normalized_path += '/'
 
     anchor_fragment = ""

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -180,17 +180,17 @@ class TestGithubStyleLinks:
     def test_relative_link_renders_with_normalized_path(self):
         fragment = _render_fragment("Navigate to [[About]] for details.")
 
-        assert '<a href="/about/">About</a>' in fragment
+        assert '<a href="/about">About</a>' in fragment
 
     def test_relative_link_with_custom_label_uses_pipe_syntax(self):
         fragment = _render_fragment("Refer to [[Guides/Getting Started|the quickstart guide]].")
 
-        assert '<a href="/guides/getting-started/">the quickstart guide</a>' in fragment
+        assert '<a href="/guides/getting-started">the quickstart guide</a>' in fragment
 
     def test_relative_link_with_anchor_slugifies_target_heading(self):
         fragment = _render_fragment("See [[Guides/Getting Started#Deep Dive|the deep dive section]].")
 
-        assert '<a href="/guides/getting-started/#deep-dive">the deep dive section</a>' in fragment
+        assert '<a href="/guides/getting-started#deep-dive">the deep dive section</a>' in fragment
 
     def test_relative_anchor_only_link_targets_heading_on_same_page(self):
         fragment = _render_fragment("Jump to [[#Usage Notes]] for details.")
@@ -205,8 +205,18 @@ class TestGithubStyleLinks:
     def test_multiple_relative_links_convert_independently(self):
         fragment = _render_fragment("See [[About]] alongside [[Guides/Overview|the overview]].")
 
-        assert '<a href="/about/">About</a>' in fragment
-        assert '<a href="/guides/overview/">the overview</a>' in fragment
+        assert '<a href="/about">About</a>' in fragment
+        assert '<a href="/guides/overview">the overview</a>' in fragment
+
+    def test_relative_link_with_lowercase_name_preserves_label(self):
+        fragment = _render_fragment("Check out [[echo]] next.")
+
+        assert '<a href="/echo">echo</a>' in fragment
+
+    def test_relative_link_with_explicit_trailing_slash_is_preserved(self):
+        fragment = _render_fragment("Browse [[Guides/Deep Dive/|the deep dive index]].")
+
+        assert '<a href="/guides/deep-dive/">the deep dive index</a>' in fragment
 
     def test_invalid_relative_link_is_left_unchanged(self):
         fragment = _render_fragment("Avoid [[   |blank]] targets.")


### PR DESCRIPTION
## Summary
- normalize GitHub-style relative wiki links without appending a trailing slash unless the source included one
- add regression coverage for lowercase wiki links and explicit trailing-slash targets in the markdown renderer tests

## Testing
- pytest test_markdown_rendering.py

------
https://chatgpt.com/codex/tasks/task_b_68d5fa023d408331962ae474e82ad899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalizes relative links to omit trailing slashes unless explicitly present in the source.
  * Preserves explicit trailing slashes when provided.
  * Fixes anchor links to avoid inserting an extra slash before the hash (e.g., /path#section).
  * Ensures consistent path normalization for final segments.

* **Tests**
  * Added and updated cases for trailing-slash preservation, lowercase labels, anchor formatting, and multi-link scenarios to match the new link output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->