### PR TITLE
Add change history import/export and CID export result page

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -211,12 +211,13 @@ class ExportForm(FlaskForm):
     include_servers = BooleanField('Servers')
     include_variables = BooleanField('Variables')
     include_secrets = BooleanField('Secrets')
+    include_history = BooleanField('Change History')
     secret_key = StringField(
         'Secret Encryption Key',
         validators=[Optional()],
         render_kw={'placeholder': 'Required when exporting secrets'},
     )
-    submit = SubmitField('Download JSON Export')
+    submit = SubmitField('Generate JSON Export')
 
     def validate(self, extra_validators=None):
         if not super().validate(extra_validators):
@@ -227,6 +228,7 @@ class ExportForm(FlaskForm):
             self.include_servers.data,
             self.include_variables.data,
             self.include_secrets.data,
+            self.include_history.data,
         ]):
             message = 'Select at least one data type to export.'
             self.include_aliases.errors.append(message)
@@ -265,6 +267,7 @@ class ImportForm(FlaskForm):
     include_servers = BooleanField('Servers')
     include_variables = BooleanField('Variables')
     include_secrets = BooleanField('Secrets')
+    include_history = BooleanField('Change History')
     secret_key = StringField(
         'Secret Decryption Key',
         validators=[Optional()],
@@ -281,6 +284,7 @@ class ImportForm(FlaskForm):
             self.include_servers.data,
             self.include_variables.data,
             self.include_secrets.data,
+            self.include_history.data,
         ]):
             message = 'Select at least one data type to import.'
             self.include_aliases.errors.append(message)

--- a/templates/export.html
+++ b/templates/export.html
@@ -52,10 +52,17 @@
                             </label>
                         </div>
 
-                        <div class="form-check mb-3">
+                        <div class="form-check mb-2">
                             {{ form.include_secrets(class="form-check-input", id="include-secrets") }}
                             <label class="form-check-label" for="include-secrets">
                                 <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="form-check mb-3">
+                            {{ form.include_history(class="form-check-input", id="include-history") }}
+                            <label class="form-check-label" for="include-history">
+                                <i class="fas fa-clock me-1 text-secondary"></i>{{ form.include_history.label.text }}
                             </label>
                         </div>
 
@@ -84,7 +91,7 @@
             </div>
 
             <div class="alert alert-info mt-4" role="alert">
-                <i class="fas fa-lock me-2"></i>Secrets are encrypted with the key you provide. Share the key securely with anyone importing this export.
+                <i class="fas fa-info-circle me-2"></i>Exports are saved as a CID-backed JSON file. Secrets are encrypted with the key you provide—share it securely with anyone importing this export.
             </div>
         </div>
     </div>

--- a/templates/export_result.html
+++ b/templates/export_result.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Export Ready{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card border-primary shadow-sm" data-export-cid="{{ cid_value }}">
+                <div class="card-header bg-primary text-white">
+                    <h4 class="card-title mb-0">
+                        <i class="fas fa-download me-2"></i>Your export is ready
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="lead">The selected data has been saved as a CID-backed JSON file.</p>
+
+                    <div class="mb-4">
+                        <h5 class="mb-2">Export CID</h5>
+                        <div class="bg-light p-3 rounded border">
+                            {{ render_cid_link(cid_value) }}
+                        </div>
+                    </div>
+
+                    <div class="alert alert-info" role="alert">
+                        <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
+                            <div><i class="fas fa-link me-2"></i>Download link:</div>
+                            <div class="input-group">
+                                <input type="text" class="form-control" value="{{ cid_full_url(request.url_root, cid_value, 'json') }}" readonly>
+                                <a class="btn btn-primary" href="{{ download_path }}" target="_blank" rel="noopener">Download JSON</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <details class="mt-3">
+                        <summary class="fw-semibold">View exported JSON</summary>
+                        <pre class="mt-3 bg-dark text-light p-3 rounded" style="max-height: 24rem; overflow:auto;">{{ json_payload }}</pre>
+                    </details>
+
+                    <div class="d-flex gap-2 mt-4 flex-wrap">
+                        <a href="{{ url_for('main.export_data') }}" class="btn btn-outline-primary">
+                            <i class="fas fa-arrow-left me-1"></i>Back to Export
+                        </a>
+                        <a href="{{ url_for('main.settings') }}" class="btn btn-secondary">
+                            <i class="fas fa-cog me-1"></i>Return to Settings
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/import.html
+++ b/templates/import.html
@@ -121,10 +121,17 @@
                                 <i class="fas fa-code me-1 text-success"></i>{{ form.include_variables.label.text }}
                             </label>
                         </div>
-                        <div class="form-check mb-3">
+                        <div class="form-check mb-2">
                             {{ form.include_secrets(class="form-check-input", id="import-secrets") }}
                             <label class="form-check-label" for="import-secrets">
                                 <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                            </label>
+                        </div>
+
+                        <div class="form-check mb-3">
+                            {{ form.include_history(class="form-check-input", id="import-history") }}
+                            <label class="form-check-label" for="import-history">
+                                <i class="fas fa-clock me-1 text-secondary"></i>{{ form.include_history.label.text }}
                             </label>
                         </div>
 


### PR DESCRIPTION
## Summary
- allow exports to include change history, save the JSON to a CID-backed download page, and expose the new export result view
- support importing change history entries alongside aliases, servers, variables, and secrets, including deduplication by timestamp
- expand import/export forms and tests to cover history handling and CID download messaging

## Testing
- pytest test_import_export.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e840664b588331a5b6951060e9fd6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to include change history in both export and import.
  - Exports now produce a CID-backed downloadable file with a dedicated results page and link.
  - Import supports processing change history with proper timestamp handling.
- UI/Style
  - Added “Include history” checkbox to Export and Import pages.
  - Updated export flow messaging and icons to reflect downloadable CID export.
  - Renamed export button to “Generate JSON Export.”
- Tests
  - Expanded coverage for exporting/importing change history and downloadable exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->