### PR TITLE
Centralize CID presentation helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 import logfire
 
 from database import db, init_db
+from cid_presenter import cid_full_url, cid_path, format_cid, format_cid_short
 
 # Load environment variables from .env file
 load_dotenv()
@@ -63,6 +64,13 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
         app.config.update(config_override)
 
     app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)  # needed for url_for to generate with https
+
+    app.jinja_env.globals.update(
+        cid_full_url=cid_full_url,
+        cid_path=cid_path,
+        format_cid=format_cid,
+        format_cid_short=format_cid_short,
+    )
 
     # Initialize database
     init_db(app)

--- a/cid_presenter.py
+++ b/cid_presenter.py
@@ -1,0 +1,62 @@
+"""Helpers for presenting CIDs and CID-backed links consistently."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _normalize_value(value: Optional[str]) -> str:
+    """Return a normalized CID value without leading slashes or surrounding whitespace."""
+    if value is None:
+        return ""
+    stripped = value.strip()
+    if stripped.startswith("/"):
+        stripped = stripped.lstrip("/")
+    return stripped
+
+
+def format_cid(value: Optional[str]) -> str:
+    """Return a canonical string representation of a CID for display."""
+    return _normalize_value(value)
+
+
+def format_cid_short(value: Optional[str], length: int = 6) -> Optional[str]:
+    """Return a shortened CID label suitable for compact displays."""
+    normalized = _normalize_value(value)
+    if not normalized:
+        return None
+    if len(normalized) <= length:
+        return normalized
+    return f"{normalized[:length]}..."
+
+
+def cid_path(value: Optional[str], extension: Optional[str] = None) -> Optional[str]:
+    """Return a relative path to CID content, optionally appending an extension."""
+    normalized = _normalize_value(value)
+    if not normalized:
+        return None
+
+    suffix = ""
+    if extension:
+        ext = extension.strip()
+        if ext:
+            suffix = f".{ext.lstrip('.')}"
+
+    return f"/{normalized}{suffix}"
+
+
+def cid_full_url(base_url: str, value: Optional[str], extension: Optional[str] = None) -> Optional[str]:
+    """Return an absolute URL pointing at CID content using the provided base URL."""
+    path = cid_path(value, extension)
+    if not path:
+        return None
+    base = (base_url or "").rstrip("/")
+    return f"{base}{path}"
+
+
+__all__ = [
+    "cid_full_url",
+    "cid_path",
+    "format_cid",
+    "format_cid_short",
+]

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -4,6 +4,8 @@ import json
 import re
 from urllib.parse import urlparse
 
+from cid_presenter import cid_path, format_cid
+
 import requests
 from flask import make_response, request
 
@@ -136,13 +138,14 @@ def save_server_definition_as_cid(definition, user_id):
     """Save server definition as CID and return the CID string"""
     _ensure_db_access()
     definition_bytes = definition.encode('utf-8')
-    cid = generate_cid(definition_bytes)
+    cid_value = format_cid(generate_cid(definition_bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if not content:
-        create_cid_record(cid, definition_bytes, user_id)
+        create_cid_record(cid_value, definition_bytes, user_id)
 
-    return cid
+    return cid_value
 
 
 def store_cid_from_json(json_content, user_id):
@@ -153,13 +156,14 @@ def store_cid_from_json(json_content, user_id):
 def store_cid_from_bytes(bytes, user_id):
     """Store content in a CID record and return the CID"""
     _ensure_db_access()
-    cid = generate_cid(bytes)
+    cid_value = format_cid(generate_cid(bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if not content:
-        create_cid_record(cid, bytes, user_id)
+        create_cid_record(cid_value, bytes, user_id)
 
-    return cid
+    return cid_value
 
 # ============================================================================
 # DEFINITIONS CID HELPERS
@@ -189,11 +193,12 @@ def get_current_server_definitions_cid(user_id):
     _ensure_db_access()
     json_content = generate_all_server_definitions_json(user_id)
     json_bytes = json_content.encode('utf-8')
-    cid = generate_cid(json_bytes)
+    cid_value = format_cid(generate_cid(json_bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if content:
-        return cid
+        return cid_value
     return store_server_definitions_cid(user_id)
 
 
@@ -221,11 +226,12 @@ def get_current_variable_definitions_cid(user_id):
     _ensure_db_access()
     json_content = generate_all_variable_definitions_json(user_id)
     json_bytes = json_content.encode('utf-8')
-    cid = generate_cid(json_bytes)
+    cid_value = format_cid(generate_cid(json_bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if content:
-        return cid
+        return cid_value
     return store_variable_definitions_cid(user_id)
 
 
@@ -246,13 +252,14 @@ def store_secret_definitions_cid(user_id):
     _ensure_db_access()
     json_content = generate_all_secret_definitions_json(user_id)
     json_bytes = json_content.encode('utf-8')
-    cid = generate_cid(json_bytes)
+    cid_value = format_cid(generate_cid(json_bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if not content:
-        create_cid_record(cid, json_bytes, user_id)
+        create_cid_record(cid_value, json_bytes, user_id)
 
-    return cid
+    return cid_value
 
 
 def get_current_secret_definitions_cid(user_id):
@@ -260,11 +267,12 @@ def get_current_secret_definitions_cid(user_id):
     _ensure_db_access()
     json_content = generate_all_secret_definitions_json(user_id)
     json_bytes = json_content.encode('utf-8')
-    cid = generate_cid(json_bytes)
+    cid_value = format_cid(generate_cid(json_bytes))
 
-    content = get_cid_by_path(f"/{cid}")
+    cid_record_path = cid_path(cid_value)
+    content = get_cid_by_path(cid_record_path) if cid_record_path else None
     if content:
-        return cid
+        return cid_value
 
     return store_secret_definitions_cid(user_id)
 

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -15,7 +15,7 @@
                 <div class="card-body">
                     <p class="text-muted">
                         You are editing the content stored for CID:
-                        <span class="font-monospace">{{ cid }}</span>
+                        <span class="font-monospace">{{ format_cid(cid) }}</span>
                     </p>
                     <form method="POST">
                         {{ form.hidden_tag() }}
@@ -57,7 +57,7 @@
                         {% endif %}
                         <div class="d-flex gap-2">
                             {{ form.submit(class="btn btn-primary", value=submit_label) }}
-                            <a href="/{{ cid }}" class="btn btn-outline-secondary" target="_blank">
+                            <a href="{{ cid_path(cid) or '#' }}" class="btn btn-outline-secondary" target="_blank">
                                 <i class="fas fa-external-link-alt me-1"></i>View Original
                             </a>
                         </div>

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -10,7 +10,8 @@
                 <h2><i class="fas fa-key me-2"></i>My Secrets</h2>
                 <div class="btn-group">
                     {% if secret_definitions_cid %}
-                    <a href="/{{ secret_definitions_cid }}.json" target="_blank" class="btn btn-outline-secondary">
+                    {% set secret_link = cid_path(secret_definitions_cid, 'json') %}
+                    <a href="{{ secret_link or '#' }}" target="_blank" class="btn btn-outline-secondary">
                         <i class="fas fa-download me-1"></i>Export All as JSON
                     </a>
                     {% endif %}

--- a/templates/server_events.html
+++ b/templates/server_events.html
@@ -67,7 +67,7 @@
                                     </td>
                                     <td>
                                         {% if event.invocation_link %}
-                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.invocation_cid) }}">
                                                 <code class="small">{{ event.invocation_label }}</code>
                                             </a>
                                         {% else %}
@@ -76,7 +76,7 @@
                                     </td>
                                     <td>
                                         {% if event.request_details_link %}
-                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.request_details_cid) }}">
                                                 <code class="small">{{ event.request_details_label }}</code>
                                             </a>
                                         {% else %}
@@ -85,7 +85,7 @@
                                     </td>
                                     <td>
                                         {% if event.result_link %}
-                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.result_cid) }}">
                                                 <code class="small">{{ event.result_label }}</code>
                                             </a>
                                         {% else %}
@@ -94,7 +94,7 @@
                                     </td>
                                     <td>
                                         {% if event.servers_cid_link %}
-                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.servers_cid) }}">
                                                 <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
                                         {% else %}

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -143,13 +143,15 @@
                                             {{ entry.created_at.strftime('%Y-%m-%d %H:%M:%S') }}
                                         </h6>
                                         <div class="ms-auto">
-                                            <a href="/{{ entry.definition_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
+                                            {% set entry_definition_link = cid_path(entry.definition_cid, 'txt') %}
+                                            <a href="{{ entry_definition_link or '#' }}" target="_blank" class="btn btn-outline-primary btn-sm me-2">
                                                 <i class="fas fa-external-link-alt me-1"></i>View as Text
                                             </a>
                                             <button class="btn btn-outline-secondary btn-sm me-2" onclick="copyHistoricalDefinition('{{ loop.index0 }}')">
                                                 <i class="fas fa-copy me-1"></i>Copy
                                             </button>
-                                            <a href="/{{ entry.snapshot_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm me-2">
+                                            {% set snapshot_link = cid_path(entry.snapshot_cid, 'json') %}
+                                            <a href="{{ snapshot_link or '#' }}" target="_blank" class="btn btn-outline-info btn-sm me-2">
                                                 <i class="fas fa-code me-1"></i>View JSON
                                             </a>
                                             <button class="btn btn-outline-info btn-sm" onclick="loadHistoricalDefinition('{{ loop.index0 }}')">
@@ -158,7 +160,7 @@
                                         </div>
                                     </div>
                                     <div class="text-muted small mb-2">
-                                        Definition CID: <code>{{ entry.definition_cid }}</code>
+                                        Definition CID: <code>{{ format_cid(entry.definition_cid) }}</code>
                                     </div>
                                     <div class="collapse" id="definition-{{ loop.index0 }}">
                                         <pre class="border rounded p-3 bg-light historical-definition" style="white-space: pre-wrap; max-height: 300px; overflow-y: auto;">{{ entry.definition }}</pre>
@@ -208,7 +210,7 @@
                                     </td>
                                     <td>
                                         {% if event.invocation_link %}
-                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.invocation_cid) }}">
                                                 <code class="small">{{ event.invocation_label }}</code>
                                             </a>
                                         {% else %}
@@ -217,7 +219,7 @@
                                     </td>
                                     <td>
                                         {% if event.request_details_link %}
-                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.request_details_cid) }}">
                                                 <code class="small">{{ event.request_details_label }}</code>
                                             </a>
                                         {% else %}
@@ -226,7 +228,7 @@
                                     </td>
                                     <td>
                                         {% if event.result_link %}
-                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.result_cid) }}">
                                                 <code class="small">{{ event.result_label }}</code>
                                             </a>
                                         {% else %}
@@ -235,7 +237,7 @@
                                     </td>
                                     <td>
                                         {% if event.servers_cid_link %}
-                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.servers_cid) }}">
                                                 <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
                                         {% else %}

--- a/templates/server_view.html
+++ b/templates/server_view.html
@@ -82,11 +82,12 @@
                         </div>
                     </div>
                     {% if server.definition_cid %}
+                    {% set definition_link = cid_path(server.definition_cid, 'txt') %}
                     <div class="row mt-3">
                         <div class="col-md-12">
                             <strong>Definition CID:</strong><br>
-                            <a href="/{{ server.definition_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm">
-                                <i class="fas fa-external-link-alt me-1"></i>View as Text ({{ server.definition_cid }})
+                            <a href="{{ definition_link or '#' }}" target="_blank" class="btn btn-outline-primary btn-sm">
+                                <i class="fas fa-external-link-alt me-1"></i>View as Text ({{ format_cid(server.definition_cid) }})
                             </a>
                         </div>
                     </div>
@@ -120,10 +121,12 @@
                                             {{ entry.created_at.strftime('%Y-%m-%d %H:%M:%S') }}
                                         </h6>
                                         <div class="ms-auto">
-                                            <a href="/{{ entry.definition_cid }}.txt" target="_blank" class="btn btn-outline-primary btn-sm me-2">
+                                            {% set entry_definition_link = cid_path(entry.definition_cid, 'txt') %}
+                                            <a href="{{ entry_definition_link or '#' }}" target="_blank" class="btn btn-outline-primary btn-sm me-2">
                                                 <i class="fas fa-external-link-alt me-1"></i>View as Text
                                             </a>
-                                            <a href="/{{ entry.snapshot_cid }}.json" target="_blank" class="btn btn-outline-info btn-sm me-2">
+                                            {% set snapshot_link = cid_path(entry.snapshot_cid, 'json') %}
+                                            <a href="{{ snapshot_link or '#' }}" target="_blank" class="btn btn-outline-info btn-sm me-2">
                                                 <i class="fas fa-code me-1"></i>View JSON
                                             </a>
                                             <button class="btn btn-outline-secondary btn-sm" onclick="copyHistoricalDefinition('{{ loop.index0 }}')">
@@ -132,7 +135,7 @@
                                         </div>
                                     </div>
                                     <div class="text-muted small mb-2">
-                                        Definition CID: <code>{{ entry.definition_cid }}</code>
+                                        Definition CID: <code>{{ format_cid(entry.definition_cid) }}</code>
                                     </div>
                                     <div class="collapse" id="definition-{{ loop.index0 }}">
                                         <pre class="border rounded p-3 bg-light historical-definition" style="white-space: pre-wrap; max-height: 300px; overflow-y: auto;">{{ entry.definition }}</pre>
@@ -182,7 +185,7 @@
                                     </td>
                                     <td>
                                         {% if event.invocation_link %}
-                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.invocation_cid }}">
+                                            <a href="{{ event.invocation_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.invocation_cid) }}">
                                                 <code class="small">{{ event.invocation_label }}</code>
                                             </a>
                                         {% else %}
@@ -191,7 +194,7 @@
                                     </td>
                                     <td>
                                         {% if event.request_details_link %}
-                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.request_details_cid }}">
+                                            <a href="{{ event.request_details_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.request_details_cid) }}">
                                                 <code class="small">{{ event.request_details_label }}</code>
                                             </a>
                                         {% else %}
@@ -200,7 +203,7 @@
                                     </td>
                                     <td>
                                         {% if event.result_link %}
-                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.result_cid }}">
+                                            <a href="{{ event.result_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.result_cid) }}">
                                                 <code class="small">{{ event.result_label }}</code>
                                             </a>
                                         {% else %}
@@ -209,7 +212,7 @@
                                     </td>
                                     <td>
                                         {% if event.servers_cid_link %}
-                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ event.servers_cid }}">
+                                            <a href="{{ event.servers_cid_link }}" target="_blank" rel="noopener" class="text-decoration-none" title="{{ format_cid(event.servers_cid) }}">
                                                 <code class="small">{{ event.servers_cid_label }}</code>
                                             </a>
                                         {% else %}

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -10,10 +10,11 @@
                 <h2><i class="fas fa-server me-2"></i>My Servers</h2>
                 <div class="btn-group">
                     {% if server_definitions_cid %}
-                    <a href="/{{ server_definitions_cid }}.json" class="btn btn-outline-info me-1" target="_blank">
+                    {% set server_defs_link = cid_path(server_definitions_cid, 'json') %}
+                    <a href="{{ server_defs_link or '#' }}" class="btn btn-outline-info me-1" target="_blank">
                         <i class="fas fa-eye me-1"></i>View JSON
                     </a>
-                    <a href="/{{ server_definitions_cid }}.json" class="btn btn-outline-secondary me-2" download="server-definitions.json">
+                    <a href="{{ server_defs_link or '#' }}" class="btn btn-outline-secondary me-2" download="server-definitions.json">
                         <i class="fas fa-download me-1"></i>Download JSON
                     </a>
                     {% endif %}

--- a/templates/upload_success.html
+++ b/templates/upload_success.html
@@ -39,8 +39,8 @@
                             <div class="bg-light p-3 rounded">
                                 <label class="form-label fw-bold">IPFS CID:</label>
                                 <div class="input-group">
-                                    <input type="text" class="form-control font-monospace" value="{{ cid }}" readonly>
-                                    <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard('{{ cid }}')">
+                                    <input type="text" class="form-control font-monospace" value="{{ format_cid(cid) }}" readonly>
+                                    <button class="btn btn-outline-secondary" type="button" onclick="copyToClipboard('{{ format_cid(cid) }}')">
                                         <i class="fas fa-copy"></i>
                                     </button>
                                 </div>
@@ -56,8 +56,9 @@
                             </h6>
                             <p>Your file is now accessible at the following URL and will be served with the correct MIME type:</p>
                             <div class="input-group">
-                                <input type="text" class="form-control" value="{{ request.url_root[:-1] }}/{{ cid }}{% if view_url_extension %}.{{ view_url_extension }}{% endif %}" readonly>
-                                <a href="/{{ cid }}{% if view_url_extension %}.{{ view_url_extension }}{% endif %}" class="btn btn-primary" target="_blank">
+                                <input type="text" class="form-control" value="{{ cid_full_url(request.url_root, cid, view_url_extension) or '' }}" readonly>
+                                {% set view_link = cid_path(cid, view_url_extension) %}
+                                <a href="{{ view_link or '#' }}" class="btn btn-primary" target="_blank">
                                     <i class="fas fa-external-link-alt me-1"></i>View/Download
                                 </a>
                             </div>

--- a/templates/variables.html
+++ b/templates/variables.html
@@ -10,7 +10,8 @@
                 <h2><i class="fas fa-code me-2"></i>My Variables</h2>
                 <div class="btn-group">
                     {% if variable_definitions_cid %}
-                    <a href="/{{ variable_definitions_cid }}.json" target="_blank" class="btn btn-outline-secondary">
+                    {% set var_link = cid_path(variable_definitions_cid, 'json') %}
+                    <a href="{{ var_link or '#' }}" target="_blank" class="btn btn-outline-secondary">
                         <i class="fas fa-download me-1"></i>Export All as JSON
                     </a>
                     {% endif %}


### PR DESCRIPTION
## Summary
- add a cid_presenter module with reusable helpers for formatting CIDs and generating CID URLs, and expose them to Jinja
- refactor CID-related routes and utilities to rely on the shared helpers instead of hand-built strings
- update CID displays and links in templates to use the shared helpers for consistent formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd440cd9448331b7a9319b8f986eb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent CID formatting and short labels across the app.
  - Template helpers for generating CID paths and full URLs.
  - Upload success page shows a copyable full access URL with safer View/Download links.
- Bug Fixes
  - Avoids broken/invalid CID links by rendering only when valid.
  - More reliable links for meta pages and JSON exports (servers, variables, secrets).
- Refactor
  - Centralized CID normalization and link generation across routes.
- Templates
  - Updated servers, server view/form/events, history, uploads, edit, secrets, and variables to use new helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->