### PR TITLE
Add alias/server creation shortcuts to 404 page

### DIFF
--- a/routes/aliases.py
+++ b/routes/aliases.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from flask import abort, flash, redirect, render_template, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 
 from auth_providers import require_login
@@ -13,7 +13,7 @@ from forms import AliasForm
 from models import Alias
 
 from . import main_bp
-from .core import get_existing_routes
+from .core import derive_name_from_path, get_existing_routes
 
 
 def _alias_name_conflicts_with_routes(name: str) -> bool:
@@ -45,6 +45,12 @@ def new_alias():
     """Create a new alias for the authenticated user."""
     form = AliasForm()
     test_results = None
+
+    if request.method == 'GET':
+        path_hint = request.args.get('path', '')
+        suggested_name = derive_name_from_path(path_hint)
+        if suggested_name and not form.name.data:
+            form.name.data = suggested_name
 
     if form.validate_on_submit():
         if form.test_pattern.data:

--- a/routes/core.py
+++ b/routes/core.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import traceback
 from typing import Any, Dict, List, Optional
 
@@ -56,6 +57,29 @@ def _extract_exception(error: Exception) -> Exception:
     if isinstance(original, Exception):
         return original
     return error
+
+
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def derive_name_from_path(path: str) -> Optional[str]:
+    """Return the first path segment when it is safe for use as a name."""
+
+    if not path:
+        return None
+
+    remainder = path.lstrip("/")
+    if not remainder:
+        return None
+
+    segment = remainder.split("/", 1)[0]
+    if not segment:
+        return None
+
+    if not _NAME_PATTERN.fullmatch(segment):
+        return None
+
+    return segment
 
 
 def _build_stack_trace(error: Exception) -> List[Dict[str, Any]]:

--- a/routes/servers.py
+++ b/routes/servers.py
@@ -1,6 +1,6 @@
 """Server management routes and helpers."""
 
-from flask import abort, flash, redirect, render_template, url_for
+from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 
 from auth_providers import require_login
@@ -15,6 +15,7 @@ from models import CID, Server, ServerInvocation
 from server_templates import get_server_templates
 
 from . import main_bp
+from .core import derive_name_from_path
 from .entities import create_entity, update_entity
 from .history import _load_request_referers
 from .uploads import _shorten_cid
@@ -106,6 +107,12 @@ def servers():
 def new_server():
     """Create a new server."""
     form = ServerForm()
+
+    if request.method == 'GET':
+        path_hint = request.args.get('path', '')
+        suggested_name = derive_name_from_path(path_hint)
+        if suggested_name and not form.name.data:
+            form.name.data = suggested_name
 
     if form.validate_on_submit():
         if create_entity(Server, form, current_user.id, 'server'):

--- a/templates/404.html
+++ b/templates/404.html
@@ -24,6 +24,12 @@
                         <a href="{{ url_for('main.upload') }}" class="btn btn-success">
                             <i class="fas fa-upload me-2"></i>Upload File
                         </a>
+                        <a href="{{ url_for('main.new_alias', path=path) }}" class="btn btn-outline-primary">
+                            <i class="fas fa-link me-2"></i>Define New Alias
+                        </a>
+                        <a href="{{ url_for('main.new_server', path=path) }}" class="btn btn-outline-success">
+                            <i class="fas fa-server me-2"></i>Define New Server
+                        </a>
                         {% if current_user.is_authenticated %}
                             <a href="{{ url_for('main.profile') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-user me-2"></i>Profile

--- a/test_alias_routing.py
+++ b/test_alias_routing.py
@@ -249,6 +249,15 @@ class TestAliasRouting(unittest.TestCase):
         self.assertEqual(created.match_pattern, '/release/*/latest')
         self.assertTrue(created.ignore_case)
 
+    def test_new_alias_prefills_name_from_path_query(self):
+        self.login()
+
+        response = self.client.get('/aliases/new?path=/docs/latest')
+
+        self.assertEqual(response.status_code, 200)
+        page = response.get_data(as_text=True)
+        self.assertIn('value="docs"', page)
+
     def test_create_alias_rejects_conflicting_route(self):
         self.login()
 

--- a/test_routes_comprehensive.py
+++ b/test_routes_comprehensive.py
@@ -153,6 +153,17 @@ class TestPublicRoutes(BaseTestCase):
         response = self.client.get('/privacy')
         self.assertEqual(response.status_code, 200)
 
+    def test_404_page_includes_creation_links(self):
+        """The 404 page should offer shortcuts for creating aliases or servers."""
+        missing_path = '/missing/path'
+
+        response = self.client.get(missing_path)
+        self.assertEqual(response.status_code, 404)
+
+        page = response.get_data(as_text=True)
+        self.assertIn(f"/aliases/new?path={missing_path}", page)
+        self.assertIn(f"/servers/new?path={missing_path}", page)
+
 
 class TestAuthenticatedRoutes(BaseTestCase):
     """Test routes that require authentication."""
@@ -845,6 +856,16 @@ class TestServerRoutes(BaseTestCase):
             self.assertIn(template['name'], page)
             if template.get('description'):
                 self.assertIn(template['description'], page)
+
+    def test_new_server_prefills_name_from_path_query(self):
+        """The server creation form should reuse the requested path for its name."""
+        self.login_user()
+
+        response = self.client.get('/servers/new?path=/docs/latest')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('value="docs"', page)
 
     def test_new_server_post(self):
         """Test creating new server."""


### PR DESCRIPTION
## Summary
- add alias and server creation links to the 404 page using the requested path
- pre-populate alias and server creation forms with a safe name derived from the missing path
- cover the new behaviour with targeted unit tests

## Testing
- pytest test_alias_routing.py::TestAliasRouting::test_new_alias_prefills_name_from_path_query test_routes_comprehensive.py::TestPublicRoutes::test_404_page_includes_creation_links test_routes_comprehensive.py::TestServerRoutes::test_new_server_prefills_name_from_path_query

------
https://chatgpt.com/codex/tasks/task_b_68d88756e7a88331a1438def43adf068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - “New Alias” and “New Server” forms now auto-suggest a name from the provided path query (e.g., ?path=/docs/latest), pre-filling the name field when empty.
  - 404 page now includes quick actions to create an alias or server for the missing path.

- Tests
  - Added coverage for name prefill behavior on alias and server creation forms.
  - Added test ensuring 404 page shows creation shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->