### PR TITLE
Add Formdown embed support for markdown pages

### DIFF
--- a/cid_utils.py
+++ b/cid_utils.py
@@ -327,6 +327,16 @@ _MARKDOWN_EXTENSIONS = [
     'sane_lists',
 ]
 
+_FORMDOWN_SCRIPT_URL = "https://www.formdown.net/js/formdown.js"
+_FORMDOWN_MARKUP_PATTERNS = [
+    re.compile(r'<\s*formdown-', re.IGNORECASE),
+    re.compile(r'data-formdown', re.IGNORECASE),
+]
+
+
+def _contains_formdown_markup(html_text: str) -> bool:
+    return any(pattern.search(html_text) for pattern in _FORMDOWN_MARKUP_PATTERNS)
+
 _MARKDOWN_INDICATOR_PATTERNS = [
     re.compile(r'(^|\n)#{1,6}\s+\S'),
     re.compile(r'(^|\n)(?:\*|-|\+)\s+\S'),
@@ -482,6 +492,11 @@ def _render_markdown_document(text):
     """Render Markdown text to a standalone HTML document."""
     converted = _convert_github_relative_links(text)
     body = markdown.markdown(converted, extensions=_MARKDOWN_EXTENSIONS, output_format='html5')
+    formdown_script_block = ""
+    if _contains_formdown_markup(body):
+        formdown_script_block = (
+            f"  <script src=\"{_FORMDOWN_SCRIPT_URL}\" async defer data-formdown-loader></script>\n"
+        )
     title = _extract_markdown_title(text)
     return (
         "<!DOCTYPE html>\n"
@@ -557,6 +572,7 @@ def _render_markdown_document(text):
         "  <main class=\"markdown-body\">\n"
         f"  {body}\n"
         "  </main>\n"
+        f"{formdown_script_block}"
         "</body>\n"
         "</html>\n"
     )

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -328,9 +328,10 @@ _MARKDOWN_EXTENSIONS = [
     'sane_lists',
 ]
 
-_FORMDOWN_SCRIPT_URL = "https://unpkg.com/@formdown/ui@latest/dist/standalone.js"
+_FORMDOWN_SCRIPT_URL = "https://www.formdown.net/js/formdown.js"
 _FORMDOWN_MARKUP_PATTERNS = [
-    re.compile(r'<\s*formdown-', re.IGNORECASE),
+    re.compile(r'<\s*div[^>]*data-formdown', re.IGNORECASE),
+    re.compile(r'<\s*script[^>]+type\s*=\s*["\']text/formdown["\']', re.IGNORECASE),
 ]
 
 _FORMDOWN_FENCE_PATTERN = re.compile(
@@ -531,15 +532,17 @@ def _render_markdown_document(text):
     body = markdown.markdown(converted, extensions=_MARKDOWN_EXTENSIONS, output_format='html5')
     for placeholder, embed_body in formdown_embeds:
         form_block = (
-            "<formdown-ui>\n"
+            "<div data-formdown>\n"
+            "  <script type=\"text/formdown\">\n"
             f"{embed_body}\n"
-            "</formdown-ui>"
+            "  </script>\n"
+            "</div>"
         )
         body = body.replace(placeholder, form_block)
     formdown_script_block = ""
     if has_formdown_fence or _contains_formdown_markup(body):
         formdown_script_block = (
-            f"  <script type=\"module\" src=\"{_FORMDOWN_SCRIPT_URL}\"></script>\n"
+            f"  <script src=\"{_FORMDOWN_SCRIPT_URL}\" defer></script>\n"
         )
     title = _extract_markdown_title(text)
     return (

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -354,11 +354,11 @@ def _expand_formdown_fences(text: str) -> str:
             return prefix
 
         form_block = (
-            "<formdown-form data-formdown-mode=\"dsl\">\n"
+            "<div data-formdown>\n"
             "  <script type=\"text/formdown\">\n"
             f"{body}\n"
             "  </script>\n"
-            "</formdown-form>\n"
+            "</div>\n"
         )
         return f"{prefix}{form_block}"
 

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -345,14 +345,22 @@ def _contains_formdown_markup(html_text: str) -> bool:
 
 
 def _expand_formdown_fences(text: str) -> str:
-    """Inline the contents of formdown code fences so Formdown can parse them."""
+    """Convert formdown code fences into embeds that the loader understands."""
 
     def _replace(match: re.Match[str]) -> str:
         prefix = match.group(1)
         body = textwrap.dedent(match.group(2)).strip()
         if not body:
             return prefix
-        return f"{prefix}{body}\n"
+
+        form_block = (
+            "<formdown-form data-formdown-mode=\"dsl\">\n"
+            "  <script type=\"text/formdown\">\n"
+            f"{body}\n"
+            "  </script>\n"
+            "</formdown-form>\n"
+        )
+        return f"{prefix}{form_block}"
 
     return _FORMDOWN_FENCE_PATTERN.sub(_replace, text)
 

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -328,7 +328,7 @@ _MARKDOWN_EXTENSIONS = [
     'sane_lists',
 ]
 
-_FORMDOWN_SCRIPT_URL = "https://www.formdown.net/js/formdown.js"
+_FORMDOWN_SCRIPT_URL = "https://formdown.dev/js/formdown.js"
 _FORMDOWN_MARKUP_PATTERNS = [
     re.compile(r'<\s*formdown-', re.IGNORECASE),
     re.compile(r'data-formdown', re.IGNORECASE),

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -328,7 +328,7 @@ _MARKDOWN_EXTENSIONS = [
     'sane_lists',
 ]
 
-_FORMDOWN_SCRIPT_URL = "https://formdown.dev/js/formdown.js"
+_FORMDOWN_SCRIPT_URL = "https://unpkg.com/@formdown/ui@latest/dist/standalone.js"
 _FORMDOWN_MARKUP_PATTERNS = [
     re.compile(r'<\s*formdown-', re.IGNORECASE),
     re.compile(r'data-formdown', re.IGNORECASE),

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import textwrap
 
+from pathlib import Path
+
 from cid_utils import _FORMDOWN_SCRIPT_URL, _render_markdown_document
 
 
@@ -189,6 +191,15 @@ class TestFormdownEmbeds:
         assert _FORMDOWN_SCRIPT_URL in html_document
         assert html_document.index('</main>') < html_document.index(_FORMDOWN_SCRIPT_URL)
 
+    def test_formdown_custom_element_injects_loader_script(self):
+        html_document = _render_markdown_document(
+            """
+            <formdown-form data-formdown-form=\"demo-support\"></formdown-form>
+            """
+        )
+
+        assert _FORMDOWN_SCRIPT_URL in html_document
+
     def test_unrelated_markdown_does_not_include_formdown_script(self):
         html_document = _render_markdown_document(
             """
@@ -199,6 +210,16 @@ class TestFormdownEmbeds:
         )
 
         assert _FORMDOWN_SCRIPT_URL not in html_document
+
+    def test_formdown_showcase_template_renders_with_embed(self):
+        template_path = Path("upload_templates/contents/formdown_showcase.md")
+        markdown_text = template_path.read_text(encoding="utf-8")
+
+        html_document = _render_markdown_document(markdown_text)
+
+        assert _FORMDOWN_SCRIPT_URL in html_document
+        assert "formdown/examples/upload" in html_document
+        assert "formdown-field" in html_document
 
 
 class TestGithubStyleLinks:

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -356,6 +356,7 @@ class TestFormdownEmbeds:
         assert "Share a support request" in html_document
         assert "U___supportingFile" in html_document
         assert "<pre" not in html_document
+        assert "formdown.dev" in html_document
 
 
 class TestGithubStyleLinks:

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 
-from cid_utils import _render_markdown_document
+from cid_utils import _FORMDOWN_SCRIPT_URL, _render_markdown_document
 
 
 def _render_fragment(markdown_text: str) -> str:
@@ -159,7 +159,6 @@ class TestFormIdeasAndDividers:
         assert '<pre><code>' in fragment
         assert ':::form id=&quot;feature-request&quot;' in fragment
         assert '[priority] (select: low | medium | high)' in fragment
-
     def test_horizontal_rule_renders_between_sections(self):
         fragment = _render_fragment(
             """
@@ -174,6 +173,32 @@ class TestFormIdeasAndDividers:
         assert fragment.count("<p>") == 2
         assert "<hr>" in fragment
         assert fragment.index("First section") < fragment.index("<hr>") < fragment.index("Second section")
+
+
+class TestFormdownEmbeds:
+    def test_formdown_markup_injects_loader_script(self):
+        html_document = _render_markdown_document(
+            """
+            <div
+              data-formdown-form=\"support-request\"
+              data-formdown-theme=\"system\"
+            ></div>
+            """
+        )
+
+        assert _FORMDOWN_SCRIPT_URL in html_document
+        assert html_document.index('</main>') < html_document.index(_FORMDOWN_SCRIPT_URL)
+
+    def test_unrelated_markdown_does_not_include_formdown_script(self):
+        html_document = _render_markdown_document(
+            """
+            # Release notes
+
+            Welcome to the changelog.
+            """
+        )
+
+        assert _FORMDOWN_SCRIPT_URL not in html_document
 
 
 class TestGithubStyleLinks:

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -178,11 +178,28 @@ class TestFormIdeasAndDividers:
 
 
 class TestFormdownEmbeds:
-    def test_formdown_code_fence_renders_embed(self):
+    def test_formdown_code_fence_renders_form_markup(self):
         markdown_text = textwrap.dedent(
             """
             ```formdown
-            <formdown-form data-formdown-form="support"></formdown-form>
+            Signup to our club!
+
+            [[
+            --Your name--
+            T___firstName
+            #placeholder|First name
+            {r m5 M40}
+
+            T___lastName
+            #placeholder|Last name
+            {r m5 M40}
+            ]]
+
+            --Email address--
+            @___email
+            {r}
+
+            (submit|Sign up!)
             ```
             """
         ).strip()
@@ -190,7 +207,9 @@ class TestFormdownEmbeds:
         fragment = _render_fragment(markdown_text)
         html_document = _render_markdown_document(markdown_text)
 
-        assert "<formdown-form data-formdown-form=\"support\"></formdown-form>" in fragment
+        assert "Signup to our club!" in fragment
+        assert "[[" in fragment
+        assert "T___firstName" in fragment
         assert "<pre" not in fragment
         assert _FORMDOWN_SCRIPT_URL in html_document
 
@@ -233,15 +252,15 @@ class TestFormdownEmbeds:
 
         assert "```formdown" in markdown_text
 
-    def test_formdown_showcase_template_renders_with_embed(self):
+    def test_formdown_showcase_template_renders_with_formdown_markup(self):
         template_path = Path("upload_templates/contents/formdown_showcase.md")
         markdown_text = template_path.read_text(encoding="utf-8")
 
         html_document = _render_markdown_document(markdown_text)
 
         assert _FORMDOWN_SCRIPT_URL in html_document
-        assert "formdown/examples/upload" in html_document
-        assert "formdown-field" in html_document
+        assert "Share a support request" in html_document
+        assert "U___supportingFile" in html_document
         assert "<pre" not in html_document
 
 

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -28,11 +28,11 @@ def _render_formdown_form(markdown_text: str) -> tuple[str, str]:
 
     fragment = _render_fragment(markdown_text)
     script_match = re.search(
-        r"<script type=\"text/formdown\">\s*(?P<body>.*?)\s*</script>",
+        r"<formdown-ui>\s*(?P<body>.*?)\s*</formdown-ui>",
         fragment,
         re.DOTALL,
     )
-    assert script_match is not None, "Expected a formdown script block in the output"
+    assert script_match is not None, "Expected a formdown-ui block in the output"
     script_body = textwrap.dedent(script_match.group("body")).strip()
     return fragment, script_body
 
@@ -222,7 +222,7 @@ class TestFormdownEmbeds:
         fragment, script_body = _render_formdown_form(markdown_text)
         html_document = _render_markdown_document(markdown_text)
 
-        assert "<div data-formdown" in fragment
+        assert "<formdown-ui" in fragment
         assert "Signup to our club!" in script_body
         assert "[[" in script_body
         assert "T___firstName" in script_body
@@ -308,13 +308,7 @@ class TestFormdownEmbeds:
 
     def test_formdown_markup_injects_loader_script(self):
         html_document = _render_markdown_document(
-            """
-            <div
-              data-formdown
-              data-formdown-form=\"support-request\"
-              data-formdown-theme=\"system\"
-            ></div>
-            """
+            "<formdown-ui form=\"support-request\" theme=\"system\"></formdown-ui>"
         )
 
         assert _FORMDOWN_SCRIPT_URL in html_document
@@ -322,9 +316,7 @@ class TestFormdownEmbeds:
 
     def test_formdown_custom_element_injects_loader_script(self):
         html_document = _render_markdown_document(
-            """
-            <formdown-form data-formdown-form=\"demo-support\"></formdown-form>
-            """
+            "<formdown-ui form=\"demo-support\"></formdown-ui>"
         )
 
         assert _FORMDOWN_SCRIPT_URL in html_document
@@ -353,7 +345,7 @@ class TestFormdownEmbeds:
         html_document = _render_markdown_document(markdown_text)
 
         assert _FORMDOWN_SCRIPT_URL in html_document
-        assert "<div data-formdown" in html_document
+        assert "<formdown-ui" in html_document
         assert "Share a support request" in html_document
         assert "U___supportingFile" in html_document
         assert "<pre" not in html_document

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -178,6 +178,22 @@ class TestFormIdeasAndDividers:
 
 
 class TestFormdownEmbeds:
+    def test_formdown_code_fence_renders_embed(self):
+        markdown_text = textwrap.dedent(
+            """
+            ```formdown
+            <formdown-form data-formdown-form="support"></formdown-form>
+            ```
+            """
+        ).strip()
+
+        fragment = _render_fragment(markdown_text)
+        html_document = _render_markdown_document(markdown_text)
+
+        assert "<formdown-form data-formdown-form=\"support\"></formdown-form>" in fragment
+        assert "<pre" not in fragment
+        assert _FORMDOWN_SCRIPT_URL in html_document
+
     def test_formdown_markup_injects_loader_script(self):
         html_document = _render_markdown_document(
             """
@@ -211,6 +227,12 @@ class TestFormdownEmbeds:
 
         assert _FORMDOWN_SCRIPT_URL not in html_document
 
+    def test_formdown_showcase_template_uses_formdown_code_fence(self):
+        template_path = Path("upload_templates/contents/formdown_showcase.md")
+        markdown_text = template_path.read_text(encoding="utf-8")
+
+        assert "```formdown" in markdown_text
+
     def test_formdown_showcase_template_renders_with_embed(self):
         template_path = Path("upload_templates/contents/formdown_showcase.md")
         markdown_text = template_path.read_text(encoding="utf-8")
@@ -220,6 +242,7 @@ class TestFormdownEmbeds:
         assert _FORMDOWN_SCRIPT_URL in html_document
         assert "formdown/examples/upload" in html_document
         assert "formdown-field" in html_document
+        assert "<pre" not in html_document
 
 
 class TestGithubStyleLinks:

--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -222,7 +222,7 @@ class TestFormdownEmbeds:
         fragment, script_body = _render_formdown_form(markdown_text)
         html_document = _render_markdown_document(markdown_text)
 
-        assert "<formdown-form" in fragment
+        assert "<div data-formdown" in fragment
         assert "Signup to our club!" in script_body
         assert "[[" in script_body
         assert "T___firstName" in script_body
@@ -310,6 +310,7 @@ class TestFormdownEmbeds:
         html_document = _render_markdown_document(
             """
             <div
+              data-formdown
               data-formdown-form=\"support-request\"
               data-formdown-theme=\"system\"
             ></div>
@@ -352,7 +353,7 @@ class TestFormdownEmbeds:
         html_document = _render_markdown_document(markdown_text)
 
         assert _FORMDOWN_SCRIPT_URL in html_document
-        assert "<formdown-form" in html_document
+        assert "<div data-formdown" in html_document
         assert "Share a support request" in html_document
         assert "U___supportingFile" in html_document
         assert "<pre" not in html_document

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -5,13 +5,20 @@ Replace the attribute values with the options from your form dashboard.
 
 ## Support request
 
+Below is a fully functional Formdown contact form. You can interact with the
+fields as-is, then replace the `data-formdown-form` value with the slug from one
+of your own forms when you are ready to publish.
+
 <div
-  data-formdown-form="your-formdown-form"
+  data-formdown-form="formdown/examples/upload"
   data-formdown-theme="system"
   data-formdown-label-style="floating"
   data-formdown-success-title="Thanks for reaching out!"
   data-formdown-success-message="We received your message and will reply soon."
   data-formdown-button-label="Send message"
+  data-formdown-upload="required"
+  data-formdown-upload-label="Attach supporting file"
+  data-formdown-upload-max-size="15"
 ></div>
 
 ### Common options
@@ -20,6 +27,8 @@ Replace the attribute values with the options from your form dashboard.
 - `data-formdown-label-style` — choose `floating` or `stacked` labels.
 - `data-formdown-success-title` / `data-formdown-success-message` — customize the confirmation copy.
 - `data-formdown-button-label` — override the submit button text.
+- `data-formdown-upload` — enable file uploads (`optional`, `required`, or omit to disable).
+- `data-formdown-upload-label` / `data-formdown-upload-max-size` — control the uploader text and maximum size (in MB).
 
 > **Tip:** Viewer automatically adds the Formdown loader script to Markdown pages that
 > include elements with `data-formdown-*` attributes, so the embed works without adding

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -5,44 +5,52 @@ Replace the attribute values with the options from your form dashboard.
 
 ## Support request
 
-Below is a fully functional Formdown contact form. You can interact with the
-fields as-is, then replace the `data-formdown-form` value with the slug from one
-of your own forms when you are ready to publish.
+Below is a working Formdown script that demonstrates the platform's DSL.
+Publish this template as-is to try it out, then swap in the copy that matches
+your own workflow.
 
 ```formdown
-<formdown-form
-  data-formdown-form="formdown/examples/upload"
-  data-formdown-theme="system"
-  data-formdown-label-style="floating"
-  data-formdown-success-title="Thanks for reaching out!"
-  data-formdown-success-message="We received your message and will reply soon."
-  data-formdown-button-label="Send message"
-  data-formdown-upload="required"
-  data-formdown-upload-label="Attach supporting file"
-  data-formdown-upload-max-size="15"
->
-  <formdown-field data-formdown-field="name"></formdown-field>
-  <formdown-field data-formdown-field="email"></formdown-field>
-  <formdown-field data-formdown-field="message"></formdown-field>
-</formdown-form>
-```
+Share a support request along with any screenshots that help explain the issue.
 
-<noscript>
-  <p>
-    Formdown forms require JavaScript to load. Enable JavaScript to interact with this
-    upload-enabled example, or replace the embed with your own form slug when publishing.
-  </p>
-</noscript>
+[[
+--Your name--
+T___firstName
+#placeholder|First name
+{r m2 M40}
+
+T___lastName
+#placeholder|Last name
+{r m2 M40}
+]]
+
+--Email address--
+@___email
+#helper|We'll use this address to follow up.
+{r}
+
+--Issue summary--
+T=__summary
+#type|textarea
+#helper|Provide as much detail as you can.
+{r m10 M400}
+
+--Attach a supporting file--
+U___supportingFile
+#helper|Optional upload, max 15 MB.
+{M15}
+
+(submit|Send request)
+```
 
 ### Common options
 
-- `data-formdown-theme` — switch between `light`, `dark`, or `system` themes.
-- `data-formdown-label-style` — choose `floating` or `stacked` labels.
-- `data-formdown-success-title` / `data-formdown-success-message` — customize the confirmation copy.
-- `data-formdown-button-label` — override the submit button text.
-- `data-formdown-upload` — enable file uploads (`optional`, `required`, or omit to disable).
-- `data-formdown-upload-label` / `data-formdown-upload-max-size` — control the uploader text and maximum size (in MB).
+- Prefix inputs with `T___`, `@___`, `U___`, or `*___` to render text, email,
+  upload, and password fields respectively.
+- Use `{r}` to make a field required, `m` and `M` to set minimum and maximum
+  lengths, and `#helper|` or `#placeholder|` to add guidance for users.
+- Wrap fields inside `[[ ... ]]` blocks to group them so Formdown renders them
+  side-by-side on larger screens.
 
-> **Tip:** Viewer automatically adds the Formdown loader script to Markdown pages that
-> include elements with `data-formdown-*` attributes, so the embed works without adding
-> extra code.
+> **Tip:** Viewer automatically converts ` ```formdown` fences into live embeds
+> and appends the Formdown loader script, so the published page renders the
+> interactive form rather than a static code sample.

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -1,11 +1,11 @@
 # Formdown form demo
 
-Easily embed a [Formdown](https://www.formdown.net/) form within a Markdown document.
-Replace the attribute values with the options from your form dashboard.
+Easily embed a [Formdown](https://formdown.dev/) form within a Markdown document.
+Replace the attribute values with the options from your workspace dashboard.
 
 ## Support request
 
-Below is a working Formdown script that demonstrates the platform's DSL.
+Below is a working Formdown.dev script that demonstrates the updated DSL syntax.
 Publish this template as-is to try it out, then swap in the copy that matches
 your own workflow.
 
@@ -52,5 +52,5 @@ U___supportingFile
   side-by-side on larger screens.
 
 > **Tip:** Viewer automatically converts ` ```formdown` fences into live embeds
-> and appends the Formdown loader script, so the published page renders the
+> and appends the Formdown.dev loader script, so the published page renders the
 > interactive form rather than a static code sample.

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -1,11 +1,11 @@
 # Formdown form demo
 
-Easily embed a [Formdown](https://formdown.dev/) form within a Markdown document.
+Easily embed a [Formdown](https://www.formdown.net/) form within a Markdown document.
 Replace the attribute values with the options from your workspace dashboard.
 
 ## Support request
 
-Below is a working Formdown.dev script that demonstrates the updated DSL syntax.
+Below is a working Formdown.net script that demonstrates the Vanilla JS embed.
 Publish this template as-is to try it out, then swap in the copy that matches
 your own workflow.
 
@@ -52,5 +52,5 @@ U___supportingFile
   side-by-side on larger screens.
 
 > **Tip:** Viewer automatically converts ` ```formdown` fences into live embeds
-> and appends the Formdown.dev loader script, so the published page renders the
-> interactive form rather than a static code sample.
+> and appends the Formdown.net Vanilla JS loader, so the published page renders
+> the interactive form rather than a static code sample.

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -9,6 +9,7 @@ Below is a fully functional Formdown contact form. You can interact with the
 fields as-is, then replace the `data-formdown-form` value with the slug from one
 of your own forms when you are ready to publish.
 
+```formdown
 <formdown-form
   data-formdown-form="formdown/examples/upload"
   data-formdown-theme="system"
@@ -24,6 +25,7 @@ of your own forms when you are ready to publish.
   <formdown-field data-formdown-field="email"></formdown-field>
   <formdown-field data-formdown-field="message"></formdown-field>
 </formdown-form>
+```
 
 <noscript>
   <p>

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -9,7 +9,7 @@ Below is a fully functional Formdown contact form. You can interact with the
 fields as-is, then replace the `data-formdown-form` value with the slug from one
 of your own forms when you are ready to publish.
 
-<div
+<formdown-form
   data-formdown-form="formdown/examples/upload"
   data-formdown-theme="system"
   data-formdown-label-style="floating"
@@ -19,7 +19,18 @@ of your own forms when you are ready to publish.
   data-formdown-upload="required"
   data-formdown-upload-label="Attach supporting file"
   data-formdown-upload-max-size="15"
-></div>
+>
+  <formdown-field data-formdown-field="name"></formdown-field>
+  <formdown-field data-formdown-field="email"></formdown-field>
+  <formdown-field data-formdown-field="message"></formdown-field>
+</formdown-form>
+
+<noscript>
+  <p>
+    Formdown forms require JavaScript to load. Enable JavaScript to interact with this
+    upload-enabled example, or replace the embed with your own form slug when publishing.
+  </p>
+</noscript>
 
 ### Common options
 

--- a/upload_templates/contents/formdown_showcase.md
+++ b/upload_templates/contents/formdown_showcase.md
@@ -1,0 +1,26 @@
+# Formdown form demo
+
+Easily embed a [Formdown](https://www.formdown.net/) form within a Markdown document.
+Replace the attribute values with the options from your form dashboard.
+
+## Support request
+
+<div
+  data-formdown-form="your-formdown-form"
+  data-formdown-theme="system"
+  data-formdown-label-style="floating"
+  data-formdown-success-title="Thanks for reaching out!"
+  data-formdown-success-message="We received your message and will reply soon."
+  data-formdown-button-label="Send message"
+></div>
+
+### Common options
+
+- `data-formdown-theme` — switch between `light`, `dark`, or `system` themes.
+- `data-formdown-label-style` — choose `floating` or `stacked` labels.
+- `data-formdown-success-title` / `data-formdown-success-message` — customize the confirmation copy.
+- `data-formdown-button-label` — override the submit button text.
+
+> **Tip:** Viewer automatically adds the Formdown loader script to Markdown pages that
+> include elements with `data-formdown-*` attributes, so the embed works without adding
+> extra code.

--- a/upload_templates/templates/formdown_showcase.json
+++ b/upload_templates/templates/formdown_showcase.json
@@ -1,0 +1,7 @@
+{
+  "id": "formdown-showcase",
+  "name": "Formdown form",
+  "description": "Markdown example that embeds a Formdown form and highlights common options.",
+  "content_file": "contents/formdown_showcase.md",
+  "suggested_filename": "formdown.md"
+}


### PR DESCRIPTION
## Summary
- auto-load the Formdown embed script when Markdown renders elements with Formdown attributes
- add regression tests covering the Formdown loader injection behaviour
- provide a new Formdown-focused upload template that demonstrates common embed options

## Testing
- pytest test_markdown_rendering.py

------
https://chatgpt.com/codex/tasks/task_b_68d6034f40d88331909a809bef143b9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown now detects Formdown embeds (fenced blocks or inline markup) and automatically injects the Formdown loader so embedded forms render in-place.

* **Documentation**
  * Added a Formdown showcase demonstrating embedding and configuration of a Formdown form in Markdown; viewer fences auto-convert to live embeds.

* **Templates**
  * Added a “Formdown form” template for quickly creating Formdown-enabled Markdown files.

* **Tests**
  * Added tests to validate embed rendering, fence preservation, and loader injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->