### PR TITLE
Add multi-purpose change messaging with interaction history

### DIFF
--- a/interaction_log.py
+++ b/interaction_log.py
@@ -1,0 +1,77 @@
+"""Helpers for presenting entity interaction history."""
+
+from __future__ import annotations
+
+from datetime import timezone
+from typing import Iterable, List, Dict, Any
+
+from db_access import get_recent_entity_interactions
+from models import EntityInteraction
+
+
+_PREVIEW_LENGTH = 80
+
+
+def _truncate_preview(text: str) -> str:
+    """Limit preview text to a friendly length."""
+
+    if len(text) <= _PREVIEW_LENGTH:
+        return text
+    return text[: _PREVIEW_LENGTH - 1] + '…'
+
+
+def summarise_interaction(interaction: EntityInteraction) -> Dict[str, Any]:
+    """Convert an interaction into a template-friendly dictionary."""
+
+    message = (interaction.message or '').strip()
+    preview_source = message or '(no message provided)'
+    preview = _truncate_preview(preview_source)
+    created_at = interaction.created_at
+    if created_at is None:
+        timestamp_display = ''
+        timestamp_iso = ''
+    else:
+        aware = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+        timestamp_iso = aware.astimezone(timezone.utc).isoformat()
+        timestamp_display = aware.strftime('%Y-%m-%d %H:%M UTC')
+
+    action = (interaction.action or '').lower() or 'save'
+    if action == 'ai':
+        action_display = 'AI'
+    elif action == 'save':
+        action_display = 'Saved'
+    else:
+        action_display = action.title()
+
+    return {
+        'id': interaction.id,
+        'action': action,
+        'action_display': action_display,
+        'timestamp': timestamp_display,
+        'timestamp_iso': timestamp_iso,
+        'message': message,
+        'preview': preview,
+        'content': interaction.content or '',
+    }
+
+
+def summarise_interactions(interactions: Iterable[EntityInteraction]) -> List[Dict[str, Any]]:
+    """Summarise a collection of interactions."""
+
+    return [summarise_interaction(item) for item in interactions]
+
+
+def load_interaction_history(
+    user_id: str,
+    entity_type: str,
+    entity_name: str,
+    limit: int = 10,
+) -> List[Dict[str, Any]]:
+    """Load and summarise the most recent interactions for an entity."""
+
+    interactions = get_recent_entity_interactions(user_id, entity_type, entity_name, limit)
+    return summarise_interactions(interactions)
+
+
+__all__ = ['summarise_interaction', 'summarise_interactions', 'load_interaction_history']
+

--- a/models.py
+++ b/models.py
@@ -198,6 +198,29 @@ class Alias(db.Model):
         return f'<Alias {self.name} -> {self.target_path}>'
 
 
+class EntityInteraction(db.Model):
+    __tablename__ = 'entity_interactions'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False, index=True)
+    entity_type = db.Column(db.String(50), nullable=False, index=True)
+    entity_name = db.Column(db.String(255), nullable=False, index=True)
+    action = db.Column(db.String(20), nullable=False)
+    message = db.Column(db.String(500), nullable=True)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+
+    user = db.relationship('User', backref='entity_interactions')
+
+    def __repr__(self):
+        return f'<EntityInteraction {self.entity_type}:{self.entity_name} {self.action}>'
+
+
 class Variable(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False, index=True)

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -14,5 +14,6 @@ from . import aliases  # noqa: F401,E402
 from . import import_export  # noqa: F401,E402
 from . import source  # noqa: F401,E402
 from . import meta  # noqa: F401,E402
+from . import interactions  # noqa: F401,E402
 
 __all__ = ["main_bp"]

--- a/routes/interactions.py
+++ b/routes/interactions.py
@@ -1,0 +1,50 @@
+from flask import jsonify, request
+from flask_login import current_user
+
+from auth_providers import require_login
+from db_access import record_entity_interaction
+from interaction_log import load_interaction_history, summarise_interaction
+
+from . import main_bp
+
+
+@main_bp.route('/api/interactions', methods=['POST'])
+@require_login
+def create_interaction_entry():
+    """Persist an interaction triggered from the client and return updated history."""
+
+    payload = request.get_json(silent=True) or {}
+
+    entity_type = (payload.get('entity_type') or '').strip()
+    entity_name = (payload.get('entity_name') or '').strip()
+    action = (payload.get('action') or '').strip() or 'ai'
+    message = payload.get('message')
+    content = payload.get('content') or ''
+
+    if not entity_type or not entity_name:
+        return jsonify({'error': 'Entity details are required.'}), 400
+
+    if content is None:
+        content = ''
+
+    interaction = record_entity_interaction(
+        current_user.id,
+        entity_type,
+        entity_name,
+        action,
+        message,
+        content,
+    )
+
+    history = load_interaction_history(current_user.id, entity_type, entity_name)
+
+    return jsonify(
+        {
+            'interaction': summarise_interaction(interaction) if interaction else None,
+            'interactions': history,
+        }
+    )
+
+
+__all__ = ['create_interaction_entry']
+

