### PR TITLE
Support alias updates during CID editing

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -93,6 +93,18 @@ def get_alias_by_name(user_id: str, name: str):
     return Alias.query.filter_by(user_id=user_id, name=name).first()
 
 
+def get_alias_by_target_path(user_id: str, target_path: str):
+    return (
+        Alias.query.filter_by(
+            user_id=user_id,
+            target_path=target_path,
+            match_type='literal',
+        )
+        .order_by(Alias.id.asc())
+        .first()
+    )
+
+
 def get_user_variables(user_id: str):
     return Variable.query.filter_by(user_id=user_id).order_by(Variable.name).all()
 

--- a/forms.py
+++ b/forms.py
@@ -64,6 +64,17 @@ class EditCidForm(FlaskForm):
         validators=[DataRequired()],
         render_kw={'rows': 15, 'placeholder': 'Update the CID content here...'},
     )
+    alias_name = StringField(
+        'Alias Name (optional)',
+        validators=[
+            Optional(),
+            Regexp(
+                r'^[a-zA-Z0-9._-]+$',
+                message='Alias name can only contain letters, numbers, dots, hyphens, and underscores',
+            ),
+        ],
+        filters=[_strip_filter],
+    )
     submit = SubmitField('Save Changes')
 
 class InvitationForm(FlaskForm):

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -30,11 +30,33 @@
                                 </div>
                             {% endif %}
                             <small class="form-text text-muted">
-                                Update the text below and click "Save Changes" to store the edited content as a new CID entry.
+                                Update the text below and click "{{ submit_label }}" to store the edited content as a new CID entry.
                             </small>
                         </div>
+                        {% if not show_alias_field and current_alias_name %}
+                            <div class="alert alert-info" role="alert">
+                                <i class="fas fa-link me-1"></i>
+                                Saving will update the <strong>{{ current_alias_name }}</strong> alias to point at the new CID.
+                            </div>
+                        {% endif %}
+                        {% if show_alias_field %}
+                            <div class="mb-3">
+                                {{ form.alias_name.label(class="form-label") }}
+                                {{ form.alias_name(class="form-control" + (" is-invalid" if form.alias_name.errors else "")) }}
+                                {% if form.alias_name.errors %}
+                                    <div class="invalid-feedback d-block">
+                                        {% for error in form.alias_name.errors %}
+                                            <div>{{ error }}</div>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                                <small class="form-text text-muted">
+                                    Optionally supply a new alias to point at the saved content. Alias names are case sensitive.
+                                </small>
+                            </div>
+                        {% endif %}
                         <div class="d-flex gap-2">
-                            {{ form.submit(class="btn btn-primary") }}
+                            {{ form.submit(class="btn btn-primary", value=submit_label) }}
                             <a href="/{{ cid }}" class="btn btn-outline-secondary" target="_blank">
                                 <i class="fas fa-external-link-alt me-1"></i>View Original
                             </a>


### PR DESCRIPTION
## Summary
- update the CID edit view to expose optional alias creation and to retarget existing aliases when new content is saved
- add form and template changes so the save button reflects the alias name and explains how aliases are handled
- expand route tests to cover alias retargeting, alias creation, and duplicate-alias validation scenarios

## Testing
- pytest test_routes_comprehensive.py::TestCidEditingRoutes -q

------
https://chatgpt.com/codex/tasks/task_b_68d88ef131f8833186297412ade115c4