### PR TITLE
Implement server-backed AI stub and defaults

### DIFF
--- a/ai_defaults.py
+++ b/ai_defaults.py
@@ -1,0 +1,111 @@
+"""Helpers for provisioning the default AI stub server and alias."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from flask import current_app
+
+from db_access import get_alias_by_name, get_server_by_name, save_entity
+from models import Alias, Server, User
+from server_templates import iter_server_templates
+
+AI_ALIAS_NAME = "ai"
+AI_SERVER_NAME = "ai_stub"
+AI_TEMPLATE_ID = "ai_stub"
+
+
+def _get_ai_stub_definition() -> Optional[str]:
+    """Load the ai_stub template definition from the bundled templates."""
+
+    for template in iter_server_templates():
+        if template.get("id") == AI_TEMPLATE_ID:
+            definition = template.get("definition")
+            if isinstance(definition, str):
+                return definition
+            break
+    return None
+
+
+def ensure_ai_stub_for_user(user_id: str) -> bool:
+    """Ensure the default AI stub server and alias exist for the given user.
+
+    Returns True when new resources were created, False otherwise.
+    """
+
+    if not user_id:
+        return False
+
+    # Respect any existing customisations.
+    alias = get_alias_by_name(user_id, AI_ALIAS_NAME)
+    if alias and getattr(alias, "target_path", None) not in {
+        f"/{AI_SERVER_NAME}",
+        f"{AI_SERVER_NAME}",
+    }:
+        return False
+
+    if get_server_by_name(user_id, AI_ALIAS_NAME):
+        return False
+
+    definition = _get_ai_stub_definition()
+    if definition is None:
+        current_app.logger.warning("AI stub template definition is unavailable")
+        return False
+
+    created = False
+
+    server = get_server_by_name(user_id, AI_SERVER_NAME)
+    if server:
+        if server.definition != definition:
+            server.definition = definition
+            save_entity(server)
+            created = True
+    else:
+        server = Server(name=AI_SERVER_NAME, definition=definition, user_id=user_id)
+        save_entity(server)
+        created = True
+
+    desired_target = f"/{AI_SERVER_NAME}"
+    desired_pattern = f"/{AI_ALIAS_NAME}"
+    if alias:
+        needs_update = any(
+            [
+                getattr(alias, "target_path", None) != desired_target,
+                getattr(alias, "match_pattern", None) != desired_pattern,
+                getattr(alias, "match_type", None) != "literal",
+                bool(getattr(alias, "ignore_case", False)),
+            ]
+        )
+        if needs_update:
+            alias.target_path = desired_target
+            alias.match_pattern = desired_pattern
+            alias.match_type = "literal"
+            alias.ignore_case = False
+            save_entity(alias)
+            created = True
+    else:
+        alias = Alias(
+            name=AI_ALIAS_NAME,
+            target_path=desired_target,
+            user_id=user_id,
+            match_type="literal",
+            match_pattern=desired_pattern,
+            ignore_case=False,
+        )
+        save_entity(alias)
+        created = True
+
+    return created
+
+
+def ensure_ai_stub_for_all_users() -> None:
+    """Ensure every existing user can use the AI stub without additional setup."""
+
+    for user in User.query.all():
+        ensure_ai_stub_for_user(user.id)
+
+
+__all__ = [
+    "ensure_ai_stub_for_all_users",
+    "ensure_ai_stub_for_user",
+]

--- a/alias_routing.py
+++ b/alias_routing.py
@@ -117,7 +117,10 @@ def try_alias_redirect(path: str):
     if query:
         target = _append_query_string(target, query)
 
-    return redirect(target)
+    status_code = 302
+    if request.method not in {"GET", "HEAD", "OPTIONS"}:
+        status_code = 307
+    return redirect(target, code=status_code)
 
 
 __all__ = ["find_matching_alias", "is_potential_alias_path", "try_alias_redirect"]

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 import logfire
 
 from database import db, init_db
+from ai_defaults import ensure_ai_stub_for_all_users
 from cid_presenter import (
     cid_full_url,
     cid_path,
@@ -160,6 +161,8 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
             "langsmith_project_url": getenv("LANGSMITH_PROJECT_URL") if langsmith_enabled else None,
             "langsmith_reason": None if langsmith_enabled else "LANGSMITH_API_KEY not set",
         }
+
+        ensure_ai_stub_for_all_users()
 
     return app
 

--- a/auth_providers.py
+++ b/auth_providers.py
@@ -10,6 +10,7 @@ from flask import session, redirect, url_for, request, flash
 from flask_login import current_user
 from database import db
 from models import User, Invitation
+from ai_defaults import ensure_ai_stub_for_user
 
 
 class AuthProvider(ABC):
@@ -210,6 +211,8 @@ def create_local_user(email: str = None, first_name: str = None, last_name: str 
     db.session.add(user)
     db.session.commit()
 
+    ensure_ai_stub_for_user(user.id)
+
     return user
 
 
@@ -256,6 +259,7 @@ def save_user_from_claims(user_claims: Dict[str, Any], invitation_code: str = No
 
     try:
         db.session.commit()
+        ensure_ai_stub_for_user(user.id)
         return user
     except Exception as e:
         db.session.rollback()

--- a/server_templates/definitions/ai_stub.py
+++ b/server_templates/definitions/ai_stub.py
@@ -1,0 +1,87 @@
+# ruff: noqa: F821, F706
+"""AI stub server template that mimics the legacy in-browser behaviour."""
+
+import json
+from typing import Any, Dict, Optional
+
+
+def _summarise_context(context: Any) -> Optional[str]:
+    """Return a short summary of context keys when possible."""
+
+    if not isinstance(context, dict):
+        return None
+
+    keys = [str(key) for key in context.keys()]
+    if not keys:
+        return None
+
+    return "Context keys: " + ", ".join(keys)
+
+
+def _summarise_form(form_summary: Any) -> Optional[str]:
+    """Return a summary of captured form field names."""
+
+    if not isinstance(form_summary, dict):
+        return None
+
+    keys = [str(key) for key in form_summary.keys()]
+    if not keys:
+        return None
+
+    return "Form fields captured: " + ", ".join(keys)
+
+
+def _build_stub_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate the same output produced by the previous JavaScript stub."""
+
+    request_text = payload.get("request_text") or ""
+    original_text = payload.get("original_text") or ""
+    target_label = payload.get("target_label") or "the text"
+    context_data = payload.get("context_data")
+    form_summary = payload.get("form_summary")
+
+    separator = ""
+    if original_text and request_text and not original_text.endswith("\n"):
+        separator = "\n"
+
+    updated_text = original_text + separator + request_text
+    message = f"OK I changed {target_label} by {request_text}"
+
+    context_summary = _summarise_context(context_data)
+    form_summary_text = _summarise_form(form_summary)
+    if form_summary_text:
+        context_summary = (
+            f"{context_summary}\n{form_summary_text}"
+            if context_summary
+            else form_summary_text
+        )
+
+    return {
+        "updated_text": updated_text,
+        "message": message,
+        "context_summary": context_summary or "",
+    }
+
+
+def main(
+    request_text=None,
+    original_text=None,
+    target_label=None,
+    context_data=None,
+    form_summary=None,
+):
+    """Entry point executed by the Viewer runtime."""
+
+    payload = {
+        "request_text": request_text,
+        "original_text": original_text,
+        "target_label": target_label,
+        "context_data": context_data,
+        "form_summary": form_summary,
+    }
+    result = _build_stub_response(payload)
+
+    return {
+        "output": json.dumps(result),
+        "content_type": "application/json",
+    }