--- a/templates/_ai_helpers.html
+++ b/templates/_ai_helpers.html
@@ -1,21 +1,47 @@
-{% macro ai_text_controls(target_id, target_label, request_label=None, helper_text=None, context=None, rows=3) %}
+{% macro ai_text_controls(target_id, target_label, request_label=None, helper_text=None, context=None, rows=3, entity_type=None, entity_name=None, entity_name_field=None, interactions=None, history_label='Recent activity', history_limit=10) %}
     {% set request_id = target_id ~ '-ai-input' %}
     {% set output_id = target_id ~ '-ai-output' %}
+    {% set interactions = interactions or [] %}
     <div class="mb-3 ai-text-assistant"
          data-ai-target-id="{{ target_id }}"
          data-ai-target-label="{{ target_label }}"
+         data-ai-history-limit="{{ history_limit }}"
+         {% if entity_type %}data-ai-entity-type="{{ entity_type }}"{% endif %}
+         {% if entity_name %}data-ai-entity-name="{{ entity_name }}"{% endif %}
+         {% if entity_name_field %}data-ai-entity-name-field="{{ entity_name_field }}"{% endif %}
          {% if context is not none %}data-ai-context='{{ context | tojson }}'{% endif %}>
-        <label for="{{ request_id }}" class="form-label">{{ request_label or ('Ask AI to edit the ' ~ target_label) }}</label>
+        <label for="{{ request_id }}" class="form-label">{{ request_label or ('Describe the change or AI request for the ' ~ target_label) }}</label>
         <textarea id="{{ request_id }}"
                   class="form-control"
                   rows="{{ rows }}"
                   data-ai-input
-                  placeholder="Describe the changes you would like the AI to make."></textarea>
-        <div class="form-text">{{ helper_text or ('Tell the AI how you would like the ' ~ target_label ~ ' to change.') }}</div>
+                  placeholder="Share instructions for AI or summarise manual edits to the {{ target_label }}."></textarea>
+        <div class="form-text">{{ helper_text or ('Use this field to instruct the AI or to describe the changes you made manually before saving.') }}</div>
+        <input type="hidden" name="change_message" data-change-message-store>
         <div class="alert alert-info d-none mt-3"
              id="{{ output_id }}"
              data-ai-output
              role="status"></div>
+        <div class="mt-3">
+            <label class="form-label small text-uppercase fw-semibold">{{ history_label }}</label>
+            <div class="list-group list-group-flush border rounded" data-ai-history-list>
+                {% for item in interactions %}
+                <button type="button"
+                        class="list-group-item list-group-item-action"
+                        data-ai-interaction
+                        data-interaction='{{ item | tojson }}'>
+                    <div class="d-flex justify-content-between align-items-center mb-1">
+                        <span class="badge bg-light text-dark border">{{ item.action_display }}</span>
+                        <small class="text-muted">{{ item.timestamp }}</small>
+                    </div>
+                    <div class="text-truncate">{{ item.preview }}</div>
+                </button>
+                {% endfor %}
+            </div>
+            <div class="text-muted small mt-2 {% if interactions %}d-none{% endif %}" data-ai-history-empty>
+                No interactions yet.
+            </div>
+        </div>
     </div>
 {% endmacro %}
 

--- a/templates/_server_test_card.html
+++ b/templates/_server_test_card.html
@@ -51,7 +51,17 @@
                     Enter each parameter on a new line in <code>key=value</code> format. Empty lines are ignored.
                 </div>
             </div>
-            {{ ai_text_controls('server-test-query', 'query parameters', request_label='Ask AI to edit the query parameters', helper_text='Describe how the AI should adjust the query parameters before running the test.', context={'form': 'server_test_card'}) }}
+            {{ ai_text_controls(
+                'server-test-query',
+                'query parameters',
+                request_label='Ask AI to edit the query parameters',
+                helper_text='Describe how the AI should adjust the query parameters before running the test.',
+                context={'form': 'server_test_card'},
+                entity_type='server-test',
+                entity_name=server_test_config.action|default(''),
+                interactions=server_test_interactions|default([]),
+                history_label='Recent test runs'
+            ) }}
             {% endif %}
 
             <div class="d-flex gap-2 mt-3 flex-wrap">

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -107,7 +107,18 @@
                             <div class="form-text">Enter one path per line to try the current configuration without saving.</div>
                         </div>
                         <div data-alias-testing>
