### PR TITLE
Add flexible alias matching with testing tools

### DIFF
--- a/alias_matching.py
+++ b/alias_matching.py
@@ -1,0 +1,167 @@
+"""Utilities for validating and matching alias patterns."""
+from __future__ import annotations
+
+import fnmatch
+import re
+from typing import Iterable
+
+from werkzeug.exceptions import MethodNotAllowed, NotFound
+from werkzeug.routing import Map, Rule
+
+
+class PatternError(ValueError):
+    """Raised when an alias pattern cannot be normalised."""
+
+
+_TYPE_PRIORITY = {
+    "literal": 0,
+    "flask": 1,
+    "glob": 2,
+    "regex": 3,
+}
+
+
+def _ensure_leading_slash(value: str) -> str:
+    """Return the value with a single leading slash."""
+
+    if not value:
+        return "/"
+    return "/" + value.lstrip("/")
+
+
+def normalise_pattern(match_type: str, pattern: str | None, fallback_name: str | None = None) -> str:
+    """Return a cleaned version of the provided pattern or raise PatternError."""
+
+    match_type = (match_type or "literal").lower()
+    raw_pattern = (pattern or "").strip()
+    fallback_name = (fallback_name or "").strip()
+
+    if match_type == "literal":
+        if not raw_pattern:
+            if not fallback_name:
+                raise PatternError("Literal aliases require a pattern or name.")
+            raw_pattern = fallback_name
+        if "\n" in raw_pattern:
+            raise PatternError("Literal patterns must be a single line.")
+        return _ensure_leading_slash(raw_pattern)
+
+    if match_type == "glob":
+        if not raw_pattern:
+            raise PatternError("Glob aliases require a pattern.")
+        # fnmatch handles validation implicitly; translate will raise for invalid groups.
+        fnmatch.translate(raw_pattern)
+        return _ensure_leading_slash(raw_pattern)
+
+    if match_type == "regex":
+        if not raw_pattern:
+            raise PatternError("Regular expression aliases require a pattern.")
+        try:
+            re.compile(raw_pattern)
+        except re.error as exc:  # pragma: no cover - defensive guard
+            raise PatternError(f"Invalid regular expression: {exc}") from exc
+        return raw_pattern
+
+    if match_type == "flask":
+        if not raw_pattern:
+            raise PatternError("Flask-style aliases require a pattern.")
+        cleaned = _ensure_leading_slash(raw_pattern)
+        try:
+            Rule(cleaned)
+        except Exception as exc:  # pragma: no cover - werkzeug provides descriptive errors
+            raise PatternError(f"Invalid Flask pattern: {exc}") from exc
+        return cleaned
+
+    raise PatternError(f"Unknown match type: {match_type}")
+
+
+def matches_path(match_type: str, pattern: str, path: str, ignore_case: bool = False) -> bool:
+    """Return True when the given path satisfies the pattern for the match type."""
+
+    if not path:
+        return False
+
+    match_type = (match_type or "literal").lower()
+    candidate = path if path.startswith("/") else "/" + path
+
+    if match_type == "literal":
+        cleaned_pattern = _ensure_leading_slash(pattern)
+        prefix = cleaned_pattern.rstrip("/") or "/"
+        if ignore_case:
+            candidate_cf = candidate.casefold()
+            pattern_cf = cleaned_pattern.casefold()
+            prefix_cf = prefix.casefold()
+            if candidate_cf == pattern_cf or candidate_cf == prefix_cf:
+                return True
+            if prefix_cf != "/" and candidate_cf.startswith(prefix_cf + "/"):
+                return True
+            return False
+        if candidate == cleaned_pattern or candidate == prefix:
+            return True
+        if prefix != "/" and candidate.startswith(prefix + "/"):
+            return True
+        return False
+
+    if match_type == "glob":
+        cleaned_pattern = _ensure_leading_slash(pattern)
+        translated = fnmatch.translate(cleaned_pattern)
+        flags = re.IGNORECASE if ignore_case else 0
+        compiled = re.compile(translated, flags)
+        return compiled.fullmatch(candidate) is not None
+
+    if match_type == "regex":
+        flags = re.IGNORECASE if ignore_case else 0
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error:
+            return False
+        return compiled.fullmatch(candidate) is not None
+
+    if match_type == "flask":
+        cleaned_pattern = _ensure_leading_slash(pattern)
+        try:
+            url_map = Map([Rule(cleaned_pattern)])
+            adapter = url_map.bind("", url_scheme="http")
+            adapter.match(candidate, method="GET")
+        except (NotFound, MethodNotAllowed):
+            return False
+        except Exception:  # pragma: no cover - defensive guard
+            return False
+        return True
+
+    return False
+
+
+def alias_sort_key(match_type: str, pattern: str) -> tuple[int, int]:
+    """Return a tuple for consistent alias prioritisation during matching."""
+
+    match_type = (match_type or "literal").lower()
+    priority = _TYPE_PRIORITY.get(match_type, len(_TYPE_PRIORITY))
+    return (priority, -len(pattern or ""))
+
+
+def evaluate_test_strings(
+    match_type: str,
+    pattern: str,
+    values: Iterable[str],
+    ignore_case: bool = False,
+) -> list[tuple[str, bool]]:
+    """Return the evaluation results for the provided set of values."""
+
+    results: list[tuple[str, bool]] = []
+    for raw_value in values:
+        value = raw_value.strip()
+        if not value:
+            continue
+        candidate = value if value.startswith("/") else "/" + value
+        matches = matches_path(match_type, pattern, candidate, ignore_case)
+        results.append((raw_value, matches))
+    return results
+
+
+__all__ = [
+    "PatternError",
+    "alias_sort_key",
+    "evaluate_test_strings",
+    "matches_path",
+    "normalise_pattern",
+]

--- a/app.py
+++ b/app.py
@@ -50,32 +50,30 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
 
     app.register_blueprint(main_bp)
     app.register_blueprint(local_auth_bp, url_prefix="/auth")
-    
+
     # Register error handlers that work even in debug mode
     from routes.core import internal_error, not_found_error
-    
+
     # Force registration of custom error handlers even in debug mode
     # This ensures our enhanced error pages with source links always work
     app.register_error_handler(500, internal_error)
     app.register_error_handler(404, not_found_error)
-    
+
     # Override Flask's debug mode error handling to use our custom handlers
     # This is necessary because Flask's debug mode bypasses custom error handlers
     def force_custom_error_handling():
         """Force Flask to use our custom error handlers even in debug mode."""
-        original_handle_exception = app.handle_exception
-        
         def enhanced_handle_exception(e):
             # Always use our custom error handlers, even in debug mode
             if hasattr(e, 'code') and e.code == 404:
                 return not_found_error(e)
             else:
                 return internal_error(e)
-        
+
         # Only override in debug mode to preserve normal behavior in production
         if app.debug:
             app.handle_exception = enhanced_handle_exception
-    
+
     force_custom_error_handling()
 
     # Register Replit auth if available

--- a/app.py
+++ b/app.py
@@ -50,6 +50,33 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
 
     app.register_blueprint(main_bp)
     app.register_blueprint(local_auth_bp, url_prefix="/auth")
+    
+    # Register error handlers that work even in debug mode
+    from routes.core import internal_error, not_found_error
+    
+    # Force registration of custom error handlers even in debug mode
+    # This ensures our enhanced error pages with source links always work
+    app.register_error_handler(500, internal_error)
+    app.register_error_handler(404, not_found_error)
+    
+    # Override Flask's debug mode error handling to use our custom handlers
+    # This is necessary because Flask's debug mode bypasses custom error handlers
+    def force_custom_error_handling():
+        """Force Flask to use our custom error handlers even in debug mode."""
+        original_handle_exception = app.handle_exception
+        
+        def enhanced_handle_exception(e):
+            # Always use our custom error handlers, even in debug mode
+            if hasattr(e, 'code') and e.code == 404:
+                return not_found_error(e)
+            else:
+                return internal_error(e)
+        
+        # Only override in debug mode to preserve normal behavior in production
+        if app.debug:
+            app.handle_exception = enhanced_handle_exception
+    
+    force_custom_error_handling()
 
     # Register Replit auth if available
     try:

--- a/debug_error_page.py
+++ b/debug_error_page.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Debug script to examine actual error page HTML output."""
+
+from app import create_app
+from database import db
+
+def debug_error_page():
+    """Generate and examine error page HTML."""
+    app = create_app({
+        'TESTING': True,
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'WTF_CSRF_ENABLED': False,
+    })
+    
+    with app.app_context():
+        db.create_all()
+        
+        with app.test_request_context('/debug-error'):
+            try:
+                # Import some project modules to get them in traceback
+                from routes.core import _build_stack_trace
+                from routes.source import _get_comprehensive_paths
+                from routes.aliases import _alias_name_conflicts_with_routes
+                
+                # Create an error with a good traceback
+                raise RuntimeError('Debug error for examining HTML output')
+            except RuntimeError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                print(f"Status Code: {status_code}")
+                print("=" * 80)
+                print("HTML Content:")
+                print("=" * 80)
+                print(html_content)
+                print("=" * 80)
+                
+                # Check for specific elements
+                print("\nChecking for specific elements:")
+                print(f"Contains 'RuntimeError': {'RuntimeError' in html_content}")
+                print(f"Contains 'Debug error': {'Debug error' in html_content}")
+                print(f"Contains 'href=\"/source/': {'href=\"/source/' in html_content}")
+                print(f"Contains '>>>': {'>>>' in html_content}")
+                print(f"Contains 'Stack trace': {'Stack trace' in html_content}")
+                print(f"Contains 'target=\"_blank\"': {'target=\"_blank\"' in html_content}")
+                
+                # Look for source links
+                import re
+                source_links = re.findall(r'href="/source/([^"]+)"', html_content)
+                print(f"\nFound {len(source_links)} source links:")
+                for link in source_links:
+                    print(f"  - /source/{link}")
+
+if __name__ == '__main__':
+    debug_error_page()

--- a/debug_error_page.py
+++ b/debug_error_page.py
@@ -18,9 +18,6 @@ def debug_error_page():
         with app.test_request_context('/debug-error'):
             try:
                 # Import some project modules to get them in traceback
-                from routes.core import _build_stack_trace
-                from routes.source import _get_comprehensive_paths
-                from routes.aliases import _alias_name_conflicts_with_routes
                 
                 # Create an error with a good traceback
                 raise RuntimeError('Debug error for examining HTML output')

--- a/routes/core.py
+++ b/routes/core.py
@@ -59,18 +59,21 @@ def _extract_exception(error: Exception) -> Exception:
 
 
 def _build_stack_trace(error: Exception) -> List[Dict[str, Any]]:
-    """Build stack trace metadata with optional /source links."""
+    """Build comprehensive stack trace metadata with /source links for all project files."""
 
     def _determine_relative_path(
         absolute_path: Path,
         root_path: Path,
         tracked_paths: frozenset[str],
     ) -> Optional[str]:
+        # First try to get relative path from project root
         try:
-            return absolute_path.relative_to(root_path).as_posix()
+            relative = absolute_path.relative_to(root_path).as_posix()
+            return relative
         except ValueError:
             pass
 
+        # Fallback: check if path ends with any tracked path
         normalized = absolute_path.as_posix()
         best_match: Optional[str] = None
         for tracked in tracked_paths:
@@ -79,45 +82,150 @@ def _build_stack_trace(error: Exception) -> List[Dict[str, Any]]:
                     best_match = tracked
         return best_match
 
-    exception = _extract_exception(error)
-    traceback_obj = getattr(exception, "__traceback__", None)
-    if traceback_obj is None:
-        return []
+    def _should_create_source_link(relative_path: str, root_path: Path) -> bool:
+        """Determine if we should create a source link for this file."""
+        if not relative_path:
+            return False
+        
+        # Create links for ALL files within the project directory, not just git-tracked ones
+        full_path = root_path / relative_path
+        try:
+            # Check if file exists and is within project bounds
+            resolved_path = full_path.resolve()
+            resolved_root = root_path.resolve()
+            if full_path.exists() and resolved_root in resolved_path.parents:
+                return True
+        except (OSError, ValueError):
+            pass
+        
+        return False
 
+    def _get_all_project_files(root_path: Path) -> frozenset[str]:
+        """Get all Python files in the project directory for comprehensive source linking."""
+        project_files = set()
+        try:
+            # Get all .py files recursively
+            for py_file in root_path.rglob("*.py"):
+                try:
+                    relative = py_file.relative_to(root_path).as_posix()
+                    project_files.add(relative)
+                except ValueError:
+                    continue
+            
+            # Also add other common source files
+            for pattern in ["*.html", "*.js", "*.css", "*.json", "*.md", "*.txt", "*.yml", "*.yaml"]:
+                for file in root_path.rglob(pattern):
+                    try:
+                        relative = file.relative_to(root_path).as_posix()
+                        project_files.add(relative)
+                    except ValueError:
+                        continue
+        except Exception:
+            pass
+        
+        return frozenset(project_files)
+
+    def _get_exception_chain(exc: Exception) -> List[Exception]:
+        """Get the full chain of exceptions including __cause__ and __context__."""
+        exceptions = []
+        current = exc
+        seen = set()
+        
+        while current and id(current) not in seen:
+            seen.add(id(current))
+            exceptions.append(current)
+            
+            # Follow __cause__ first (explicit chaining), then __context__ (implicit)
+            current = getattr(current, '__cause__', None) or getattr(current, '__context__', None)
+        
+        return exceptions
+
+    # Get the primary exception and build comprehensive trace
+    exception = _extract_exception(error)
+    exception_chain = _get_exception_chain(exception)
+    
     root_path = Path(current_app.root_path).resolve()
 
+    # Get both git-tracked paths and all project files for comprehensive coverage
     try:
         from .source import _get_tracked_paths
-
         tracked_paths = _get_tracked_paths(current_app.root_path)
     except Exception:  # pragma: no cover - defensive fallback when git unavailable
         tracked_paths = frozenset()
+    
+    # Get all project files to ensure comprehensive source link coverage
+    all_project_files = _get_all_project_files(root_path)
+    # Combine tracked and all project files
+    comprehensive_paths = tracked_paths | all_project_files
 
     frames: List[Dict[str, Any]] = []
-    for frame in traceback.extract_tb(traceback_obj):
-        try:
-            absolute_path = Path(frame.filename).resolve()
-        except OSError:
-            absolute_path = Path(frame.filename)
+    
+    # Process each exception in the chain
+    for exc_index, exc in enumerate(exception_chain):
+        traceback_obj = getattr(exc, "__traceback__", None)
+        if traceback_obj is None:
+            continue
+            
+        # Add separator for chained exceptions (except for the first one)
+        if exc_index > 0:
+            frames.append({
+                "display_path": "--- Exception Chain ---",
+                "lineno": 0,
+                "function": f"Caused by: {type(exc).__name__}",
+                "code": str(exc) if str(exc) else None,
+                "source_link": None,
+                "is_separator": True,
+            })
 
-        source_link = None
-        display_path = frame.filename
+        # Extract frames from this exception's traceback
+        for frame in traceback.extract_tb(traceback_obj):
+            try:
+                absolute_path = Path(frame.filename).resolve()
+            except OSError:
+                absolute_path = Path(frame.filename)
 
-        relative_path = _determine_relative_path(absolute_path, root_path, tracked_paths)
-        if relative_path:
-            display_path = relative_path
-            if not tracked_paths or relative_path in tracked_paths:
-                source_link = f"/source/{relative_path}"
+            source_link = None
+            display_path = frame.filename
 
-        frames.append(
-            {
-                "display_path": display_path,
-                "lineno": frame.lineno,
-                "function": frame.name,
-                "code": frame.line,
-                "source_link": source_link,
-            }
-        )
+            relative_path = _determine_relative_path(absolute_path, root_path, comprehensive_paths)
+            if relative_path:
+                display_path = relative_path
+                # Create source links for ALL project files, not just git-tracked ones
+                if _should_create_source_link(relative_path, root_path):
+                    source_link = f"/source/{relative_path}"
+
+            # Get more context around the error line if possible (5 lines instead of 2)
+            code_context = frame.line
+            try:
+                if frame.line and absolute_path.exists():
+                    # Try to get more lines of context around the error
+                    with open(absolute_path, 'r', encoding='utf-8') as f:
+                        lines = f.readlines()
+                        if 0 < frame.lineno <= len(lines):
+                            # Get 5 lines before and after for better context
+                            start_line = max(0, frame.lineno - 6)
+                            end_line = min(len(lines), frame.lineno + 5)
+                            context_lines = []
+                            for i in range(start_line, end_line):
+                                line_num = i + 1
+                                line_content = lines[i].rstrip()
+                                marker = ">>> " if line_num == frame.lineno else "    "
+                                context_lines.append(f"{marker}{line_num:4d}: {line_content}")
+                            code_context = "\n".join(context_lines)
+            except (OSError, UnicodeDecodeError, IndexError):
+                # Fall back to the original line if we can't read context
+                pass
+
+            frames.append(
+                {
+                    "display_path": display_path,
+                    "lineno": frame.lineno,
+                    "function": frame.name,
+                    "code": code_context,
+                    "source_link": source_link,
+                    "is_separator": False,
+                }
+            )
 
     return frames
 
@@ -208,8 +316,9 @@ def plans():
 
 @main_bp.route('/terms')
 def terms():
-    """Display terms and conditions."""
+    """Terms of service page."""
     return render_template('terms.html', current_version=CURRENT_TERMS_VERSION)
+
 
 
 @main_bp.route('/privacy')
@@ -351,7 +460,6 @@ def get_existing_routes():
     }
 
 
-@main_bp.app_errorhandler(404)
 def not_found_error(error):
     """Custom 404 handler that checks CID table and server names for content."""
     path = request.path
@@ -384,18 +492,63 @@ def not_found_error(error):
     return render_template('404.html', path=path), 404
 
 
-@main_bp.app_errorhandler(500)
 def internal_error(error):
+    """Enhanced 500 error handler with comprehensive stack trace reporting."""
     db.session.rollback()
-    stack_trace = _build_stack_trace(error)
-    exception = _extract_exception(error)
+    
+    # Always try to build a comprehensive stack trace
+    stack_trace = []
+    exception = None
+    exception_type = "Unknown Error"
+    exception_message = "An unexpected error occurred"
+    
+    try:
+        exception = _extract_exception(error)
+        exception_type = type(exception).__name__
+        exception_message = str(exception) if str(exception) else "No error message available"
+        stack_trace = _build_stack_trace(error)
+    except Exception as trace_error:
+        # If stack trace building fails, create a minimal fallback
+        try:
+            import traceback
+            import sys
+            
+            # Get the current exception info
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            if exc_traceback:
+                # Create a basic stack trace as fallback
+                stack_trace = [{
+                    "display_path": "Error in stack trace generation",
+                    "lineno": 0,
+                    "function": "internal_error",
+                    "code": f"Stack trace generation failed: {trace_error}\n\nOriginal error: {error}",
+                    "source_link": None,
+                    "is_separator": False,
+                }]
+            
+            # Try to get basic info about the original error
+            if not exception:
+                exception = error
+                exception_type = type(error).__name__
+                exception_message = str(error) if str(error) else "Error occurred during error handling"
+                
+        except Exception:
+            # Ultimate fallback - just show basic error info
+            stack_trace = [{
+                "display_path": "Critical error handling failure",
+                "lineno": 0,
+                "function": "internal_error",
+                "code": f"Both original error and error handling failed.\nOriginal error: {error}",
+                "source_link": None,
+                "is_separator": False,
+            }]
 
     return (
         render_template(
             '500.html',
             stack_trace=stack_trace,
-            exception_type=type(exception).__name__,
-            exception_message=str(exception),
+            exception_type=exception_type,
+            exception_message=exception_message,
         ),
         500,
     )

--- a/routes/core.py
+++ b/routes/core.py
@@ -510,7 +510,6 @@ def internal_error(error):
     except Exception as trace_error:
         # If stack trace building fails, create a minimal fallback
         try:
-            import traceback
             import sys
             
             # Get the current exception info

--- a/templates/500.html
+++ b/templates/500.html
@@ -19,27 +19,70 @@
 
             {% if stack_trace %}
                 <div class="card">
-                    <div class="card-header bg-light">
-                        <strong>Exception:</strong> {{ exception_type }}{% if exception_message %}: {{ exception_message }}{% endif %}
+                    <div class="card-header bg-danger text-white">
+                        <h5 class="mb-0">
+                            <i class="fas fa-bug me-2"></i>
+                            <strong>Exception:</strong> {{ exception_type }}{% if exception_message %}: {{ exception_message }}{% endif %}
+                        </h5>
                     </div>
                     <div class="card-body">
+                        <div class="mb-3">
+                            <small class="text-muted">
+                                <i class="fas fa-info-circle me-1"></i>
+                                Stack trace with source links (most recent call last):
+                            </small>
+                        </div>
                         <ol class="mb-0 ps-3">
                             {% for frame in stack_trace %}
-                                <li class="mb-3">
-                                    <div class="mb-1">
-                                        {% if frame.source_link %}
-                                            <a href="{{ frame.source_link }}"><code>{{ frame.display_path }}</code></a>
-                                        {% else %}
-                                            <code>{{ frame.display_path }}</code>
+                                {% if frame.is_separator %}
+                                    <li class="mb-3 list-unstyled">
+                                        <div class="border-top pt-2 mt-2">
+                                            <div class="text-warning fw-bold">
+                                                <i class="fas fa-link me-1"></i>
+                                                {{ frame.display_path }}
+                                            </div>
+                                            <div class="text-muted small">{{ frame.function }}</div>
+                                            {% if frame.code %}
+                                                <div class="mt-1 text-warning small">{{ frame.code }}</div>
+                                            {% endif %}
+                                        </div>
+                                    </li>
+                                {% else %}
+                                    <li class="mb-3">
+                                        <div class="mb-1">
+                                            {% if frame.source_link %}
+                                                <a href="{{ frame.source_link }}" class="text-decoration-none" target="_blank">
+                                                    <i class="fas fa-external-link-alt me-1 text-primary"></i>
+                                                    <code class="text-primary">{{ frame.display_path }}</code>
+                                                </a>
+                                            {% else %}
+                                                <code class="text-muted">{{ frame.display_path }}</code>
+                                            {% endif %}
+                                            <span class="text-muted ms-2">
+                                                in <strong>{{ frame.function }}</strong> at line <strong>{{ frame.lineno }}</strong>
+                                            </span>
+                                        </div>
+                                        {% if frame.code %}
+                                            <pre class="bg-light p-3 rounded border-start border-3 border-primary"><code>{{ frame.code | e }}</code></pre>
                                         {% endif %}
-                                        <span class="text-muted">in {{ frame.function }} at line {{ frame.lineno }}</span>
-                                    </div>
-                                    {% if frame.code %}
-                                        <pre class="bg-light p-2 rounded"><code>{{ frame.code | e }}</code></pre>
-                                    {% endif %}
-                                </li>
+                                    </li>
+                                {% endif %}
                             {% endfor %}
                         </ol>
+                        <div class="mt-4 p-3 bg-info bg-opacity-10 rounded">
+                            <div class="d-flex align-items-start">
+                                <i class="fas fa-lightbulb text-info me-2 mt-1"></i>
+                                <div>
+                                    <strong class="text-info">Debugging Tips:</strong>
+                                    <ul class="mb-0 mt-1 small">
+                                        <li>Click the <i class="fas fa-external-link-alt"></i> links to view source code</li>
+                                        <li>The <code>>>> </code> marker shows the exact line where the error occurred</li>
+                                        <li>Exception chains show the full error propagation path</li>
+                                        <li>Check the most recent call (bottom of stack) first</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             {% endif %}

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -53,11 +53,87 @@
                             {% endif %}
                         </div>
 
-                        <div class="d-flex justify-content-between">
+                        <div class="mb-3">
+                            <label class="form-label">{{ form.match_type.label.text }}</label>
+                            <div class="btn-group" role="group" aria-label="Alias match type">
+                                {% for subfield in form.match_type %}
+                                <input type="radio"
+                                       class="btn-check"
+                                       name="{{ form.match_type.name }}"
+                                       id="match-type-{{ loop.index }}"
+                                       value="{{ subfield._value() }}"
+                                       {% if subfield.checked %}checked{% endif %}>
+                                <label class="btn btn-outline-primary" for="match-type-{{ loop.index }}">{{ subfield.label.text }}</label>
+                                {% endfor %}
+                            </div>
+                            {% if form.match_type.errors %}
+                                <div class="text-danger small mt-1">
+                                    {% for error in form.match_type.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">
+                                    Choose how the alias pattern is matched. Literal matches behave like the original aliases.
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-3">
+                            {{ form.match_pattern.label(class="form-label") }}
+                            {{ form.match_pattern(class="form-control" + (" is-invalid" if form.match_pattern.errors else "")) }}
+                            {% if form.match_pattern.errors %}
+                                <div class="invalid-feedback">
+                                    {% for error in form.match_pattern.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <div class="form-text">
+                                    Patterns are matched against request paths starting with <code>/</code>. Glob patterns support <code>*</code>, <code>?</code>, and <code>**</code>. Flask patterns accept converters like <code>&lt;username&gt;</code>.
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <div class="form-check form-switch mb-3">
+                            {{ form.ignore_case(class="form-check-input", role="switch") }}
+                            {{ form.ignore_case.label(class="form-check-label") }}
+                        </div>
+
+                        <div class="mb-3">
+                            {{ form.test_strings.label(class="form-label") }}
+                            {{ form.test_strings(class="form-control") }}
+                            <div class="form-text">Enter one path per line to try the current configuration without saving.</div>
+                        </div>
+
+                        {% if test_results %}
+                        <div class="mb-3">
+                            <div class="alert alert-secondary mb-0">
+                                <h6 class="alert-heading">Test Results</h6>
+                                <ul class="list-unstyled mb-0 small">
+                                    {% for value, matches in test_results %}
+                                    <li>
+                                        {% if matches %}
+                                            <span class="badge bg-success me-2"><i class="fas fa-check"></i></span>
+                                        {% else %}
+                                            <span class="badge bg-danger me-2"><i class="fas fa-times"></i></span>
+                                        {% endif %}
+                                        <code>{{ value.strip() }}</code>
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                        {% endif %}
+
+                        <div class="d-flex justify-content-between align-items-center">
                             <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            {{ form.submit(class="btn btn-primary") }}
+                            <div class="d-flex gap-2">
+                                {{ form.test_pattern(class="btn btn-outline-primary") }}
+                                {{ form.submit(class="btn btn-primary") }}
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -30,6 +30,15 @@
                         <dt class="col-sm-3">Redirect Path</dt>
                         <dd class="col-sm-9"><code>{{ alias.target_path }}</code></dd>
 
+                        <dt class="col-sm-3">Match Pattern</dt>
+                        <dd class="col-sm-9"><code>{{ alias.match_pattern }}</code></dd>
+
+                        <dt class="col-sm-3">Match Type</dt>
+                        <dd class="col-sm-9 text-capitalize">{{ alias.match_type }}</dd>
+
+                        <dt class="col-sm-3">Ignore Case</dt>
+                        <dd class="col-sm-9">{{ 'Yes' if alias.ignore_case else 'No' }}</dd>
+
                         <dt class="col-sm-3">Public URL</dt>
                         <dd class="col-sm-9"><code>{{ request.url_root }}{{ alias.name }}</code></dd>
                     </dl>

--- a/templates/aliases.html
+++ b/templates/aliases.html
@@ -19,6 +19,7 @@
                     <thead class="table-light">
                         <tr>
                             <th scope="col">Name</th>
+                            <th scope="col">Match</th>
                             <th scope="col">Target</th>
                             <th scope="col" class="text-end">Actions</th>
                         </tr>
@@ -29,6 +30,10 @@
                             <td class="fw-semibold">
                                 <span class="badge bg-secondary me-2">/{{ alias.name }}</span>
                                 {{ alias.name }}
+                            </td>
+                            <td>
+                                <div><code>{{ alias.match_pattern }}</code></div>
+                                <div class="small text-muted text-capitalize">{{ alias.match_type }}{% if alias.ignore_case %} · ignore case{% endif %}</div>
                             </td>
                             <td><code>{{ alias.target_path }}</code></td>
                             <td class="text-end">

--- a/test_enhanced_error_pages.py
+++ b/test_enhanced_error_pages.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Test script to verify enhanced error page functionality with comprehensive source links."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import tempfile
+import os
+
+from app import create_app
+from database import db
+from routes.core import internal_error, _build_stack_trace
+from routes.source import _get_all_project_files, _get_comprehensive_paths
+
+
+class TestEnhancedErrorPageIntegration(unittest.TestCase):
+    """Integration tests for enhanced error page system."""
+
+    def setUp(self):
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+            'WTF_CSRF_ENABLED': False,
+        })
+        self.app.config['PROPAGATE_EXCEPTIONS'] = False
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_aliases_route_error_shows_comprehensive_source_links(self):
+        """Test that error pages show comprehensive source links for all project files."""
+        with self.app.test_request_context('/test'):
+            try:
+                # Create a simple error that will have this test file in the traceback
+                raise RuntimeError('Test error for comprehensive source links')
+            except RuntimeError as exc:
+                response, status = internal_error(exc)
+                
+                self.assertEqual(status, 500)
+                
+                # Verify the error page contains basic error info
+                self.assertIn('RuntimeError', response)
+                self.assertIn('Test error for comprehensive source links', response)
+                
+                # Should have source link to this test file
+                self.assertIn('href="/source/test_enhanced_error_pages.py"', response)
+                
+                # Should show enhanced code context with >>> markers
+                self.assertIn('>>>', response)
+                
+                # Verify the enhanced error page structure
+                self.assertIn('Stack trace with source links', response)
+                self.assertIn('target="_blank"', response)  # Links should open in new tab
+
+    def test_comprehensive_file_discovery_includes_all_project_files(self):
+        """Test that comprehensive file discovery includes all project files, not just git-tracked."""
+        with self.app.app_context():
+            comprehensive_paths = _get_comprehensive_paths(self.app.root_path)
+            
+            # Should include Python files
+            self.assertTrue(any('routes/aliases.py' in path for path in comprehensive_paths))
+            self.assertTrue(any('routes/core.py' in path for path in comprehensive_paths))
+            
+            # Should include template files
+            self.assertTrue(any('.html' in path for path in comprehensive_paths))
+            
+            # Should include this test file
+            self.assertTrue(any('test_enhanced_error_pages.py' in path for path in comprehensive_paths))
+
+    def test_error_page_template_renders_with_source_links(self):
+        """Test that the 500.html template properly renders source links."""
+        with self.app.test_request_context('/test'):
+            try:
+                # Create a traceback that includes multiple project files
+                raise ValueError('Test error for template rendering')
+            except ValueError as exc:
+                response, status = internal_error(exc)
+
+        self.assertEqual(status, 500)
+        
+        # Check for proper HTML structure
+        self.assertIn('<div class="card-header bg-danger text-white">', response)
+        self.assertIn('<i class="fas fa-bug me-2"></i>', response)
+        self.assertIn('Exception:', response)
+        self.assertIn('ValueError', response)
+        
+        # Check for source link icons and styling
+        self.assertIn('<i class="fas fa-external-link-alt me-1 text-primary"></i>', response)
+        self.assertIn('target="_blank"', response)
+        
+        # Check for debugging tips section
+        self.assertIn('Debugging Tips:', response)
+        self.assertIn('Click the', response)
+        self.assertIn('links to view source code', response)
+
+    def test_exception_chain_display_with_separators(self):
+        """Test that exception chains are displayed with proper visual separators."""
+        with self.app.app_context():
+            try:
+                try:
+                    raise ValueError('Original error')
+                except ValueError as e:
+                    raise RuntimeError('Chained error') from e
+            except RuntimeError as exc:
+                frames = _build_stack_trace(exc)
+
+        # Should have separator frames for exception chain
+        separator_frames = [f for f in frames if f.get('is_separator', False)]
+        self.assertTrue(len(separator_frames) > 0)
+        
+        # Check separator styling and content
+        separator = separator_frames[0]
+        self.assertIn('Exception Chain', separator['display_path'])
+        self.assertIn('ValueError', separator['function'])
+        self.assertIsNone(separator['source_link'])
+
+    def test_source_browser_serves_comprehensive_files(self):
+        """Test that source browser can serve files discovered by comprehensive file discovery."""
+        with self.app.test_client() as client:
+            # Test accessing a Python file
+            response = client.get('/source/routes/aliases.py')
+            self.assertIn(response.status_code, [200, 302])  # 200 for file, 302 for redirect to login
+            
+            # Test accessing a template file
+            response = client.get('/source/templates/500.html')
+            self.assertIn(response.status_code, [200, 302])
+
+    def test_error_handling_robustness(self):
+        """Test that error handling is robust even when stack trace building fails."""
+        with self.app.test_request_context('/test'):
+            # Mock _build_stack_trace to fail
+            with patch('routes.core._build_stack_trace', side_effect=Exception('Stack trace building failed')):
+                try:
+                    raise ValueError('Original error')
+                except ValueError as exc:
+                    response, status = internal_error(exc)
+
+        self.assertEqual(status, 500)
+        
+        # Should still show basic error information
+        self.assertIn('ValueError', response)
+        self.assertIn('Original error', response)
+        
+        # Should show fallback error information
+        self.assertIn('Stack trace generation failed', response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_enhanced_error_pages.py
+++ b/test_enhanced_error_pages.py
@@ -2,15 +2,12 @@
 """Test script to verify enhanced error page functionality with comprehensive source links."""
 
 import unittest
-from unittest.mock import patch, MagicMock
-from pathlib import Path
-import tempfile
-import os
+from unittest.mock import patch
 
 from app import create_app
 from database import db
 from routes.core import internal_error, _build_stack_trace
-from routes.source import _get_all_project_files, _get_comprehensive_paths
+from routes.source import _get_comprehensive_paths
 
 
 class TestEnhancedErrorPageIntegration(unittest.TestCase):

--- a/test_error_page_source_links.py
+++ b/test_error_page_source_links.py
@@ -1,0 +1,474 @@
+"""Test that error pages show proper source links for all project files in stack traces."""
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+import re
+from pathlib import Path
+
+from app import create_app
+from database import db
+from models import User
+
+
+class TestErrorPageSourceLinks(unittest.TestCase):
+    """Test that error pages include proper source links in stack traces."""
+
+    def setUp(self):
+        """Set up test environment."""
+        # Skip tests if app is mocked (during unittest discover)
+        from app import create_app as app_factory
+        app = app_factory()
+        if isinstance(app, Mock):
+            self.skipTest("Skipping due to mocked app during unittest discover")
+            
+        self.app = app
+        self.app.config['TESTING'] = True
+        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        
+        self.client = self.app.test_client()
+        
+        with self.app.app_context():
+            db.create_all()
+            
+            # Create a test user
+            self.test_user = User(
+                id='test_user_123',
+                email='test@example.com',
+                first_name='Test',
+                last_name='User'
+            )
+            db.session.add(self.test_user)
+            db.session.commit()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        if hasattr(self, 'app'):
+            with self.app.app_context():
+                db.session.remove()
+                db.drop_all()
+
+    def test_aliases_error_shows_source_links_in_stack_trace(self):
+        """Test that when aliases page throws an error, the error page shows source links."""
+        with self.app.test_request_context('/aliases'):
+            try:
+                # Mock the get_user_aliases function to raise a database error similar to the real issue
+                with patch('db_access.get_user_aliases') as mock_get_aliases:
+                    with patch('flask_login.current_user') as mock_current_user:
+                        # Mock authentication
+                        mock_current_user.is_authenticated = True
+                        mock_current_user.id = 'test_user_123'
+                        
+                        # Simulate the SQLAlchemy OperationalError that occurs in the real scenario
+                        from sqlalchemy.exc import OperationalError
+                        import sqlite3
+                        
+                        # Create a realistic database error like the one in the stack trace
+                        sqlite_error = sqlite3.OperationalError("no such column: alias.match_type")
+                        sqlalchemy_error = OperationalError(
+                            "SELECT alias.id AS alias_id, alias.name AS alias_name, alias.target_path AS alias_target_path, alias.match_type AS alias_match_type, alias.match_pattern AS alias_match_pattern, alias.ignore_case AS alias_ignore_case, alias.user_id AS alias_user_id, alias.created_at AS alias_created_at, alias.updated_at AS alias_updated_at \nFROM alias \nWHERE alias.user_id = ? ORDER BY alias.name",
+                            {'user_id': 'test_user_123'},
+                            sqlite_error
+                        )
+                        mock_get_aliases.side_effect = sqlalchemy_error
+                        
+                        # Import the aliases function to get it in the traceback
+                        from routes.aliases import aliases
+                        
+                        # This should raise the error
+                        aliases()
+                        
+            except Exception as exc:
+                # Call the error handler directly
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Check that we have a stack trace section
+                self.assertIn('Stack trace with source links', html_content)
+                
+                # Check that we have source links for project files
+                # The error should show links to routes/aliases.py and db_access.py
+                self.assertIn('href="/source/routes/aliases.py"', html_content, 
+                             "Should have source link to routes/aliases.py")
+                self.assertIn('href="/source/db_access.py"', html_content,
+                             "Should have source link to db_access.py")
+                
+                # Check for external link icons
+                self.assertIn('fas fa-external-link-alt', html_content,
+                             "Should have external link icons for source links")
+                
+                # Check that links open in new tab
+                self.assertIn('target="_blank"', html_content,
+                             "Source links should open in new tab")
+                
+                # Verify we have the enhanced code context with >>> markers
+                self.assertIn('>>>', html_content,
+                             "Should show enhanced code context with >>> error markers")
+
+    def test_debug_mode_now_uses_custom_error_handler(self):
+        """Test that our fix allows custom error handlers to work in debug mode."""
+        # Create an app in debug mode (like the real scenario)
+        debug_app = create_app({'TESTING': True, 'DEBUG': True})
+        
+        with debug_app.test_request_context('/test-error'):
+            # Test the error handler directly to verify it works in debug mode
+            try:
+                # Create a realistic error
+                from sqlalchemy.exc import OperationalError
+                import sqlite3
+                
+                sqlite_error = sqlite3.OperationalError("no such column: alias.match_type")
+                sqlalchemy_error = OperationalError(
+                    "SELECT alias.id AS alias_id, alias.name AS alias_name, alias.target_path AS alias_target_path, alias.match_type AS alias_match_type",
+                    {'user_id': 'test_user_123'},
+                    sqlite_error
+                )
+                
+                # Raise the error to create a proper traceback
+                raise sqlalchemy_error
+                
+            except Exception as exc:
+                # Call our custom error handler directly
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                # Should get 500 status
+                self.assertEqual(status_code, 500)
+                
+                # Should have our custom error page with source links
+                self.assertIn('Stack trace with source links', html_content,
+                             "Should show our custom error page with source links")
+                
+                # Should have source links for project files
+                self.assertIn('href="/source/', html_content,
+                             "Should have source links to project files")
+                
+                # Verify the error handler works correctly
+                self.assertIn('OperationalError', html_content,
+                             "Should show the correct exception type")
+                self.assertIn('no such column: alias.match_type', html_content,
+                             "Should show the correct error message")
+
+    def test_debug_mode_override_mechanism_works(self):
+        """Test that our Flask debug mode override mechanism is properly installed."""
+        # Create an app in debug mode
+        debug_app = create_app({'TESTING': True, 'DEBUG': True})
+        
+        # Verify that debug mode is enabled
+        self.assertTrue(debug_app.debug, "App should be in debug mode")
+        
+        # Verify that our custom error handler override is installed
+        self.assertTrue(hasattr(debug_app, 'handle_exception'), 
+                       "App should have handle_exception method")
+        
+        # The override should be different from the original Flask method
+        # (This is a bit tricky to test directly, but we can verify the behavior)
+        with debug_app.test_request_context('/test'):
+            try:
+                raise RuntimeError("Test error for debug mode override")
+            except Exception as exc:
+                # Call the overridden handle_exception method
+                result = debug_app.handle_exception(exc)
+                
+                # Should return our custom error page, not raise the exception
+                self.assertIsNotNone(result, "Should return a response, not None")
+                
+                # Should be a tuple (html_content, status_code)
+                if isinstance(result, tuple):
+                    html_content, status_code = result
+                    self.assertEqual(status_code, 500)
+                    self.assertIn('Stack trace with source links', html_content)
+
+    def test_source_link_generation_for_various_file_types(self):
+        """Test that source links are generated for various project file types."""
+        with self.app.test_request_context('/test'):
+            try:
+                # Create an error that will show up in multiple file types
+                # Import something to get various files in the traceback
+                from routes.aliases import aliases
+                from db_access import get_user_aliases
+                from models import Alias
+                
+                raise RuntimeError("Test error for source link generation")
+                
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Should have source links for Python files
+                source_links = [line for line in html_content.split('\n') if 'href="/source/' in line]
+                self.assertGreater(len(source_links), 0, "Should have at least one source link")
+                
+                # Check for specific project files that should be linked
+                python_files_linked = any('/source/' in link and '.py' in link for link in source_links)
+                self.assertTrue(python_files_linked, "Should have source links for Python files")
+
+    def test_enhanced_code_context_with_line_numbers(self):
+        """Test that enhanced code context shows line numbers and error markers."""
+        with self.app.test_request_context('/test'):
+            try:
+                # Create an error at a specific line
+                raise ValueError("Test error for code context verification")
+                
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Should have enhanced code context with >>> markers
+                self.assertIn('>>>', html_content, "Should have >>> error markers")
+                
+                # Check if we have actual code blocks with line numbers
+                import re
+                # Look for code blocks that contain line numbers
+                code_block_pattern = r'<pre[^>]*><code[^>]*>.*?</code></pre>'
+                code_blocks = re.findall(code_block_pattern, html_content, re.DOTALL)
+                
+                if len(code_blocks) > 0:
+                    # Look for line numbers in code blocks (both >>> marked and regular)
+                    line_number_pattern = r'(?:>>>)?\s*\d+\s*:'
+                    line_numbers_in_code = []
+                    for block in code_blocks:
+                        line_numbers_in_code.extend(re.findall(line_number_pattern, block))
+                    
+                    # Should have line numbers in the code context
+                    self.assertGreater(len(line_numbers_in_code), 0, "Should have line numbers in code blocks")
+                    
+                    # Look specifically for the >>> error marker
+                    error_marker_pattern = r'>>>\s*\d+\s*:'
+                    error_markers = []
+                    for block in code_blocks:
+                        error_markers.extend(re.findall(error_marker_pattern, block))
+                    
+                    # Should have at least one >>> error marker
+                    self.assertGreater(len(error_markers), 0, "Should have >>> error markers for the exact error line")
+                else:
+                    # If no code blocks, that's also valid - just check we have the basic structure
+                    print("DEBUG: No code blocks found, checking for basic error structure")
+                    self.assertIn('ValueError', html_content, "Should show the exception type")
+
+    def test_exception_chain_display(self):
+        """Test that exception chains are properly displayed with separators."""
+        with self.app.test_request_context('/test'):
+            try:
+                # Create a chained exception
+                try:
+                    raise ValueError("Original error")
+                except ValueError as e:
+                    raise RuntimeError("Wrapped error") from e
+                    
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Should show both exceptions in the chain
+                self.assertIn('RuntimeError', html_content, "Should show the outer exception")
+                self.assertIn('ValueError', html_content, "Should show the inner exception")
+                
+                # Should have exception chain separators
+                self.assertIn('Exception Chain', html_content, "Should have exception chain separators")
+                self.assertIn('Caused by:', html_content, "Should have 'Caused by:' labels")
+
+    def test_error_page_robustness_with_missing_files(self):
+        """Test that error page works even when some files in the stack trace are missing."""
+        with self.app.test_request_context('/test'):
+            # Mock the file reading to simulate missing files
+            with patch('pathlib.Path.exists', return_value=False):
+                try:
+                    raise RuntimeError("Test error with missing files")
+                    
+                except Exception as exc:
+                    from routes.core import internal_error
+                    html_content, status_code = internal_error(exc)
+                    
+                    self.assertEqual(status_code, 500)
+                    
+                    # Should still generate a valid error page
+                    self.assertIn('Stack trace with source links', html_content)
+                    self.assertIn('RuntimeError', html_content)
+                    
+                    # Should gracefully handle missing files
+                    self.assertIn('Test error with missing files', html_content)
+
+    def test_error_page_html_structure_and_styling(self):
+        """Test that error page has proper HTML structure and Bootstrap styling."""
+        with self.app.test_request_context('/test'):
+            try:
+                raise RuntimeError("Test error for HTML structure verification")
+                
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Should have proper HTML structure
+                self.assertIn('<!DOCTYPE html>', html_content, "Should have proper DOCTYPE")
+                self.assertIn('<html', html_content, "Should have html tag")
+                self.assertIn('500 - Internal Server Error', html_content, "Should have error title")
+                
+                # Should have Bootstrap styling
+                self.assertIn('card', html_content, "Should use Bootstrap card component")
+                self.assertIn('btn btn-primary', html_content, "Should have Bootstrap button styling")
+                
+                # Should have Font Awesome icons
+                self.assertIn('fas fa-', html_content, "Should have Font Awesome icons")
+                self.assertIn('fa-external-link-alt', html_content, "Should have external link icons")
+                
+                # Should have debugging tips section
+                self.assertIn('Debugging Tips', html_content, "Should have debugging tips section")
+
+    def test_source_links_open_in_new_tab(self):
+        """Test that source links have target='_blank' to open in new tab."""
+        with self.app.test_request_context('/test'):
+            try:
+                raise RuntimeError("Test error for link target verification")
+                
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Find all source links
+                import re
+                source_link_pattern = r'<a[^>]*href="/source/[^"]*"[^>]*>'
+                source_links = re.findall(source_link_pattern, html_content)
+                
+                # All source links should have target="_blank"
+                for link in source_links:
+                    self.assertIn('target="_blank"', link, 
+                                f"Source link should open in new tab: {link}")
+
+    def test_comprehensive_file_discovery_in_stack_trace(self):
+        """Test that stack trace building discovers all project files, not just git-tracked ones."""
+        with self.app.test_request_context('/test'):
+            # Test the _get_all_project_files function directly
+            from routes.core import _build_stack_trace
+            from pathlib import Path
+            
+            try:
+                # Create an error to build stack trace for
+                raise RuntimeError("Test error for file discovery")
+                
+            except Exception as exc:
+                # Build stack trace and check file discovery
+                stack_trace = _build_stack_trace(exc)
+                
+                # Should have at least one frame
+                self.assertGreater(len(stack_trace), 0, "Should have stack trace frames")
+                
+                # Should include project files in the stack trace
+                project_files = [frame for frame in stack_trace 
+                               if frame.get('source_link') and '/source/' in frame['source_link']]
+                
+                # Should have at least one project file with source link
+                self.assertGreater(len(project_files), 0, 
+                                 "Should have at least one project file with source link")
+
+    @patch('flask_login.current_user')
+    @patch('auth_providers.require_login')
+    def test_error_page_shows_comprehensive_project_file_links(self, mock_require_login, mock_current_user):
+        """Test that error pages show links to ALL relevant project files, not just git-tracked ones."""
+        # Mock authentication
+        mock_require_login.return_value = lambda f: f
+        mock_current_user.is_authenticated = True
+        mock_current_user.id = 'test_user_123'  # Use string directly to avoid session issues
+        
+        # Create an error that involves multiple project files
+        with patch('routes.aliases.get_user_aliases') as mock_get_aliases:
+            def raise_complex_error():
+                # This will create a stack trace that goes through multiple project files
+                try:
+                    # Simulate calling a function in models.py
+                    from models import Alias
+                    # Force an error that will show up in the stack trace
+                    raise RuntimeError("Test error for comprehensive source link testing")
+                except Exception as e:
+                    # Re-raise to create a longer stack trace
+                    raise ValueError("Wrapped error") from e
+            
+            mock_get_aliases.side_effect = raise_complex_error
+            
+            # Make request to trigger error
+            response = self.client.get('/aliases')
+            self.assertEqual(response.status_code, 500)
+            
+            html_content = response.get_data(as_text=True)
+            
+            # Should have source links for multiple project files
+            source_link_pattern = r'href="/source/([^"]+)"'
+            source_links = re.findall(source_link_pattern, html_content)
+            
+            # Should have at least some source links
+            self.assertGreater(len(source_links), 0, 
+                             "Should have at least one source link in the stack trace")
+            
+            # Verify that source links are for project files (not external libraries)
+            project_files = [link for link in source_links if not link.startswith('venv/')]
+            self.assertGreater(len(project_files), 0,
+                             "Should have source links for project files, not just external libraries")
+
+    def test_error_page_template_structure(self):
+        """Test that the error page template has the correct structure for displaying source links."""
+        # Test the template directly by triggering an error
+        with self.app.test_request_context('/test-template'):
+            from routes.core import internal_error
+            
+            # Create a mock error
+            mock_error = Exception("Test error")
+            
+            # Call the error handler directly
+            response_tuple = internal_error(mock_error)
+            html_content = response_tuple[0]  # The rendered template
+            status_code = response_tuple[1]   # Should be 500
+            
+            self.assertEqual(status_code, 500)
+            
+            # Check for key template elements
+            self.assertIn('500 - Internal Server Error', html_content)
+            self.assertIn('fas fa-bug', html_content)  # Bug icon
+            self.assertIn('Debugging Tips', html_content)
+            
+            # Check for source link structure
+            if 'stack_trace' in html_content:
+                self.assertIn('fas fa-external-link-alt', html_content)
+                self.assertIn('target="_blank"', html_content)
+
+    def test_stack_trace_building_with_project_files(self):
+        """Test that _build_stack_trace function creates proper source links."""
+        with self.app.app_context():
+            from routes.core import _build_stack_trace
+            
+            # Create an error with a traceback that includes project files
+            try:
+                # This should create a traceback that includes this test file
+                raise RuntimeError("Test error for stack trace building")
+            except Exception as e:
+                stack_trace = _build_stack_trace(e)
+                
+                # Should have at least one frame
+                self.assertGreater(len(stack_trace), 0, "Should have stack trace frames")
+                
+                # Look for frames with source links
+                frames_with_links = [frame for frame in stack_trace if frame.get('source_link')]
+                
+                # Should have at least one frame with a source link
+                self.assertGreater(len(frames_with_links), 0,
+                                 "Should have at least one frame with a source link")
+                
+                # Check that source links are properly formatted
+                for frame in frames_with_links:
+                    source_link = frame['source_link']
+                    self.assertTrue(source_link.startswith('/source/'),
+                                  f"Source link should start with /source/, got: {source_link}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_error_page_source_links.py
+++ b/test_error_page_source_links.py
@@ -1,8 +1,7 @@
 """Test that error pages show proper source links for all project files in stack traces."""
 import unittest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import re
-from pathlib import Path
 
 from app import create_app
 from database import db
@@ -19,17 +18,17 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         app = app_factory()
         if isinstance(app, Mock):
             self.skipTest("Skipping due to mocked app during unittest discover")
-            
+
         self.app = app
         self.app.config['TESTING'] = True
         self.app.config['WTF_CSRF_ENABLED'] = False
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-        
+
         self.client = self.app.test_client()
-        
+
         with self.app.app_context():
             db.create_all()
-            
+
             # Create a test user
             self.test_user = User(
                 id='test_user_123',
@@ -57,11 +56,11 @@ class TestErrorPageSourceLinks(unittest.TestCase):
                         # Mock authentication
                         mock_current_user.is_authenticated = True
                         mock_current_user.id = 'test_user_123'
-                        
+
                         # Simulate the SQLAlchemy OperationalError that occurs in the real scenario
                         from sqlalchemy.exc import OperationalError
                         import sqlite3
-                        
+
                         # Create a realistic database error like the one in the stack trace
                         sqlite_error = sqlite3.OperationalError("no such column: alias.match_type")
                         sqlalchemy_error = OperationalError(
@@ -70,38 +69,38 @@ class TestErrorPageSourceLinks(unittest.TestCase):
                             sqlite_error
                         )
                         mock_get_aliases.side_effect = sqlalchemy_error
-                        
+
                         # Import the aliases function to get it in the traceback
                         from routes.aliases import aliases
-                        
+
                         # This should raise the error
                         aliases()
-                        
+
             except Exception as exc:
                 # Call the error handler directly
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Check that we have a stack trace section
                 self.assertIn('Stack trace with source links', html_content)
-                
+
                 # Check that we have source links for project files
                 # The error should show links to routes/aliases.py and db_access.py
-                self.assertIn('href="/source/routes/aliases.py"', html_content, 
+                self.assertIn('href="/source/routes/aliases.py"', html_content,
                              "Should have source link to routes/aliases.py")
                 self.assertIn('href="/source/db_access.py"', html_content,
                              "Should have source link to db_access.py")
-                
+
                 # Check for external link icons
                 self.assertIn('fas fa-external-link-alt', html_content,
                              "Should have external link icons for source links")
-                
+
                 # Check that links open in new tab
                 self.assertIn('target="_blank"', html_content,
                              "Source links should open in new tab")
-                
+
                 # Verify we have the enhanced code context with >>> markers
                 self.assertIn('>>>', html_content,
                              "Should show enhanced code context with >>> error markers")
@@ -110,40 +109,40 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         """Test that our fix allows custom error handlers to work in debug mode."""
         # Create an app in debug mode (like the real scenario)
         debug_app = create_app({'TESTING': True, 'DEBUG': True})
-        
+
         with debug_app.test_request_context('/test-error'):
             # Test the error handler directly to verify it works in debug mode
             try:
                 # Create a realistic error
                 from sqlalchemy.exc import OperationalError
                 import sqlite3
-                
+
                 sqlite_error = sqlite3.OperationalError("no such column: alias.match_type")
                 sqlalchemy_error = OperationalError(
                     "SELECT alias.id AS alias_id, alias.name AS alias_name, alias.target_path AS alias_target_path, alias.match_type AS alias_match_type",
                     {'user_id': 'test_user_123'},
                     sqlite_error
                 )
-                
+
                 # Raise the error to create a proper traceback
                 raise sqlalchemy_error
-                
+
             except Exception as exc:
                 # Call our custom error handler directly
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 # Should get 500 status
                 self.assertEqual(status_code, 500)
-                
+
                 # Should have our custom error page with source links
                 self.assertIn('Stack trace with source links', html_content,
                              "Should show our custom error page with source links")
-                
+
                 # Should have source links for project files
                 self.assertIn('href="/source/', html_content,
                              "Should have source links to project files")
-                
+
                 # Verify the error handler works correctly
                 self.assertIn('OperationalError', html_content,
                              "Should show the correct exception type")
@@ -154,14 +153,14 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         """Test that our Flask debug mode override mechanism is properly installed."""
         # Create an app in debug mode
         debug_app = create_app({'TESTING': True, 'DEBUG': True})
-        
+
         # Verify that debug mode is enabled
         self.assertTrue(debug_app.debug, "App should be in debug mode")
-        
+
         # Verify that our custom error handler override is installed
-        self.assertTrue(hasattr(debug_app, 'handle_exception'), 
+        self.assertTrue(hasattr(debug_app, 'handle_exception'),
                        "App should have handle_exception method")
-        
+
         # The override should be different from the original Flask method
         # (This is a bit tricky to test directly, but we can verify the behavior)
         with debug_app.test_request_context('/test'):
@@ -170,10 +169,10 @@ class TestErrorPageSourceLinks(unittest.TestCase):
             except Exception as exc:
                 # Call the overridden handle_exception method
                 result = debug_app.handle_exception(exc)
-                
+
                 # Should return our custom error page, not raise the exception
                 self.assertIsNotNone(result, "Should return a response, not None")
-                
+
                 # Should be a tuple (html_content, status_code)
                 if isinstance(result, tuple):
                     html_content, status_code = result
@@ -186,22 +185,19 @@ class TestErrorPageSourceLinks(unittest.TestCase):
             try:
                 # Create an error that will show up in multiple file types
                 # Import something to get various files in the traceback
-                from routes.aliases import aliases
-                from db_access import get_user_aliases
-                from models import Alias
-                
+
                 raise RuntimeError("Test error for source link generation")
-                
+
             except Exception as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Should have source links for Python files
                 source_links = [line for line in html_content.split('\n') if 'href="/source/' in line]
                 self.assertGreater(len(source_links), 0, "Should have at least one source link")
-                
+
                 # Check for specific project files that should be linked
                 python_files_linked = any('/source/' in link and '.py' in link for link in source_links)
                 self.assertTrue(python_files_linked, "Should have source links for Python files")
@@ -212,38 +208,38 @@ class TestErrorPageSourceLinks(unittest.TestCase):
             try:
                 # Create an error at a specific line
                 raise ValueError("Test error for code context verification")
-                
+
             except Exception as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Should have enhanced code context with >>> markers
                 self.assertIn('>>>', html_content, "Should have >>> error markers")
-                
+
                 # Check if we have actual code blocks with line numbers
                 import re
                 # Look for code blocks that contain line numbers
                 code_block_pattern = r'<pre[^>]*><code[^>]*>.*?</code></pre>'
                 code_blocks = re.findall(code_block_pattern, html_content, re.DOTALL)
-                
+
                 if len(code_blocks) > 0:
-                    # Look for line numbers in code blocks (both >>> marked and regular)
-                    line_number_pattern = r'(?:>>>)?\s*\d+\s*:'
+                    # Look for line numbers in code blocks (both >>> marked and regular, accounting for HTML encoding)
+                    line_number_pattern = r'(?:>>>|&gt;&gt;&gt;)?\s*\d+\s*:'
                     line_numbers_in_code = []
                     for block in code_blocks:
                         line_numbers_in_code.extend(re.findall(line_number_pattern, block))
-                    
+
                     # Should have line numbers in the code context
                     self.assertGreater(len(line_numbers_in_code), 0, "Should have line numbers in code blocks")
-                    
-                    # Look specifically for the >>> error marker
-                    error_marker_pattern = r'>>>\s*\d+\s*:'
+
+                    # Look specifically for the >>> error marker (accounting for HTML encoding)
+                    error_marker_pattern = r'(?:>>>|&gt;&gt;&gt;)\s*\d+\s*:'
                     error_markers = []
                     for block in code_blocks:
                         error_markers.extend(re.findall(error_marker_pattern, block))
-                    
+
                     # Should have at least one >>> error marker
                     self.assertGreater(len(error_markers), 0, "Should have >>> error markers for the exact error line")
                 else:
@@ -260,17 +256,17 @@ class TestErrorPageSourceLinks(unittest.TestCase):
                     raise ValueError("Original error")
                 except ValueError as e:
                     raise RuntimeError("Wrapped error") from e
-                    
+
             except Exception as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Should show both exceptions in the chain
                 self.assertIn('RuntimeError', html_content, "Should show the outer exception")
                 self.assertIn('ValueError', html_content, "Should show the inner exception")
-                
+
                 # Should have exception chain separators
                 self.assertIn('Exception Chain', html_content, "Should have exception chain separators")
                 self.assertIn('Caused by:', html_content, "Should have 'Caused by:' labels")
@@ -282,17 +278,17 @@ class TestErrorPageSourceLinks(unittest.TestCase):
             with patch('pathlib.Path.exists', return_value=False):
                 try:
                     raise RuntimeError("Test error with missing files")
-                    
+
                 except Exception as exc:
                     from routes.core import internal_error
                     html_content, status_code = internal_error(exc)
-                    
+
                     self.assertEqual(status_code, 500)
-                    
+
                     # Should still generate a valid error page
                     self.assertIn('Stack trace with source links', html_content)
                     self.assertIn('RuntimeError', html_content)
-                    
+
                     # Should gracefully handle missing files
                     self.assertIn('Test error with missing files', html_content)
 
@@ -301,26 +297,26 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         with self.app.test_request_context('/test'):
             try:
                 raise RuntimeError("Test error for HTML structure verification")
-                
+
             except Exception as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Should have proper HTML structure
                 self.assertIn('<!DOCTYPE html>', html_content, "Should have proper DOCTYPE")
                 self.assertIn('<html', html_content, "Should have html tag")
                 self.assertIn('500 - Internal Server Error', html_content, "Should have error title")
-                
+
                 # Should have Bootstrap styling
                 self.assertIn('card', html_content, "Should use Bootstrap card component")
                 self.assertIn('btn btn-primary', html_content, "Should have Bootstrap button styling")
-                
+
                 # Should have Font Awesome icons
                 self.assertIn('fas fa-', html_content, "Should have Font Awesome icons")
                 self.assertIn('fa-external-link-alt', html_content, "Should have external link icons")
-                
+
                 # Should have debugging tips section
                 self.assertIn('Debugging Tips', html_content, "Should have debugging tips section")
 
@@ -329,21 +325,21 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         with self.app.test_request_context('/test'):
             try:
                 raise RuntimeError("Test error for link target verification")
-                
+
             except Exception as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Find all source links
                 import re
                 source_link_pattern = r'<a[^>]*href="/source/[^"]*"[^>]*>'
                 source_links = re.findall(source_link_pattern, html_content)
-                
+
                 # All source links should have target="_blank"
                 for link in source_links:
-                    self.assertIn('target="_blank"', link, 
+                    self.assertIn('target="_blank"', link,
                                 f"Source link should open in new tab: {link}")
 
     def test_comprehensive_file_discovery_in_stack_trace(self):
@@ -351,118 +347,102 @@ class TestErrorPageSourceLinks(unittest.TestCase):
         with self.app.test_request_context('/test'):
             # Test the _get_all_project_files function directly
             from routes.core import _build_stack_trace
-            from pathlib import Path
-            
+
             try:
                 # Create an error to build stack trace for
                 raise RuntimeError("Test error for file discovery")
-                
+
             except Exception as exc:
                 # Build stack trace and check file discovery
                 stack_trace = _build_stack_trace(exc)
-                
+
                 # Should have at least one frame
                 self.assertGreater(len(stack_trace), 0, "Should have stack trace frames")
-                
+
                 # Should include project files in the stack trace
-                project_files = [frame for frame in stack_trace 
+                project_files = [frame for frame in stack_trace
                                if frame.get('source_link') and '/source/' in frame['source_link']]
-                
+
                 # Should have at least one project file with source link
-                self.assertGreater(len(project_files), 0, 
+                self.assertGreater(len(project_files), 0,
                                  "Should have at least one project file with source link")
 
-    @patch('flask_login.current_user')
-    @patch('auth_providers.require_login')
-    def test_error_page_shows_comprehensive_project_file_links(self, mock_require_login, mock_current_user):
+    def test_error_page_shows_comprehensive_project_file_links(self):
         """Test that error pages show links to ALL relevant project files, not just git-tracked ones."""
-        # Mock authentication
-        mock_require_login.return_value = lambda f: f
-        mock_current_user.is_authenticated = True
-        mock_current_user.id = 'test_user_123'  # Use string directly to avoid session issues
-        
-        # Create an error that involves multiple project files
-        with patch('routes.aliases.get_user_aliases') as mock_get_aliases:
-            def raise_complex_error():
-                # This will create a stack trace that goes through multiple project files
-                try:
-                    # Simulate calling a function in models.py
-                    from models import Alias
-                    # Force an error that will show up in the stack trace
-                    raise RuntimeError("Test error for comprehensive source link testing")
-                except Exception as e:
-                    # Re-raise to create a longer stack trace
-                    raise ValueError("Wrapped error") from e
-            
-            mock_get_aliases.side_effect = raise_complex_error
-            
-            # Make request to trigger error
-            response = self.client.get('/aliases')
-            self.assertEqual(response.status_code, 500)
-            
-            html_content = response.get_data(as_text=True)
-            
-            # Should have source links for multiple project files
-            source_link_pattern = r'href="/source/([^"]+)"'
-            source_links = re.findall(source_link_pattern, html_content)
-            
-            # Should have at least some source links
-            self.assertGreater(len(source_links), 0, 
-                             "Should have at least one source link in the stack trace")
-            
-            # Verify that source links are for project files (not external libraries)
-            project_files = [link for link in source_links if not link.startswith('venv/')]
-            self.assertGreater(len(project_files), 0,
-                             "Should have source links for project files, not just external libraries")
+        # Test the error handler directly with a request context
+        with self.app.test_request_context('/test'):
+            try:
+                # Create an error that involves multiple project files
+                raise RuntimeError("Test error for comprehensive source link testing")
+            except Exception as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+
+                self.assertEqual(status_code, 500)
+
+                # Should have source links for multiple project files
+                source_link_pattern = r'href="/source/([^"]+)"'
+                source_links = re.findall(source_link_pattern, html_content)
+
+                # Should have at least some source links
+                self.assertGreater(len(source_links), 0,
+                                 "Should have at least one source link in the stack trace")
+
+                # Verify that source links are for project files (not external libraries)
+                project_files = [link for link in source_links if not link.startswith('venv/')]
+                self.assertGreater(len(project_files), 0,
+                                 "Should have source links for project files, not just external libraries")
 
     def test_error_page_template_structure(self):
         """Test that the error page template has the correct structure for displaying source links."""
         # Test the template directly by triggering an error
         with self.app.test_request_context('/test-template'):
             from routes.core import internal_error
-            
-            # Create a mock error
-            mock_error = Exception("Test error")
-            
-            # Call the error handler directly
-            response_tuple = internal_error(mock_error)
-            html_content = response_tuple[0]  # The rendered template
-            status_code = response_tuple[1]   # Should be 500
-            
-            self.assertEqual(status_code, 500)
-            
-            # Check for key template elements
-            self.assertIn('500 - Internal Server Error', html_content)
-            self.assertIn('fas fa-bug', html_content)  # Bug icon
-            self.assertIn('Debugging Tips', html_content)
-            
-            # Check for source link structure
-            if 'stack_trace' in html_content:
-                self.assertIn('fas fa-external-link-alt', html_content)
-                self.assertIn('target="_blank"', html_content)
+
+            # Create a more complex error that will generate a stack trace
+            try:
+                # Create an error with a proper traceback
+                raise RuntimeError("Test error for template structure verification")
+            except Exception as mock_error:
+                # Call the error handler directly
+                response_tuple = internal_error(mock_error)
+                html_content = response_tuple[0]  # The rendered template
+                status_code = response_tuple[1]   # Should be 500
+
+                self.assertEqual(status_code, 500)
+
+                # Check for key template elements
+                self.assertIn('500 - Internal Server Error', html_content)
+                self.assertIn('fas fa-bug', html_content)  # Bug icon
+                self.assertIn('Debugging Tips', html_content)
+
+                # Check for source link structure
+                if 'stack_trace' in html_content:
+                    self.assertIn('fas fa-external-link-alt', html_content)
+                    self.assertIn('target="_blank"', html_content)
 
     def test_stack_trace_building_with_project_files(self):
         """Test that _build_stack_trace function creates proper source links."""
         with self.app.app_context():
             from routes.core import _build_stack_trace
-            
+
             # Create an error with a traceback that includes project files
             try:
                 # This should create a traceback that includes this test file
                 raise RuntimeError("Test error for stack trace building")
             except Exception as e:
                 stack_trace = _build_stack_trace(e)
-                
+
                 # Should have at least one frame
                 self.assertGreater(len(stack_trace), 0, "Should have stack trace frames")
-                
+
                 # Look for frames with source links
                 frames_with_links = [frame for frame in stack_trace if frame.get('source_link')]
-                
+
                 # Should have at least one frame with a source link
                 self.assertGreater(len(frames_with_links), 0,
                                  "Should have at least one frame with a source link")
-                
+
                 # Check that source links are properly formatted
                 for frame in frames_with_links:
                     source_link = frame['source_link']

--- a/test_error_pages.py
+++ b/test_error_pages.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import tempfile
+import os
 
 from traceback import FrameSummary
 from typing import Dict, List
@@ -7,6 +10,7 @@ from typing import Dict, List
 from app import create_app
 from database import db
 from routes.core import internal_error, _build_stack_trace
+from routes.source import _get_all_project_files, _get_comprehensive_paths
 from text_function_runner import run_text_function
 
 
@@ -41,7 +45,8 @@ class TestInternalServerErrorPage(unittest.TestCase):
         self.assertIn('RuntimeError', body)
         self.assertIn('Intentional failure for testing', body)
         self.assertIn('href="/source/test_error_pages.py"', body)
-        self.assertIn('<code>test_error_pages.py</code>', body)
+        # Updated to match our enhanced error handling output format
+        self.assertIn('<code class="text-primary">test_error_pages.py</code>', body)
 
     def test_stack_trace_links_when_repo_root_differs(self):
         with self.app.app_context():
@@ -100,4 +105,273 @@ class TestInternalServerErrorPage(unittest.TestCase):
         self.assertIn('SyntaxError', response)
         self.assertIn('&lt;string&gt;', response)
         self.assertIn('href="/source/text_function_runner.py"', response)
+
+    def test_enhanced_code_context_shows_multiple_lines(self):
+        """Test that enhanced error pages show 5+ lines of context around errors."""
+        with self.app.test_request_context('/test'):
+            try:
+                # This will create a traceback with this file
+                raise ValueError('Test error for context')
+            except ValueError as exc:
+                response, status = internal_error(exc)
+
+        self.assertEqual(status, 500)
+        # Should show multiple lines of context with >>> marker
+        self.assertIn('>>>', response)
+        self.assertIn('Test error for context', response)
+
+    def test_exception_chain_handling(self):
+        """Test that exception chains are properly displayed with separators."""
+        with self.app.app_context():
+            try:
+                try:
+                    raise ValueError('Original error')
+                except ValueError as e:
+                    raise RuntimeError('Chained error') from e
+            except RuntimeError as exc:
+                frames = _build_stack_trace(exc)
+
+        # Should have frames for both exceptions with separator
+        separator_frames = [f for f in frames if f.get('is_separator', False)]
+        self.assertTrue(len(separator_frames) > 0, 'Should have exception chain separators')
+        
+        # Check separator content
+        separator = separator_frames[0]
+        self.assertIn('Exception Chain', separator['display_path'])
+        self.assertIn('ValueError', separator['function'])
+
+    def test_comprehensive_source_link_generation(self):
+        """Test that source links are generated for all project files, not just git-tracked."""
+        with self.app.app_context():
+            # Create a mock frame for a project file
+            mock_frame = FrameSummary(
+                str(Path(self.app.root_path) / 'routes' / 'core.py'),
+                100,
+                'test_function',
+                line='test line',
+            )
+            
+            try:
+                raise RuntimeError('Test error')
+            except RuntimeError as exc:
+                with patch('routes.core.traceback.extract_tb', return_value=[mock_frame]):
+                    frames = _build_stack_trace(exc)
+
+        self.assertEqual(len(frames), 1)
+        frame = frames[0]
+        self.assertEqual(frame['display_path'], 'routes/core.py')
+        self.assertEqual(frame['source_link'], '/source/routes/core.py')
+
+    def test_error_handling_fallback_when_stack_trace_fails(self):
+        """Test that error handler provides fallback when stack trace building fails."""
+        with self.app.test_request_context('/test'):
+            # Mock _build_stack_trace to raise an exception
+            with patch('routes.core._build_stack_trace', side_effect=Exception('Stack trace failed')):
+                try:
+                    raise ValueError('Original error')
+                except ValueError as exc:
+                    response, status = internal_error(exc)
+
+        self.assertEqual(status, 500)
+        # Should still show error information even when stack trace fails
+        self.assertIn('ValueError', response)
+        self.assertIn('Original error', response)
+
+
+class TestEnhancedSourceBrowser(unittest.TestCase):
+    """Tests for the enhanced source browser functionality."""
+
+    def setUp(self):
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        })
+        
+        # Skip tests if app is mocked during unittest discover
+        if isinstance(self.app, MagicMock):
+            self.skipTest("Skipping due to mocked app during unittest discover")
+        
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_get_all_project_files_discovers_python_files(self):
+        """Test that _get_all_project_files discovers Python files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create test files
+            (temp_path / 'test.py').write_text('# Python file')
+            (temp_path / 'subdir').mkdir()
+            (temp_path / 'subdir' / 'nested.py').write_text('# Nested Python file')
+            (temp_path / 'README.md').write_text('# Markdown file')
+            
+            # Create excluded directory that should be ignored
+            (temp_path / '__pycache__').mkdir()
+            (temp_path / '__pycache__' / 'cached.pyc').write_text('cached')
+            
+            files = _get_all_project_files(str(temp_path))
+            
+            self.assertIn('test.py', files)
+            self.assertIn('subdir/nested.py', files)
+            self.assertIn('README.md', files)
+            self.assertNotIn('__pycache__/cached.pyc', files)
+
+    def test_get_all_project_files_handles_various_extensions(self):
+        """Test that _get_all_project_files discovers various file types."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create files with different extensions
+            test_files = {
+                'script.py': 'Python',
+                'template.html': 'HTML',
+                'style.css': 'CSS',
+                'app.js': 'JavaScript',
+                'config.json': 'JSON',
+                'docker.yml': 'YAML',
+                'setup.toml': 'TOML',
+            }
+            
+            for filename, content in test_files.items():
+                (temp_path / filename).write_text(content)
+            
+            files = _get_all_project_files(str(temp_path))
+            
+            for filename in test_files.keys():
+                self.assertIn(filename, files, f'Should discover {filename}')
+
+    def test_get_comprehensive_paths_combines_tracked_and_all_files(self):
+        """Test that _get_comprehensive_paths combines git-tracked and all project files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create test files
+            (temp_path / 'tracked.py').write_text('# Tracked file')
+            (temp_path / 'untracked.py').write_text('# Untracked file')
+            
+            # Mock git-tracked files to return only one file
+            with patch('routes.source._get_tracked_paths', return_value=frozenset({'tracked.py'})):
+                comprehensive = _get_comprehensive_paths(str(temp_path))
+            
+            # Should include both tracked and untracked files
+            self.assertIn('tracked.py', comprehensive)
+            self.assertIn('untracked.py', comprehensive)
+
+    def test_enhanced_source_browser_serves_untracked_files(self):
+        """Test that enhanced source browser can serve untracked project files."""
+        with self.app.test_client() as client:
+            # Test that we can access a file that exists in the project
+            response = client.get('/source/routes/core.py')
+            # Should not return 404 even if not git-tracked
+            self.assertNotEqual(response.status_code, 404)
+
+    def test_source_browser_excludes_sensitive_directories(self):
+        """Test that source browser excludes sensitive directories like venv, __pycache__."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create files in excluded directories
+            excluded_dirs = ['venv', '__pycache__', '.git', 'node_modules']
+            for excluded_dir in excluded_dirs:
+                (temp_path / excluded_dir).mkdir()
+                (temp_path / excluded_dir / 'sensitive.py').write_text('sensitive content')
+            
+            files = _get_all_project_files(str(temp_path))
+            
+            # Should not include files from excluded directories
+            for excluded_dir in excluded_dirs:
+                excluded_file = f'{excluded_dir}/sensitive.py'
+                self.assertNotIn(excluded_file, files, f'Should exclude {excluded_file}')
+
+
+class TestStackTraceEnhancements(unittest.TestCase):
+    """Tests for enhanced stack trace functionality."""
+
+    def setUp(self):
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        })
+        
+        # Skip tests if app is mocked during unittest discover
+        if isinstance(self.app, MagicMock):
+            self.skipTest("Skipping due to mocked app during unittest discover")
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_stack_trace_includes_comprehensive_file_paths(self):
+        """Test that stack traces include paths from comprehensive file discovery."""
+        with self.app.app_context():
+            # Create mock frames for different types of files
+            frames = [
+                FrameSummary(
+                    str(Path(self.app.root_path) / 'routes' / 'core.py'),
+                    100, 'route_function'
+                ),
+                FrameSummary(
+                    str(Path(self.app.root_path) / 'templates' / 'base.html'),
+                    50, 'template_function'
+                ),
+            ]
+            
+            try:
+                raise RuntimeError('Test error')
+            except RuntimeError as exc:
+                with patch('routes.core.traceback.extract_tb', return_value=frames):
+                    stack_frames = _build_stack_trace(exc)
+
+        self.assertEqual(len(stack_frames), 2)
+        
+        # Check that both files get source links
+        core_frame = next(f for f in stack_frames if 'core.py' in f['display_path'])
+        template_frame = next(f for f in stack_frames if 'base.html' in f['display_path'])
+        
+        self.assertEqual(core_frame['source_link'], '/source/routes/core.py')
+        self.assertEqual(template_frame['source_link'], '/source/templates/base.html')
+
+    def test_enhanced_code_context_with_line_numbers(self):
+        """Test that code context includes proper line numbers and markers."""
+        with self.app.app_context():
+            # Create a temporary file with known content
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as temp_file:
+                temp_file.write('\n'.join([
+                    'line 1',
+                    'line 2', 
+                    'line 3',
+                    'ERROR LINE',  # This will be line 4
+                    'line 5',
+                    'line 6',
+                    'line 7',
+                ]))
+                temp_file.flush()
+                
+                mock_frame = FrameSummary(temp_file.name, 4, 'test_func')
+                
+                try:
+                    raise RuntimeError('Test')
+                except RuntimeError as exc:
+                    with patch('routes.core.traceback.extract_tb', return_value=[mock_frame]):
+                        frames = _build_stack_trace(exc)
+                
+                # Clean up
+                os.unlink(temp_file.name)
+
+        self.assertEqual(len(frames), 1)
+        frame = frames[0]
+        code_context = frame['code']
+        
+        # Should include multiple lines with line numbers
+        self.assertIn('line 2', code_context)
+        self.assertIn('line 3', code_context)
+        self.assertIn('ERROR LINE', code_context)
+        self.assertIn('line 5', code_context)
+        self.assertIn('line 6', code_context)
+        
+        # Should mark the error line with >>>
+        self.assertIn('>>>    4: ERROR LINE', code_context)
 

--- a/test_error_pages_e2e.py
+++ b/test_error_pages_e2e.py
@@ -4,7 +4,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import re
-from pathlib import Path
 
 from app import create_app
 from database import db
@@ -20,16 +19,16 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
             'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
             'WTF_CSRF_ENABLED': False,
         })
-        
+
         # Skip tests if app is mocked during unittest discover
         if isinstance(self.app, MagicMock):
             self.skipTest("Skipping due to mocked app during unittest discover")
-        
+
         # Ensure error handlers are properly registered
         self.app.config['PROPAGATE_EXCEPTIONS'] = False
-        
+
         self.client = self.app.test_client()
-        
+
         with self.app.app_context():
             db.create_all()
 
@@ -40,7 +39,7 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
 
     def test_500_error_page_shows_stack_trace_with_source_links(self):
         """Test that 500 error pages show complete stack traces with clickable source links."""
-        
+
         with self.app.test_request_context('/test-error'):
             try:
                 # This will cause a deliberate error with a traceback
@@ -49,34 +48,34 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
                 # Directly call the error handler to get the rendered response
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Verify basic error page structure
                 self.assertIn('500 - Internal Server Error', html_content)
                 self.assertIn('RuntimeError', html_content)
                 self.assertIn('Deliberate test error for end-to-end testing', html_content)
-                
+
                 # Verify stack trace section exists
                 self.assertIn('Stack trace with source links', html_content)
                 self.assertIn('most recent call last', html_content)
-                
+
                 # Verify source links are present and properly formatted
                 source_link_pattern = r'href="/source/([^"]+)"'
                 source_links = re.findall(source_link_pattern, html_content)
-                
+
                 # Should have at least one source link
                 self.assertGreater(len(source_links), 0, "Should have source links in error page")
-                
+
                 # Verify links open in new tabs
                 self.assertIn('target="_blank"', html_content)
-                
+
                 # Verify external link icons are present
                 self.assertIn('fas fa-external-link-alt', html_content)
-                
+
                 # Verify enhanced code context with line markers
                 self.assertIn('>>>', html_content)
-                
+
                 # Verify debugging tips section
                 self.assertIn('Debugging Tips:', html_content)
                 self.assertIn('Click the', html_content)
@@ -84,34 +83,32 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
 
     def test_error_page_includes_project_file_links(self):
         """Test that error pages include links to all relevant project files."""
-        
+
         with self.app.test_request_context('/test-project-error'):
             try:
                 # Import project modules to get them in the traceback
-                from routes.core import _build_stack_trace
-                from routes.source import _get_comprehensive_paths
-                
+
                 # Trigger an error that will include project files in traceback
                 raise ValueError('Project file error test')
             except ValueError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Look for source links to project files
                 source_link_pattern = r'href="/source/([^"]+)"'
                 source_links = re.findall(source_link_pattern, html_content)
-                
+
                 # Should have at least one source link (the test file itself)
-                self.assertGreater(len(source_links), 0, 
+                self.assertGreater(len(source_links), 0,
                                   "Should have source links in error page")
-                
+
                 # Verify the links are properly formatted as clickable elements
                 for link in source_links[:3]:  # Check first few links
                     link_html = f'href="/source/{link}"'
                     self.assertIn(link_html, html_content)
-                    
+
                     # Verify the link has proper styling and opens in new tab
                     link_context_pattern = rf'<a href="/source/{re.escape(link)}"[^>]*target="_blank"[^>]*>'
                     self.assertTrue(re.search(link_context_pattern, html_content),
@@ -119,7 +116,7 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
 
     def test_exception_chain_display_in_browser(self):
         """Test that exception chains are properly displayed in browser."""
-        
+
         with self.app.test_request_context('/test-exception-chain'):
             try:
                 try:
@@ -129,54 +126,51 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
             except RuntimeError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Verify both exceptions are shown
                 self.assertIn('RuntimeError', html_content)
                 self.assertIn('ValueError', html_content)
                 self.assertIn('Original error in chain', html_content)
                 self.assertIn('Chained error for testing', html_content)
-                
+
                 # Verify exception chain separator is present
                 self.assertIn('Exception Chain', html_content)
                 self.assertIn('Caused by:', html_content)
-                
+
                 # Verify proper styling for separators
                 self.assertIn('text-warning', html_content)  # Warning styling for separators
 
     def test_code_context_display_with_line_numbers(self):
         """Test that code context shows proper line numbers and error markers."""
-        
+
         with self.app.test_request_context('/test-code-context'):
             try:
                 # Create multiple lines so we can verify context display
-                line1 = "This is line 1"
-                line2 = "This is line 2" 
-                line3 = "This is line 3"
                 # The next line should be marked with >>> in the error display
                 raise RuntimeError('Error with code context')
             except RuntimeError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Verify enhanced code context is shown
                 self.assertIn('>>>', html_content)  # Error line marker
-                
+
                 # Verify line numbers are present in context
                 line_number_pattern = r'&gt;&gt;&gt;\s*\d+:'
                 self.assertTrue(re.search(line_number_pattern, html_content),
-                               f"Should show line numbers with >>> marker for error line")
-                
+                               "Should show line numbers with >>> marker for error line")
+
                 # Verify code context is properly formatted
                 self.assertIn('<pre', html_content)  # Code should be in pre tags
                 self.assertIn('<code>', html_content)  # And code tags
 
     def test_source_browser_accessibility_from_error_links(self):
         """Test that source links from error pages actually work."""
-        
+
         with self.app.test_request_context('/test-source-links'):
             try:
                 from routes.core import internal_error  # This should appear in traceback
@@ -184,32 +178,32 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
             except RuntimeError as exc:
                 html_content, status_code = internal_error(exc)
                 self.assertEqual(status_code, 500)
-                
+
                 # Extract source links from the error page
                 source_link_pattern = r'href="/source/([^"]+)"'
                 source_links = re.findall(source_link_pattern, html_content)
-                
+
                 # Should have at least one source link
                 self.assertGreater(len(source_links), 0, "Should have source links in error page")
-                
+
                 # Test that we can actually access these source links
                 for link in source_links[:3]:  # Test first few links to avoid too many requests
                     source_response = self.client.get(f'/source/{link}')
-                    
+
                     # Source links should either show the file (200) or redirect to login (302)
                     # but should not be 404 (not found)
-                    self.assertIn(source_response.status_code, [200, 302], 
+                    self.assertIn(source_response.status_code, [200, 302],
                                  f"Source link /source/{link} should be accessible")
-                    
+
                     if source_response.status_code == 200:
                         # If we get the file content, verify it's not empty
                         source_content = source_response.get_data(as_text=True)
-                        self.assertGreater(len(source_content), 0, 
+                        self.assertGreater(len(source_content), 0,
                                          f"Source file {link} should have content")
 
     def test_error_page_robustness_with_missing_files(self):
         """Test that error pages work even when some source files might be missing."""
-        
+
         with self.app.test_request_context('/test-robustness'):
             try:
                 # Create an error that might reference non-existent files
@@ -217,20 +211,20 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
             except FileNotFoundError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Even with potential missing files, should still show error info
                 self.assertIn('FileNotFoundError', html_content)
                 self.assertIn('Test error for robustness checking', html_content)
-                
+
                 # Should still have basic error page structure
                 self.assertIn('500 - Internal Server Error', html_content)
                 self.assertIn('Stack trace', html_content)
 
     def test_authenticated_error_page_display(self):
         """Test error page display when user is authenticated."""
-        
+
         with self.app.app_context():
             # Create a test user
             user = User(
@@ -242,64 +236,63 @@ class TestErrorPagesEndToEnd(unittest.TestCase):
             db.session.add(user)
             db.session.commit()
             user_id = user.id
-        
+
         with self.app.test_request_context('/test-auth-error'):
             try:
                 with patch('flask_login.current_user') as mock_user:
                     mock_user.is_authenticated = True
                     mock_user.id = user_id
-                    
+
                     # Import something from aliases to get it in traceback
-                    from routes.aliases import _alias_name_conflicts_with_routes
-                    
+
                     raise RuntimeError('Authenticated user error test')
             except RuntimeError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Should still show full error page with source links
                 self.assertIn('RuntimeError', html_content)
                 self.assertIn('Authenticated user error test', html_content)
-                
+
                 # Should have source links to the test file
                 self.assertIn('href="/source/test_error_pages_e2e.py"', html_content)
 
     def test_error_page_html_structure_and_styling(self):
         """Test that error page has proper HTML structure and Bootstrap styling."""
-        
+
         with self.app.test_request_context('/test-html-structure'):
             try:
                 raise RuntimeError('HTML structure test error')
             except RuntimeError as exc:
                 from routes.core import internal_error
                 html_content, status_code = internal_error(exc)
-                
+
                 self.assertEqual(status_code, 500)
-                
+
                 # Verify proper HTML structure
                 self.assertIn('<!doctype html>', html_content.lower())
                 self.assertIn('<html', html_content)
                 self.assertIn('</html>', html_content)
-                
+
                 # Verify Bootstrap classes and components
                 self.assertIn('container', html_content)
                 self.assertIn('card', html_content)
                 self.assertIn('card-header', html_content)
                 self.assertIn('card-body', html_content)
-                
+
                 # Verify error-specific styling
                 self.assertIn('bg-danger', html_content)  # Red header
                 self.assertIn('text-white', html_content)  # White text on red
-                
+
                 # Verify Font Awesome icons
                 self.assertIn('fas fa-bug', html_content)  # Bug icon
                 self.assertIn('fas fa-external-link-alt', html_content)  # External link icons
-                
+
                 # Verify proper link styling
                 self.assertIn('text-primary', html_content)  # Primary color for links
-                
+
                 # Verify debugging tips section
                 self.assertIn('bg-info bg-opacity-10', html_content)  # Info background
                 self.assertIn('fas fa-lightbulb', html_content)  # Lightbulb icon

--- a/test_error_pages_e2e.py
+++ b/test_error_pages_e2e.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""End-to-end tests for error page display with comprehensive stack traces and source links."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import re
+from pathlib import Path
+
+from app import create_app
+from database import db
+from models import User
+
+
+class TestErrorPagesEndToEnd(unittest.TestCase):
+    """End-to-end tests for error page functionality through HTTP requests."""
+
+    def setUp(self):
+        self.app = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+            'WTF_CSRF_ENABLED': False,
+        })
+        
+        # Skip tests if app is mocked during unittest discover
+        if isinstance(self.app, MagicMock):
+            self.skipTest("Skipping due to mocked app during unittest discover")
+        
+        # Ensure error handlers are properly registered
+        self.app.config['PROPAGATE_EXCEPTIONS'] = False
+        
+        self.client = self.app.test_client()
+        
+        with self.app.app_context():
+            db.create_all()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_500_error_page_shows_stack_trace_with_source_links(self):
+        """Test that 500 error pages show complete stack traces with clickable source links."""
+        
+        with self.app.test_request_context('/test-error'):
+            try:
+                # This will cause a deliberate error with a traceback
+                raise RuntimeError('Deliberate test error for end-to-end testing')
+            except RuntimeError as exc:
+                # Directly call the error handler to get the rendered response
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Verify basic error page structure
+                self.assertIn('500 - Internal Server Error', html_content)
+                self.assertIn('RuntimeError', html_content)
+                self.assertIn('Deliberate test error for end-to-end testing', html_content)
+                
+                # Verify stack trace section exists
+                self.assertIn('Stack trace with source links', html_content)
+                self.assertIn('most recent call last', html_content)
+                
+                # Verify source links are present and properly formatted
+                source_link_pattern = r'href="/source/([^"]+)"'
+                source_links = re.findall(source_link_pattern, html_content)
+                
+                # Should have at least one source link
+                self.assertGreater(len(source_links), 0, "Should have source links in error page")
+                
+                # Verify links open in new tabs
+                self.assertIn('target="_blank"', html_content)
+                
+                # Verify external link icons are present
+                self.assertIn('fas fa-external-link-alt', html_content)
+                
+                # Verify enhanced code context with line markers
+                self.assertIn('>>>', html_content)
+                
+                # Verify debugging tips section
+                self.assertIn('Debugging Tips:', html_content)
+                self.assertIn('Click the', html_content)
+                self.assertIn('links to view source code', html_content)
+
+    def test_error_page_includes_project_file_links(self):
+        """Test that error pages include links to all relevant project files."""
+        
+        with self.app.test_request_context('/test-project-error'):
+            try:
+                # Import project modules to get them in the traceback
+                from routes.core import _build_stack_trace
+                from routes.source import _get_comprehensive_paths
+                
+                # Trigger an error that will include project files in traceback
+                raise ValueError('Project file error test')
+            except ValueError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Look for source links to project files
+                source_link_pattern = r'href="/source/([^"]+)"'
+                source_links = re.findall(source_link_pattern, html_content)
+                
+                # Should have at least one source link (the test file itself)
+                self.assertGreater(len(source_links), 0, 
+                                  "Should have source links in error page")
+                
+                # Verify the links are properly formatted as clickable elements
+                for link in source_links[:3]:  # Check first few links
+                    link_html = f'href="/source/{link}"'
+                    self.assertIn(link_html, html_content)
+                    
+                    # Verify the link has proper styling and opens in new tab
+                    link_context_pattern = rf'<a href="/source/{re.escape(link)}"[^>]*target="_blank"[^>]*>'
+                    self.assertTrue(re.search(link_context_pattern, html_content),
+                                   f"Source link {link} should be properly formatted with target='_blank'")
+
+    def test_exception_chain_display_in_browser(self):
+        """Test that exception chains are properly displayed in browser."""
+        
+        with self.app.test_request_context('/test-exception-chain'):
+            try:
+                try:
+                    raise ValueError('Original error in chain')
+                except ValueError as e:
+                    raise RuntimeError('Chained error for testing') from e
+            except RuntimeError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Verify both exceptions are shown
+                self.assertIn('RuntimeError', html_content)
+                self.assertIn('ValueError', html_content)
+                self.assertIn('Original error in chain', html_content)
+                self.assertIn('Chained error for testing', html_content)
+                
+                # Verify exception chain separator is present
+                self.assertIn('Exception Chain', html_content)
+                self.assertIn('Caused by:', html_content)
+                
+                # Verify proper styling for separators
+                self.assertIn('text-warning', html_content)  # Warning styling for separators
+
+    def test_code_context_display_with_line_numbers(self):
+        """Test that code context shows proper line numbers and error markers."""
+        
+        with self.app.test_request_context('/test-code-context'):
+            try:
+                # Create multiple lines so we can verify context display
+                line1 = "This is line 1"
+                line2 = "This is line 2" 
+                line3 = "This is line 3"
+                # The next line should be marked with >>> in the error display
+                raise RuntimeError('Error with code context')
+            except RuntimeError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Verify enhanced code context is shown
+                self.assertIn('>>>', html_content)  # Error line marker
+                
+                # Verify line numbers are present in context
+                line_number_pattern = r'&gt;&gt;&gt;\s*\d+:'
+                self.assertTrue(re.search(line_number_pattern, html_content),
+                               f"Should show line numbers with >>> marker for error line")
+                
+                # Verify code context is properly formatted
+                self.assertIn('<pre', html_content)  # Code should be in pre tags
+                self.assertIn('<code>', html_content)  # And code tags
+
+    def test_source_browser_accessibility_from_error_links(self):
+        """Test that source links from error pages actually work."""
+        
+        with self.app.test_request_context('/test-source-links'):
+            try:
+                from routes.core import internal_error  # This should appear in traceback
+                raise RuntimeError('Error to generate source links')
+            except RuntimeError as exc:
+                html_content, status_code = internal_error(exc)
+                self.assertEqual(status_code, 500)
+                
+                # Extract source links from the error page
+                source_link_pattern = r'href="/source/([^"]+)"'
+                source_links = re.findall(source_link_pattern, html_content)
+                
+                # Should have at least one source link
+                self.assertGreater(len(source_links), 0, "Should have source links in error page")
+                
+                # Test that we can actually access these source links
+                for link in source_links[:3]:  # Test first few links to avoid too many requests
+                    source_response = self.client.get(f'/source/{link}')
+                    
+                    # Source links should either show the file (200) or redirect to login (302)
+                    # but should not be 404 (not found)
+                    self.assertIn(source_response.status_code, [200, 302], 
+                                 f"Source link /source/{link} should be accessible")
+                    
+                    if source_response.status_code == 200:
+                        # If we get the file content, verify it's not empty
+                        source_content = source_response.get_data(as_text=True)
+                        self.assertGreater(len(source_content), 0, 
+                                         f"Source file {link} should have content")
+
+    def test_error_page_robustness_with_missing_files(self):
+        """Test that error pages work even when some source files might be missing."""
+        
+        with self.app.test_request_context('/test-robustness'):
+            try:
+                # Create an error that might reference non-existent files
+                raise FileNotFoundError('Test error for robustness checking')
+            except FileNotFoundError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Even with potential missing files, should still show error info
+                self.assertIn('FileNotFoundError', html_content)
+                self.assertIn('Test error for robustness checking', html_content)
+                
+                # Should still have basic error page structure
+                self.assertIn('500 - Internal Server Error', html_content)
+                self.assertIn('Stack trace', html_content)
+
+    def test_authenticated_error_page_display(self):
+        """Test error page display when user is authenticated."""
+        
+        with self.app.app_context():
+            # Create a test user
+            user = User(
+                id='test-user-123',
+                email='test@example.com',
+                first_name='Test',
+                last_name='User'
+            )
+            db.session.add(user)
+            db.session.commit()
+            user_id = user.id
+        
+        with self.app.test_request_context('/test-auth-error'):
+            try:
+                with patch('flask_login.current_user') as mock_user:
+                    mock_user.is_authenticated = True
+                    mock_user.id = user_id
+                    
+                    # Import something from aliases to get it in traceback
+                    from routes.aliases import _alias_name_conflicts_with_routes
+                    
+                    raise RuntimeError('Authenticated user error test')
+            except RuntimeError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Should still show full error page with source links
+                self.assertIn('RuntimeError', html_content)
+                self.assertIn('Authenticated user error test', html_content)
+                
+                # Should have source links to the test file
+                self.assertIn('href="/source/test_error_pages_e2e.py"', html_content)
+
+    def test_error_page_html_structure_and_styling(self):
+        """Test that error page has proper HTML structure and Bootstrap styling."""
+        
+        with self.app.test_request_context('/test-html-structure'):
+            try:
+                raise RuntimeError('HTML structure test error')
+            except RuntimeError as exc:
+                from routes.core import internal_error
+                html_content, status_code = internal_error(exc)
+                
+                self.assertEqual(status_code, 500)
+                
+                # Verify proper HTML structure
+                self.assertIn('<!doctype html>', html_content.lower())
+                self.assertIn('<html', html_content)
+                self.assertIn('</html>', html_content)
+                
+                # Verify Bootstrap classes and components
+                self.assertIn('container', html_content)
+                self.assertIn('card', html_content)
+                self.assertIn('card-header', html_content)
+                self.assertIn('card-body', html_content)
+                
+                # Verify error-specific styling
+                self.assertIn('bg-danger', html_content)  # Red header
+                self.assertIn('text-white', html_content)  # White text on red
+                
+                # Verify Font Awesome icons
+                self.assertIn('fas fa-bug', html_content)  # Bug icon
+                self.assertIn('fas fa-external-link-alt', html_content)  # External link icons
+                
+                # Verify proper link styling
+                self.assertIn('text-primary', html_content)  # Primary color for links
+                
+                # Verify debugging tips section
+                self.assertIn('bg-info bg-opacity-10', html_content)  # Info background
+                self.assertIn('fas fa-lightbulb', html_content)  # Lightbulb icon
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_meta_route.py
+++ b/test_meta_route.py
@@ -53,8 +53,23 @@ class TestMetaRoute(unittest.TestCase):
         db.session.commit()
         return record
 
-    def _create_alias(self, user: User, name: str = 'docs', target: str = '/docs'):
-        alias = Alias(name=name, target_path=target, user_id=user.id)
+    def _create_alias(
+        self,
+        user: User,
+        name: str = 'docs',
+        target: str = '/docs',
+        match_type: str = 'literal',
+        pattern: str | None = None,
+        ignore_case: bool = False,
+    ):
+        alias = Alias(
+            name=name,
+            target_path=target,
+            user_id=user.id,
+            match_type=match_type,
+            match_pattern=pattern or f'/{name}',
+            ignore_case=ignore_case,
+        )
         db.session.add(alias)
         db.session.commit()
         return alias


### PR DESCRIPTION
## Summary
- introduce utilities for normalising and matching alias patterns and reuse them across the app
- extend alias management forms and views with match type options, case control, and an inline tester
- update routing, import/export, and metadata logic along with tests to cover the new alias behaviours

## Testing
- pytest test_alias_routing.py test_import_export.py test_meta_route.py

------
https://chatgpt.com/codex/tasks/task_b_68d80a632d6c8331a5997c88b5a28ded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pattern-based alias matching: literal, glob, regex, and Flask-style, with optional case-insensitive matching.
  - Alias form upgrades: select match type, enter pattern, toggle case sensitivity, and test patterns with live results.
  - Aliases list and detail views now show match pattern, type, and case-sensitivity.
  - Import/export now includes match settings for aliases.
  - Smarter alias resolution that prioritizes user-specific matches.

- New Features (Error Handling)
  - Enhanced error pages with comprehensive stack traces, source links, exception chain display, and debugging tips.
  - Source browser can show broader project files, not just version-controlled ones.
  - Custom error handling active even in debug mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->