--- a/server_templates/templates/ai_stub.json
+++ b/server_templates/templates/ai_stub.json
@@ -1,0 +1,6 @@
+{
+  "id": "ai_stub",
+  "name": "AI stub",
+  "description": "Mimics the legacy in-browser AI helper by echoing edits on the server.",
+  "definition_file": "definitions/ai_stub.py"
+}

--- a/test_ai_stub_server.py
+++ b/test_ai_stub_server.py
@@ -1,0 +1,106 @@
+import os
+import unittest
+
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('SESSION_SECRET', 'test-secret-key')
+
+from app import app, db
+from auth_providers import create_local_user
+from db_access import get_alias_by_name, get_server_by_name
+from models import Alias, Server
+
+
+class TestAiStubServer(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.user = create_local_user(email='ai@example.com')
+        self.login()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def login(self):
+        with self.client.session_transaction() as session:
+            session['_user_id'] = self.user.id
+            session['_fresh'] = True
+
+    def test_ai_stub_resources_created(self):
+        alias = get_alias_by_name(self.user.id, 'ai')
+        server = get_server_by_name(self.user.id, 'ai_stub')
+        self.assertIsInstance(alias, Alias)
+        self.assertIsInstance(server, Server)
+
+    def test_ai_stub_invocation_returns_expected_payload(self):
+        payload = {
+            'request_text': 'Add this line',
+            'original_text': 'Existing text',
+            'target_label': 'CID content',
+            'context_data': {'form': 'upload_text'},
+            'form_summary': {'text_content': 'Existing text'},
+        }
+
+        initial_response = self.client.post('/ai', json=payload, follow_redirects=False)
+        self.assertEqual(initial_response.status_code, 307)
+        self.assertEqual(initial_response.headers['Location'], '/ai_stub')
+
+        response = self.client.post('/ai', json=payload, follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'application/json')
+        data = response.get_json()
+        self.assertEqual(
+            data,
+            {
+                'updated_text': 'Existing text\nAdd this line',
+                'message': 'OK I changed CID content by Add this line',
+                'context_summary': 'Context keys: form\nForm fields captured: text_content',
+            },
+        )
+
+    def test_custom_ai_server_takes_precedence(self):
+        # Remove the default alias so the custom server handles /ai directly
+        alias = get_alias_by_name(self.user.id, 'ai')
+        if alias:
+            db.session.delete(alias)
+            db.session.commit()
+
+        custom_definition = """
+import json
+
+def main():
+    return {
+        'output': json.dumps({
+            'updated_text': 'Custom output',
+            'message': 'Handled by custom AI server',
+            'context_summary': ''
+        }),
+        'content_type': 'application/json',
+    }
+"""
+        server = Server(name='ai', definition=custom_definition, user_id=self.user.id)
+        db.session.add(server)
+        db.session.commit()
+
+        payload = {'request_text': '', 'original_text': 'Ignored'}
+        response = self.client.post('/ai', json=payload, follow_redirects=True)
+        data = response.get_json()
+        self.assertEqual(
+            data,
+            {
+                'updated_text': 'Custom output',
+                'message': 'Handled by custom AI server',
+                'context_summary': '',
+            },
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_alias_routing.py
+++ b/test_alias_routing.py
@@ -117,6 +117,15 @@ class TestAliasRouting(unittest.TestCase):
                 self.assertEqual(response.status_code, 302)
                 self.assertEqual(response.location, '/cid123')
 
+    def test_try_alias_redirect_preserves_method_for_post(self):
+        self.create_alias(target='/cid123')
+        with app.test_request_context('/latest', method='POST'):
+            with patch('alias_routing.current_user', new=SimpleNamespace(is_authenticated=True, id=self.test_user.id)):
+                response = try_alias_redirect('/latest')
+                self.assertIsNotNone(response)
+                self.assertEqual(response.status_code, 307)
+                self.assertEqual(response.location, '/cid123')
+
     def test_try_alias_redirect_preserves_query(self):
         self.create_alias(target='/cid123')
         with app.test_request_context('/latest?download=1&format=html'):


### PR DESCRIPTION
## Summary
- add an ai_stub server template and metadata that mimics the previous in-browser behaviour
- provision the default ai alias/server on startup and whenever new users are created
- update the AI assistant front-end to call /ai via HTTP and adjust alias routing to preserve POST requests
- cover the new server workflow with dedicated tests

## Testing
- pytest test_ai_stub_server.py test_alias_routing.py

------
https://chatgpt.com/codex/tasks/task_b_68e803cdd3988331aaf30bc086d958ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic per-user AI assistant stub is provisioned and accessible via the /ai route.
  * AI assistant is ensured on app startup and when new users are created.
  * Web UI AI Assistant now calls a server-side endpoint, shows loading states, clearer responses, and better error feedback; related buttons are disabled during processing.

* **Bug Fixes**
  * Alias redirects now preserve HTTP methods: non-GET requests use 307, while GET/HEAD/OPTIONS use 302.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->