-                        {{ ai_text_controls(form.test_strings.id, 'test strings', request_label='Ask AI to edit the test paths', helper_text='Describe how the AI should update the test paths before trying them.', context={'form': 'alias_form'}) }}
+                        {{ ai_text_controls(
+                            form.test_strings.id,
+                            'test strings',
+                            request_label='Ask AI to edit the test paths',
+                            helper_text='Describe how the AI should update the test paths before trying them.',
+                            context={'form': 'alias_form'},
+                            entity_type='alias',
+                            entity_name=ai_entity_name|default(''),
+                            entity_name_field=ai_entity_name_field|default(''),
+                            interactions=interaction_history|default([]),
+                            history_label='Recent alias edits and requests'
+                        ) }}
                         </div>
 
                         {% if test_results %}

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -34,7 +34,17 @@
                                 Update the text below and click "{{ submit_label }}" to store the edited content as a new CID entry.
                             </small>
                         </div>
-                        {{ ai_text_controls(form.text_content.id, 'CID content', request_label='Ask AI to update the CID content', helper_text='Describe how you want the AI to adjust the CID content before saving.', context={'form': 'edit_cid'}) }}
+                        {{ ai_text_controls(
+                            form.text_content.id,
+                            'CID content',
+                            request_label='Ask AI to update the CID content',
+                            helper_text='Describe how you want the AI to adjust the CID content before saving.',
+                            context={'form': 'edit_cid'},
+                            entity_type='cid',
+                            entity_name=cid,
+                            interactions=interaction_history|default([]),
+                            history_label='Recent edits and requests'
+                        ) }}
                         {% if not show_alias_field and current_alias_name %}
                             <div class="alert alert-info" role="alert">
                                 <i class="fas fa-link me-1"></i>

--- a/templates/import.html
+++ b/templates/import.html
@@ -68,7 +68,17 @@
                                 <div class="form-text">Paste JSON content directly if you do not have a file.</div>
                             {% endif %}
                         </div>
-                        {{ ai_text_controls(form.import_text.id, 'import JSON', request_label='Ask AI to prepare the import JSON', helper_text='Describe how the AI should adjust the JSON content before importing.', context={'form': 'import_form'}) }}
+                        {{ ai_text_controls(
+                            form.import_text.id,
+                            'import JSON',
+                            request_label='Ask AI to prepare the import JSON',
+                            helper_text='Describe how the AI should adjust the JSON content before importing.',
+                            context={'form': 'import_form'},
+                            entity_type='import',
+                            entity_name='json',
+                            interactions=import_interactions|default([]),
+                            history_label='Recent imports and requests'
+                        ) }}
 
                         <div class="mb-4">
                             {{ form.import_url.label(class="form-label") }}

--- a/templates/secret_form.html
+++ b/templates/secret_form.html
@@ -53,7 +53,18 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {{ ai_text_controls(form.definition.id, 'secret definition', request_label='Ask AI to edit the secret definition', helper_text='Describe how the AI should adjust the secret definition before saving.', context={'form': 'secret_form'}) }}
+                        {{ ai_text_controls(
+                            form.definition.id,
+                            'secret definition',
+                            request_label='Ask AI to edit the secret definition',
+                            helper_text='Describe how the AI should adjust the secret definition before saving.',
+                            context={'form': 'secret_form'},
+                            entity_type='secret',
+                            entity_name=ai_entity_name|default(''),
+                            entity_name_field=ai_entity_name_field|default(''),
+                            interactions=interaction_history|default([]),
+                            history_label='Recent edits and requests'
+                        ) }}
 
                         <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.secrets') }}" class="btn btn-secondary">

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -69,7 +69,18 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {{ ai_text_controls(form.definition.id, 'server definition', request_label='Ask AI to edit the server definition', helper_text='Describe how the AI should adjust the server definition before saving.', context={'form': 'server_form'}) }}
+                        {{ ai_text_controls(
+                            form.definition.id,
+                            'server definition',
+                            request_label='Ask AI to edit the server definition',
+                            helper_text='Describe how the AI should adjust the server definition before saving.',
+                            context={'form': 'server_form'},
+                            entity_type='server',
+                            entity_name=ai_entity_name|default(''),
+                            entity_name_field=ai_entity_name_field|default(''),
+                            interactions=interaction_history|default([]),
+                            history_label='Recent edits and requests'
+                        ) }}
 
                         <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.servers') }}" class="btn btn-secondary">

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -94,7 +94,17 @@
                                     Paste or type your text content here. A unique IPFS CID will be generated based on the content.
                                 </small>
                             </div>
