### PR TITLE
Add AI helper controls for editable text areas

### DIFF
--- a/static/js/ai_assistant.js
+++ b/static/js/ai_assistant.js
@@ -1,0 +1,175 @@
+(function () {
+    'use strict';
+
+    function parseContext(root) {
+        var contextAttribute = root.getAttribute('data-ai-context');
+        if (!contextAttribute) {
+            return null;
+        }
+        try {
+            return JSON.parse(contextAttribute);
+        } catch (error) {
+            console.warn('Unable to parse AI context data:', error);
+            return null;
+        }
+    }
+
+    function normaliseButtonClasses(button) {
+        if (!button.classList.contains('btn')) {
+            button.classList.add('btn');
+        }
+        if (!button.classList.contains('btn-outline-primary') && !button.classList.contains('btn-primary')) {
+            button.classList.add('btn-outline-primary');
+        }
+    }
+
+    function summariseContext(context) {
+        if (!context || typeof context !== 'object') {
+            return null;
+        }
+        var keys = Object.keys(context);
+        if (keys.length === 0) {
+            return null;
+        }
+        return 'Context keys: ' + keys.join(', ');
+    }
+
+    function collectFormData(form) {
+        if (!form) {
+            return null;
+        }
+        try {
+            var formData = new FormData(form);
+            var summary = {};
+            for (var pair of formData.entries()) {
+                var key = pair[0];
+                var value = pair[1];
+                if (value instanceof File) {
+                    summary[key] = value.name || 'file';
+                } else {
+                    summary[key] = value;
+                }
+            }
+            return summary;
+        } catch (error) {
+            console.warn('Unable to collect form data for AI assistant:', error);
+            return null;
+        }
+    }
+
+    function buildStubResponse(config) {
+        var requestText = config.requestText || '';
+        var originalText = config.originalText || '';
+        var separator = '';
+        if (originalText && requestText) {
+            separator = originalText.endsWith('\n') ? '' : '\n';
+        }
+        var updatedText = originalText + separator + requestText;
+        var targetLabel = config.targetLabel || 'the text';
+        var message = 'OK I changed ' + targetLabel + ' by ' + requestText;
+        var contextSummary = summariseContext(config.contextData) || '';
+        if (config.formSummary) {
+            var formKeys = Object.keys(config.formSummary);
+            if (formKeys.length > 0) {
+                var formSummary = 'Form fields captured: ' + formKeys.join(', ');
+                contextSummary = contextSummary ? contextSummary + '\n' + formSummary : formSummary;
+            }
+        }
+        return {
+            updatedText: updatedText,
+            message: message,
+            contextSummary: contextSummary
+        };
+    }
+
+    function AiAssistant(root, target, requestField, outputField) {
+        this.root = root;
+        this.target = target;
+        this.requestField = requestField;
+        this.outputField = outputField;
+        this.contextData = parseContext(root);
+        this.targetLabel = root.getAttribute('data-ai-target-label') || 'the text';
+    }
+
+    AiAssistant.prototype.run = function () {
+        if (!this.target || !this.requestField) {
+            return;
+        }
+
+        var requestText = this.requestField.value || '';
+        var originalText = this.target.value || '';
+        var form = this.target.form || this.root.closest('form');
+        var contextData = this.contextData || {};
+        var formSummary = collectFormData(form);
+
+        var result = buildStubResponse({
+            requestText: requestText,
+            originalText: originalText,
+            targetLabel: this.targetLabel,
+            contextData: contextData,
+            formSummary: formSummary
+        });
+
+        this.target.value = result.updatedText;
+        this.target.dispatchEvent(new Event('input', { bubbles: true }));
+
+        if (this.outputField) {
+            this.outputField.classList.remove('d-none');
+            this.outputField.classList.remove('alert-danger');
+            this.outputField.classList.add('alert-info');
+            this.outputField.innerHTML = '';
+
+            var heading = document.createElement('strong');
+            heading.textContent = 'AI Response:';
+            this.outputField.appendChild(heading);
+
+            var message = document.createElement('div');
+            message.textContent = result.message;
+            this.outputField.appendChild(message);
+
+            if (result.contextSummary) {
+                var summary = document.createElement('div');
+                summary.classList.add('small', 'text-muted', 'mt-1');
+                summary.textContent = result.contextSummary;
+                this.outputField.appendChild(summary);
+            }
+        }
+
+        this.target.focus();
+    };
+
+    function initialiseAssistants() {
+        var assistantMap = new Map();
+        document.querySelectorAll('.ai-text-assistant').forEach(function (root) {
+            var targetId = root.getAttribute('data-ai-target-id');
+            if (!targetId) {
+                return;
+            }
+            var target = document.getElementById(targetId);
+            var requestField = root.querySelector('[data-ai-input]');
+            var outputField = root.querySelector('[data-ai-output]');
+            if (!target || !requestField) {
+                return;
+            }
+            var assistant = new AiAssistant(root, target, requestField, outputField);
+            assistantMap.set(targetId, assistant);
+        });
+
+        document.querySelectorAll('[data-ai-trigger]').forEach(function (button) {
+            var targetId = button.getAttribute('data-ai-target-id');
+            if (!targetId || !assistantMap.has(targetId)) {
+                return;
+            }
+            normaliseButtonClasses(button);
+            button.addEventListener('click', function () {
+                assistantMap.get(targetId).run();
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialiseAssistants);
+    } else {
+        initialiseAssistants();
+    }
+})();

--- a/templates/_ai_helpers.html
+++ b/templates/_ai_helpers.html
@@ -1,0 +1,33 @@
+{% macro ai_text_controls(target_id, target_label, request_label=None, helper_text=None, context=None, rows=3) %}
+    {% set request_id = target_id ~ '-ai-input' %}
+    {% set output_id = target_id ~ '-ai-output' %}
+    <div class="mb-3 ai-text-assistant"
+         data-ai-target-id="{{ target_id }}"
+         data-ai-target-label="{{ target_label }}"
+         {% if context is not none %}data-ai-context='{{ context | tojson }}'{% endif %}>
+        <label for="{{ request_id }}" class="form-label">{{ request_label or ('Ask AI to edit the ' ~ target_label) }}</label>
+        <textarea id="{{ request_id }}"
+                  class="form-control"
+                  rows="{{ rows }}"
+                  data-ai-input
+                  placeholder="Describe the changes you would like the AI to make."></textarea>
+        <div class="form-text">{{ helper_text or ('Tell the AI how you would like the ' ~ target_label ~ ' to change.') }}</div>
+        <div class="alert alert-info d-none mt-3"
+             id="{{ output_id }}"
+             data-ai-output
+             role="status"></div>
+    </div>
+{% endmacro %}
+
+{% macro ai_action_button(target_id, button_label='AI', extra_classes='btn-outline-primary btn') %}
+    {% set classes = extra_classes.split(' ') %}
+    {% if 'btn' not in classes %}
+        {% set classes = ['btn'] + classes %}
+    {% endif %}
+    <button type="button"
+            class="{{ classes | join(' ') }}"
+            data-ai-trigger
+            data-ai-target-id="{{ target_id }}">
+        <i class="fas fa-robot me-1"></i>{{ button_label }}
+    </button>
+{% endmacro %}

--- a/templates/_server_test_card.html
+++ b/templates/_server_test_card.html
@@ -1,3 +1,4 @@
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 <div class="card mt-4" id="server-test-card">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="card-title mb-0"><i class="fas fa-vial me-2"></i>Test Server</h5>
@@ -50,12 +51,16 @@
                     Enter each parameter on a new line in <code>key=value</code> format. Empty lines are ignored.
                 </div>
             </div>
+            {{ ai_text_controls('server-test-query', 'query parameters', request_label='Ask AI to edit the query parameters', helper_text='Describe how the AI should adjust the query parameters before running the test.', context={'form': 'server_test_card'}) }}
             {% endif %}
 
-            <div class="d-flex gap-2 mt-3">
+            <div class="d-flex gap-2 mt-3 flex-wrap">
                 <button type="submit" class="btn btn-primary">
                     <i class="fas fa-play me-1"></i>Run Test
                 </button>
+                {% if server_test_config.mode != 'main' %}
+                {{ ai_action_button('server-test-query', button_label='AI', extra_classes='btn-outline-primary') }}
+                {% endif %}
                 <button type="button" class="btn btn-outline-secondary" onclick="resetServerTestForm(this.form)">
                     <i class="fas fa-undo me-1"></i>Clear Inputs
                 </button>

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -105,6 +106,9 @@
                             {{ form.test_strings(class="form-control") }}
                             <div class="form-text">Enter one path per line to try the current configuration without saving.</div>
                         </div>
+                        <div data-alias-testing>
+                        {{ ai_text_controls(form.test_strings.id, 'test strings', request_label='Ask AI to edit the test paths', helper_text='Describe how the AI should update the test paths before trying them.', context={'form': 'alias_form'}) }}
+                        </div>
 
                         {% if test_results %}
                         <div class="mb-3" data-alias-testing>
@@ -126,14 +130,15 @@
                         </div>
                         {% endif %}
 
-                        <div class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            <div class="d-flex gap-2">
+                            <div class="d-flex gap-2 flex-wrap align-items-center">
                                 <div data-alias-testing>
                                     {{ form.test_pattern(class="btn btn-outline-primary") }}
                                 </div>
+                                {{ ai_action_button(form.test_strings.id, button_label='AI', extra_classes='btn-outline-primary') }}
                                 {{ form.submit(class="btn btn-primary") }}
                             </div>
                         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -188,6 +188,8 @@
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
+    <script src="{{ url_for('static', filename='js/ai_assistant.js') }}"></script>
+
     <script>
     document.addEventListener('click', function (event) {
         const trigger = event.target.closest('.cid-copy-action');

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}Edit CID{% endblock %}
 
@@ -33,6 +34,7 @@
                                 Update the text below and click "{{ submit_label }}" to store the edited content as a new CID entry.
                             </small>
                         </div>
+                        {{ ai_text_controls(form.text_content.id, 'CID content', request_label='Ask AI to update the CID content', helper_text='Describe how you want the AI to adjust the CID content before saving.', context={'form': 'edit_cid'}) }}
                         {% if not show_alias_field and current_alias_name %}
                             <div class="alert alert-info" role="alert">
                                 <i class="fas fa-link me-1"></i>
@@ -57,6 +59,7 @@
                         {% endif %}
                         <div class="d-flex gap-2 align-items-center flex-wrap">
                             {{ form.submit(class="btn btn-primary", value=submit_label) }}
+                            {{ ai_action_button(form.text_content.id, button_label='AI', extra_classes='btn-outline-primary') }}
                             {{ render_cid_link(cid) }}
                         </div>
                     </form>

--- a/templates/import.html
+++ b/templates/import.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}Import Data{% endblock %}
 
@@ -67,6 +68,7 @@
                                 <div class="form-text">Paste JSON content directly if you do not have a file.</div>
                             {% endif %}
                         </div>
+                        {{ ai_text_controls(form.import_text.id, 'import JSON', request_label='Ask AI to prepare the import JSON', helper_text='Describe how the AI should adjust the JSON content before importing.', context={'form': 'import_form'}) }}
 
                         <div class="mb-4">
                             {{ form.import_url.label(class="form-label") }}
@@ -130,11 +132,14 @@
                             {% endif %}
                         </div>
 
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.settings') }}" class="btn btn-outline-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            {{ form.submit(class="btn btn-primary") }}
+                            <div class="d-flex gap-2 flex-wrap">
+                                {{ ai_action_button(form.import_text.id, button_label='AI', extra_classes='btn-outline-primary') }}
+                                {{ form.submit(class="btn btn-primary") }}
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/templates/secret_form.html
+++ b/templates/secret_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -52,12 +53,16 @@
                                 </div>
                             {% endif %}
                         </div>
+                        {{ ai_text_controls(form.definition.id, 'secret definition', request_label='Ask AI to edit the secret definition', helper_text='Describe how the AI should adjust the secret definition before saving.', context={'form': 'secret_form'}) }}
 
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.secrets') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            {{ form.submit(class="btn btn-primary") }}
+                            <div class="d-flex gap-2 flex-wrap">
+                                {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
+                                {{ form.submit(class="btn btn-primary") }}
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -83,12 +84,16 @@
                                 </div>
                             {% endif %}
                         </div>
+                        {{ ai_text_controls(form.definition.id, 'server definition', request_label='Ask AI to edit the server definition', helper_text='Describe how the AI should adjust the server definition before saving.', context={'form': 'server_form'}) }}
 
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            {{ form.submit(class="btn btn-primary") }}
+                            <div class="d-flex gap-2 flex-wrap">
+                                {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
+                                {{ form.submit(class="btn btn-primary") }}
+                            </div>
                         </div>
                     </form>
             </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}Upload Content{% endblock %}
 
@@ -108,6 +109,7 @@
                                     Paste or type your text content here. A unique IPFS CID will be generated based on the content.
                                 </small>
                             </div>
+                            {{ ai_text_controls(form.text_content.id, 'text content', request_label='Ask AI to edit the text content', helper_text='Describe how the AI should adjust your text before uploading.', context={'form': 'upload_text'}) }}
                         </div>
 
                         <!-- URL Upload Section -->
@@ -129,8 +131,9 @@
                         </div>
 
 
-                        <div class="d-flex gap-2">
+                        <div class="d-flex gap-2 align-items-center flex-wrap">
                             {{ form.submit(class="btn btn-success") }}
+                            {{ ai_action_button(form.text_content.id, button_label='AI', extra_classes='btn-outline-primary') }}
                             <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">Cancel</a>
                         </div>
                     </form>
@@ -154,6 +157,8 @@ function toggleUploadMethod() {
     const fileSection = document.getElementById('fileUploadSection');
     const textSection = document.getElementById('textUploadSection');
     const urlSection = document.getElementById('urlUploadSection');
+    const aiButton = document.querySelector('[data-ai-trigger][data-ai-target-id="{{ form.text_content.id }}"]');
+    const aiAssistant = document.querySelector('.ai-text-assistant[data-ai-target-id="{{ form.text_content.id }}"]');
 
     if (fileRadio.checked) {
         fileSection.style.display = 'block';
@@ -167,6 +172,13 @@ function toggleUploadMethod() {
         fileSection.style.display = 'none';
         textSection.style.display = 'none';
         urlSection.style.display = 'block';
+    }
+
+    if (aiButton) {
+        aiButton.classList.toggle('d-none', !textRadio.checked);
+    }
+    if (aiAssistant) {
+        aiAssistant.classList.toggle('d-none', !textRadio.checked);
     }
 }
 

--- a/templates/variable_form.html
+++ b/templates/variable_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_ai_helpers.html" import ai_text_controls, ai_action_button %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -52,12 +53,16 @@
                                 </div>
                             {% endif %}
                         </div>
+                        {{ ai_text_controls(form.definition.id, 'variable definition', request_label='Ask AI to edit the variable definition', helper_text='Describe how the AI should adjust the variable definition before saving.', context={'form': 'variable_form'}) }}
 
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.variables') }}" class="btn btn-secondary">
                                 <i class="fas fa-times me-1"></i>Cancel
                             </a>
-                            {{ form.submit(class="btn btn-primary") }}
+                            <div class="d-flex gap-2 flex-wrap">
+                                {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
+                                {{ form.submit(class="btn btn-primary") }}
+                            </div>
                         </div>
                     </form>
                 </div>

--- a/test_routes_comprehensive.py
+++ b/test_routes_comprehensive.py
@@ -362,6 +362,10 @@ class TestFileUploadRoutes(BaseTestCase):
         response = self.client.get('/upload')
         self.assertEqual(response.status_code, 200)
 
+        page = response.get_data(as_text=True)
+        self.assertIn('text_content-ai-input', page)
+        self.assertIn('data-ai-target-id="text_content"', page)
+
     def test_upload_post_success(self):
         """Test successful file upload."""
         self.login_user()
@@ -619,6 +623,8 @@ class TestCidEditingRoutes(BaseTestCase):
         page = response.get_data(as_text=True)
         self.assertIn('original content', page)
         self.assertIn(cid_value, page)
+        self.assertIn('text_content-ai-input', page)
+        self.assertIn('data-ai-target-id="text_content"', page)
 
     def test_edit_cid_get_without_alias_shows_alias_field(self):
         cid_value = self._create_cid_record(b'no alias yet')
@@ -1006,6 +1012,8 @@ class TestServerRoutes(BaseTestCase):
         page = response.get_data(as_text=True)
         self.assertIn('Start from a Template', page)
         self.assertIn('server-template-select', page)
+        self.assertIn('definition-ai-input', page)
+        self.assertIn('data-ai-target-id="definition"', page)
 
         for template in get_server_templates():
             self.assertIn(template['name'], page)
@@ -1114,6 +1122,8 @@ class TestServerRoutes(BaseTestCase):
         self.assertIn('data-mode="query"', page)
         self.assertIn('Enter each parameter on a new line', page)
         self.assertIn('/simple-test', page)
+        self.assertIn('server-test-query-ai-input', page)
+        self.assertIn('data-ai-target-id="server-test-query"', page)
 
     def test_view_server_invocation_history_table(self):
         """Server detail page should show invocation events in table format."""
@@ -1284,6 +1294,16 @@ class TestVariableRoutes(BaseTestCase):
         self.assertIsNotNone(variable)
         self.assertEqual(variable.definition, 'Test variable definition')
 
+    def test_new_variable_form_includes_ai_controls(self):
+        """Variable form should expose AI helper controls."""
+        self.login_user()
+        response = self.client.get('/variables/new')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('definition-ai-input', page)
+        self.assertIn('Ask AI to edit the variable definition', page)
+
 
 class TestSecretRoutes(BaseTestCase):
     """Test secret management routes."""
@@ -1310,6 +1330,31 @@ class TestSecretRoutes(BaseTestCase):
         self.assertIsNotNone(secret)
         self.assertEqual(secret.definition, 'Test secret definition')
 
+    def test_new_secret_form_includes_ai_controls(self):
+        """Secret form should expose AI helper controls."""
+        self.login_user()
+        response = self.client.get('/secrets/new')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('definition-ai-input', page)
+        self.assertIn('Ask AI to edit the secret definition', page)
+
+
+class TestAliasRoutes(BaseTestCase):
+    """Test alias management AI helpers."""
+
+    def test_new_alias_form_includes_ai_controls(self):
+        """Alias form should expose AI helper controls."""
+        self.login_user()
+        response = self.client.get('/aliases/new')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('test_strings-ai-input', page)
+        self.assertIn('data-ai-target-id="test_strings"', page)
+        self.assertIn('Ask AI to edit the test paths', page)
+
 
 class TestSettingsRoutes(BaseTestCase):
     """Test settings routes."""
@@ -1319,6 +1364,16 @@ class TestSettingsRoutes(BaseTestCase):
         self.login_user()
         response = self.client.get('/settings')
         self.assertEqual(response.status_code, 200)
+
+    def test_import_form_includes_ai_controls(self):
+        """Import form should expose AI helper controls."""
+        self.login_user()
+        response = self.client.get('/import')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('import_text-ai-input', page)
+        self.assertIn('data-ai-target-id="import_text"', page)
 
 
 class TestErrorHandlers(BaseTestCase):


### PR DESCRIPTION
## Summary
- add shared macros and a stubbed JavaScript helper to provide reusable AI text assistance controls
- integrate the assistant textarea, trigger button, and response display across every editable text form and the server test card
- extend route tests to assert the new AI controls render on the relevant pages

## Testing
- pytest test_routes_comprehensive.py

------
https://chatgpt.com/codex/tasks/task_b_68e7daf189648331b8102d61a7ffebb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added AI-assisted text controls and action button across key forms (upload text, server definitions, variables, secrets, aliases, import JSON, CID edit, server query).
  - Context-aware suggestions with optional output panel; auto-initializes on page load.
- Style
  - Updated form layouts for responsive wrapping and spacing to accommodate the AI button and controls.
- Tests
  - Expanded coverage to verify AI controls are present and correctly wired across relevant pages and flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->