### PR TITLE
Add automatic main() mapping for server definitions

### DIFF
--- a/server_templates/definitions/auto_main.py
+++ b/server_templates/definitions/auto_main.py
@@ -1,0 +1,28 @@
+# ruff: noqa: F821, F706
+"""Demonstrates automatic mapping to a main() function."""
+
+from html import escape
+
+
+def render_row(label, value):
+    if value in (None, ""):
+        return ""
+    return f"<p><strong>{escape(str(label))}:</strong> {escape(str(value))}</p>"
+
+
+def main(name, greeting="Hello", topic="Viewer", user_agent=None, context=None):
+    """Render a greeting using values drawn from the request."""
+    message = f"{greeting}, {name}!"
+    details = [
+        "<html><body>",
+        "<h1>Automatic main() mapping</h1>",
+        render_row("Message", message),
+        render_row("Topic", topic),
+        render_row("User-Agent", user_agent or "(not provided)"),
+        "<p>This template reads query parameters, request body values, and headers.</p>",
+        "</body></html>",
+    ]
+    return {
+        "output": "".join(details),
+        "content_type": "text/html",
+    }

--- a/server_templates/templates/auto_main.json
+++ b/server_templates/templates/auto_main.json
@@ -1,0 +1,6 @@
+{
+  "id": "auto-main",
+  "name": "Automatic main() mapping",
+  "description": "Demonstrates automatic request parameter mapping to a main() function.",
+  "definition_file": "definitions/auto_main.py"
+}