-                            {{ ai_text_controls(form.text_content.id, 'text content', request_label='Ask AI to edit the text content', helper_text='Describe how the AI should adjust your text before uploading.', context={'form': 'upload_text'}) }}
+                            {{ ai_text_controls(
+                                form.text_content.id,
+                                'text content',
+                                request_label='Ask AI to edit the text content',
+                                helper_text='Describe how the AI should adjust your text before uploading.',
+                                context={'form': 'upload_text'},
+                                entity_type='upload',
+                                entity_name='text',
+                                interactions=upload_interactions|default([]),
+                                history_label='Recent uploads and requests'
+                            ) }}
                         </div>
 
                         <!-- URL Upload Section -->

--- a/templates/variable_form.html
+++ b/templates/variable_form.html
@@ -53,7 +53,18 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {{ ai_text_controls(form.definition.id, 'variable definition', request_label='Ask AI to edit the variable definition', helper_text='Describe how the AI should adjust the variable definition before saving.', context={'form': 'variable_form'}) }}
+                        {{ ai_text_controls(
+                            form.definition.id,
+                            'variable definition',
+                            request_label='Ask AI to edit the variable definition',
+                            helper_text='Describe how the AI should adjust the variable definition before saving.',
+                            context={'form': 'variable_form'},
+                            entity_type='variable',
+                            entity_name=ai_entity_name|default(''),
+                            entity_name_field=ai_entity_name_field|default(''),
+                            interactions=interaction_history|default([]),
+                            history_label='Recent edits and requests'
+                        ) }}
 
                         <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
                             <a href="{{ url_for('main.variables') }}" class="btn btn-secondary">

--- a/test_entity_interactions.py
+++ b/test_entity_interactions.py
@@ -1,0 +1,86 @@
+import os
+import unittest
+
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+os.environ.setdefault('SESSION_SECRET', 'test-secret-key')
+
+from app import app, db
+from auth_providers import create_local_user
+from db_access import record_entity_interaction, get_recent_entity_interactions
+
+
+class TestEntityInteractions(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        app.config['WTF_CSRF_ENABLED'] = False
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.user = create_local_user(email='interactions@example.com')
+        self._login()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def _login(self):
+        with self.client.session_transaction() as session:
+            session['_user_id'] = self.user.id
+            session['_fresh'] = True
+
+    def test_record_entity_interaction_persists(self):
+        record_entity_interaction(
+            self.user.id,
+            'server',
+            'example',
+            'save',
+            'initial setup',
+            'print("hello world")',
+        )
+
+        interactions = get_recent_entity_interactions(self.user.id, 'server', 'example')
+        self.assertEqual(len(interactions), 1)
+        self.assertEqual(interactions[0].message, 'initial setup')
+        self.assertEqual(interactions[0].content, 'print("hello world")')
+
+    def test_api_records_and_returns_updated_history(self):
+        record_entity_interaction(
+            self.user.id,
+            'server',
+            'example',
+            'save',
+            'initial setup',
+            'print("hello world")',
+        )
+
+        payload = {
+            'entity_type': 'server',
+            'entity_name': 'example',
+            'action': 'ai',
+            'message': 'trim trailing spaces',
+            'content': 'print("hello world")\n'.strip(),
+        }
+
+        response = self.client.post('/api/interactions', json=payload)
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn('interactions', data)
+        self.assertGreaterEqual(len(data['interactions']), 2)
+        latest = data['interactions'][0]
+        self.assertEqual(latest['action'], 'ai')
+        self.assertEqual(latest['message'], 'trim trailing spaces')
+
+    def test_api_requires_entity_details(self):
+        response = self.client.post('/api/interactions', json={'content': 'value'})
+        self.assertEqual(response.status_code, 400)
+        data = response.get_json()
+        self.assertIn('error', data)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- turn the AI request textarea into a shared change-message input that is used for both AI prompts and manual saves
- capture and display the last ten AI/manual interactions per entity, including quick-apply history controls
- add an API and persistence layer for entity interactions with accompanying regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e834cd0aa48331bd8c07f516ac4173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added interaction history UI to AI controls with recent activity lists and previews.
  - Enabled AI assistant to log interactions and apply past suggestions across pages.
  - Introduced an interactions API for recording and retrieving per-entity activity.
  - Added “change message” support in create/edit/import/upload flows to capture context.
  - Updated labels and helper text for clearer AI request guidance.
  - Integrated history and AI context across aliases, variables, secrets, servers, uploads, imports, and CID editing (including server tests).

- Tests
  - Added tests covering interaction persistence, API responses, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->