### PR TITLE
Add formdown rendering support to markdown pages

### DIFF
--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -176,6 +176,46 @@ class TestFormIdeasAndDividers:
         assert fragment.index("First section") < fragment.index("<hr>") < fragment.index("Second section")
 
 
+class TestFormdownIntegration:
+    def test_formdown_fence_renders_form_component(self):
+        fragment = _render_fragment(
+            """
+            ```formdown
+            @name: [text required]
+            @email: [email required]
+            @submit: [submit label="Send"]
+            ```
+            """
+        )
+
+        assert "<formdown-ui>" in fragment
+        assert "@name: [text required]" in fragment
+        assert "@submit: [submit label=\"Send\"]" in fragment
+        assert fragment.strip().endswith("</formdown-ui>")
+
+    def test_formdown_fence_includes_ui_script_in_head(self):
+        html_document = _render_markdown_document(
+            """
+            ```formdown
+            @feedback: [textarea]
+            ```
+            """
+        )
+
+        assert (
+            '<script type="module" src="https://unpkg.com/@formdown/ui@latest/dist/standalone.js"></script>'
+            in html_document
+        )
+
+    def test_plain_markdown_omits_formdown_script(self):
+        html_document = _render_markdown_document("Regular content with no forms.")
+
+        assert (
+            '<script type="module" src="https://unpkg.com/@formdown/ui@latest/dist/standalone.js"></script>'
+            not in html_document
+        )
+
+
 class TestGithubStyleLinks:
     def test_relative_link_renders_with_normalized_path(self):
         fragment = _render_fragment("Navigate to [[About]] for details.")


### PR DESCRIPTION
## Summary
- convert ```formdown``` fenced code blocks into `<formdown-ui>` components during markdown rendering
- automatically add the Formdown standalone script to the document head whenever a formdown block is present
- add unit tests that cover the new rendering behavior and script injection safeguards

## Testing
- pytest test_markdown_rendering.py

------
https://chatgpt.com/codex/tasks/task_b_68d7e7879b3c8331822dab18d03bea9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add Markdown support for formdown code fences, rendering them as embedded Formdown UI components.
  - Automatically include the Formdown UI script when formdown content is present.
  - Ensure correct HTML structure by removing stray paragraph wrappers around inserted components.
- Tests
  - Added tests verifying component rendering, conditional script inclusion, and that plain Markdown and GitHub-style links remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->