--- a/test_server_auto_main.py
+++ b/test_server_auto_main.py
@@ -1,0 +1,190 @@
+from types import SimpleNamespace
+
+import pytest
+
+import server_execution
+from app import app
+from server_templates import get_server_templates
+
+
+@pytest.fixture(autouse=True)
+def patch_execution_environment(monkeypatch):
+    monkeypatch.setattr(
+        server_execution,
+        "current_user",
+        SimpleNamespace(is_authenticated=True, id="user-123"),
+    )
+    monkeypatch.setattr(
+        server_execution,
+        "_load_user_context",
+        lambda: {"variables": {}, "secrets": {}, "servers": {}},
+    )
+
+    def fake_success(output, content_type, server_name):
+        return {
+            "output": output,
+            "content_type": content_type,
+            "server_name": server_name,
+        }
+
+    monkeypatch.setattr(server_execution, "_handle_successful_execution", fake_success)
+
+
+def test_auto_main_uses_query_parameters_over_other_sources():
+    definition = """
+ def main(name, greeting="Hello"):
+     return {"output": f"{greeting}, {name}", "content_type": "text/plain"}
+ """
+
+    with app.test_request_context(
+        "/welcome?name=Query&greeting=Hi",
+        json={"name": "Body", "greeting": "Body"},
+        headers={"Name": "Header"},
+    ):
+        result = server_execution.execute_server_code_from_definition(definition, "welcome")
+
+    assert result["output"] == "Hi, Query"
+    assert result["content_type"] == "text/plain"
+    assert result["server_name"] == "welcome"
+
+
+def test_auto_main_reads_request_body_when_query_missing():
+    definition = """
+ def main(topic):
+     return {"output": topic, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/topic", json={"topic": "Body topic"}):
+        result = server_execution.execute_server_code_from_definition(definition, "topic")
+
+    assert result["output"] == "Body topic"
+
+
+def test_auto_main_prefers_body_over_headers():
+    definition = """
+ def main(token):
+     return {"output": token, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context(
+        "/body", json={"token": "from-body"}, headers={"Token": "from-header"}
+    ):
+        result = server_execution.execute_server_code_from_definition(definition, "body")
+
+    assert result["output"] == "from-body"
+
+
+def test_auto_main_reads_headers_when_query_and_body_missing():
+    definition = """
+ def main(user_agent):
+     return {"output": user_agent, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/ua", headers={"User-Agent": "HeaderUA"}):
+        result = server_execution.execute_server_code_from_definition(definition, "ua")
+
+    assert result["output"] == "HeaderUA"
+
+
+def test_auto_main_matches_hyphenated_headers():
+    definition = """
+ def main(x_custom_token):
+     return {"output": x_custom_token, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/token", headers={"X-Custom-Token": "header-value"}):
+        result = server_execution.execute_server_code_from_definition(definition, "token")
+
+    assert result["output"] == "header-value"
+
+
+def test_auto_main_missing_required_parameter_returns_detailed_error():
+    definition = """
+ def main(required_value):
+     return {"output": required_value}
+ """
+
+    with app.test_request_context("/missing"):
+        response = server_execution.execute_server_code_from_definition(definition, "missing")
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Missing required parameters for main()"
+    assert payload["missing_parameters"][0]["name"] == "required_value"
+    assert payload["available_keys"]["query_string"] == []
+    assert payload["available_keys"]["request_body"] == []
+    assert isinstance(payload["available_keys"]["headers"], list)
+
+
+def test_auto_main_honors_optional_defaults():
+    definition = """
+ def main(name="World"):
+     return {"output": name, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/optional"):
+        result = server_execution.execute_server_code_from_definition(definition, "optional")
+
+    assert result["output"] == "World"
+
+
+def test_auto_main_supports_keyword_only_parameters():
+    definition = """
+ def main(*, token):
+     return {"output": token, "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/kwonly", json={"token": "kw"}):
+        result = server_execution.execute_server_code_from_definition(definition, "kwonly")
+
+    assert result["output"] == "kw"
+
+
+def test_auto_main_allows_request_context_parameter():
+    definition = """
+ def main(request):
+     return {"output": request["path"], "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/context?value=1"):
+        result = server_execution.execute_server_code_from_definition(definition, "context")
+
+    assert result["output"] == "/context"
+
+
+def test_auto_main_skips_when_explicit_return_present():
+    definition = """
+ def main(name):
+     return {"output": f"auto {name}"}
+
+ return {"output": "manual", "content_type": "text/plain"}
+ """
+
+    with app.test_request_context("/manual?name=Query"):
+        result = server_execution.execute_server_code_from_definition(definition, "manual")
+
+    assert result["output"] == "manual"
+
+
+def test_auto_main_rejects_unsupported_signatures():
+    definition = """
+ def main(name, *args):
+     return {"output": name}
+ """
+
+    with app.test_request_context("/unsupported?name=value"):
+        response = server_execution.execute_server_code_from_definition(definition, "unsupported")
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "Unsupported main() signature" in payload["error"]
+    assert any("*args" in reason for reason in payload["reasons"])
+
+
+def test_server_templates_include_auto_main_definition():
+    templates = get_server_templates()
+    auto_templates = [template for template in templates if template["id"] == "auto-main"]
+    assert auto_templates, "auto-main template should be registered"
+    definition = auto_templates[0]["definition"]
+    assert "def main(" in definition
+    assert "Automatic main() mapping" in definition


### PR DESCRIPTION
## Summary
- detect main() definitions without explicit returns and wrap them for automatic invocation
- resolve main() parameters from query strings, bodies, and headers with clear missing-parameter errors
- add an automatic main() template and comprehensive tests covering the new mapping rules

## Testing
- pytest test_server_auto_main.py

------
https://chatgpt.com/codex/tasks/task_b_68d9858b6518833195ff93fc3bb097e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic mapping of request data to a main() function’s parameters, with support for defaults and keyword-only args.
  - Clear 400 errors when required parameters are missing or signatures are unsupported, including detailed diagnostics.
  - Hyphenated headers are recognized and correctly mapped.
  - Parameter precedence: query > JSON/form body > headers.
  - New “Automatic main() mapping” server template and example.
- Tests
  - Comprehensive test coverage for parameter resolution, error handling, header mapping, precedence rules, template registration, and opt-out when a manual return is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->