### PR TITLE
Ensure literal alias forms derive literal patterns from the alias name

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -157,7 +157,10 @@ class AliasForm(FlaskForm):
         if not super().validate(extra_validators):
             return False
 
-        match_type = self.match_type.data or 'literal'
+        match_type = (self.match_type.data or 'literal').lower()
+
+        if match_type == 'literal':
+            self.match_pattern.data = self.name.data
         try:
             normalised = normalise_pattern(match_type, self.match_pattern.data, self.name.data)
         except PatternError as exc:

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -79,7 +79,7 @@
                             {% endif %}
                         </div>
 
-                        <div class="mb-3">
+                        <div class="mb-3" id="match-pattern-group">
                             {{ form.match_pattern.label(class="form-label") }}
                             {{ form.match_pattern(class="form-control" + (" is-invalid" if form.match_pattern.errors else "")) }}
                             {% if form.match_pattern.errors %}
@@ -100,14 +100,14 @@
                             {{ form.ignore_case.label(class="form-check-label") }}
                         </div>
 
-                        <div class="mb-3">
+                        <div class="mb-3" data-alias-testing>
                             {{ form.test_strings.label(class="form-label") }}
                             {{ form.test_strings(class="form-control") }}
                             <div class="form-text">Enter one path per line to try the current configuration without saving.</div>
                         </div>
 
                         {% if test_results %}
-                        <div class="mb-3">
+                        <div class="mb-3" data-alias-testing>
                             <div class="alert alert-secondary mb-0">
                                 <h6 class="alert-heading">Test Results</h6>
                                 <ul class="list-unstyled mb-0 small">
@@ -131,7 +131,9 @@
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
                             <div class="d-flex gap-2">
-                                {{ form.test_pattern(class="btn btn-outline-primary") }}
+                                <div data-alias-testing>
+                                    {{ form.test_pattern(class="btn btn-outline-primary") }}
+                                </div>
                                 {{ form.submit(class="btn btn-primary") }}
                             </div>
                         </div>
@@ -161,4 +163,35 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var matchTypeName = {{ form.match_type.name|tojson }};
+    var matchTypeInputs = document.querySelectorAll('input[name="' + matchTypeName + '"]');
+    var patternGroup = document.getElementById('match-pattern-group');
+    var testingGroups = document.querySelectorAll('[data-alias-testing]');
+
+    function updateVisibility() {
+        var selected = document.querySelector('input[name="' + matchTypeName + '"]:checked');
+        var isLiteral = selected && selected.value === 'literal';
+
+        if (patternGroup) {
+            patternGroup.classList.toggle('d-none', isLiteral);
+        }
+
+        testingGroups.forEach(function (element) {
+            element.classList.toggle('d-none', isLiteral);
+        });
+    }
+
+    matchTypeInputs.forEach(function (input) {
+        input.addEventListener('change', updateVisibility);
+    });
+
+    updateVisibility();
+});
+</script>
 {% endblock %}

--- a/test_alias_routing.py
+++ b/test_alias_routing.py
@@ -212,7 +212,7 @@ class TestAliasRouting(unittest.TestCase):
                 'name': 'release',
                 'target_path': '/cid456',
                 'match_type': 'literal',
-                'match_pattern': '',
+                'match_pattern': '/custom-pattern',
             },
             follow_redirects=False,
         )
@@ -277,7 +277,7 @@ class TestAliasRouting(unittest.TestCase):
                 'name': 'docs',
                 'target_path': '/docs',
                 'match_type': 'literal',
-                'match_pattern': '',
+                'match_pattern': '/custom-pattern',
             },
             follow_redirects=False,
         )


### PR DESCRIPTION
## Summary
- hide the match pattern input and testing controls when the literal match type is chosen on the alias form
- force literal aliases to derive their stored match pattern directly from the alias name during validation
- update alias routing tests to assert literal patterns ignore custom input values

## Testing
- pytest test_alias_routing.py

------
https://chatgpt.com/codex/tasks/task_b_68d880ab5adc8331860ff74c865c768f