### PR TITLE
Switch import/export to CID-backed server definitions

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -212,6 +212,7 @@ class ExportForm(FlaskForm):
     include_variables = BooleanField('Variables')
     include_secrets = BooleanField('Secrets')
     include_history = BooleanField('Change History')
+    include_cid_map = BooleanField('CID Content Map', default=True)
     secret_key = StringField(
         'Secret Encryption Key',
         validators=[Optional()],
@@ -268,6 +269,7 @@ class ImportForm(FlaskForm):
     include_variables = BooleanField('Variables')
     include_secrets = BooleanField('Secrets')
     include_history = BooleanField('Change History')
+    process_cid_map = BooleanField('Process CID Map', default=True)
     secret_key = StringField(
         'Secret Decryption Key',
         validators=[Optional()],

--- a/templates/export.html
+++ b/templates/export.html
@@ -66,6 +66,14 @@
                             </label>
                         </div>
 
+                        <div class="form-check mb-4">
+                            {{ form.include_cid_map(class="form-check-input", id="include-cid-map") }}
+                            <label class="form-check-label" for="include-cid-map">
+                                <i class="fas fa-database me-1 text-primary"></i>{{ form.include_cid_map.label.text }}
+                                <span class="d-block text-muted small">Include the CID to content map so other environments can load referenced definitions.</span>
+                            </label>
+                        </div>
+
                         <div class="mb-4">
                             {{ form.secret_key.label(class="form-label") }}
                             {{ form.secret_key(class="form-control" + (" is-invalid" if form.secret_key.errors else "")) }}

--- a/templates/import.html
+++ b/templates/import.html
@@ -135,6 +135,14 @@
                             </label>
                         </div>
 
+                        <div class="form-check mb-4">
+                            {{ form.process_cid_map(class="form-check-input", id="import-cid-map") }}
+                            <label class="form-check-label" for="import-cid-map">
+                                <i class="fas fa-database me-1 text-primary"></i>{{ form.process_cid_map.label.text }}
+                                <span class="d-block text-muted small">Store CID content included with the import before processing referenced definitions.</span>
+                            </label>
+                        </div>
+
                         <div class="mb-4">
                             {{ form.secret_key.label(class="form-label") }}
                             {{ form.secret_key(class="form-control" + (" is-invalid" if form.secret_key.errors else "")) }}


### PR DESCRIPTION
## Summary
- replace server exports with definition_cid values and optionally bundle CID content in a cid_values map
- add export/import form controls so users can include CID data during export and hydrate it during import
- extend import/export tests to cover CID map handling and updated server payloads

## Testing
- pytest test_import_export.py

------
https://chatgpt.com/codex/tasks/task_b_68e848e5ea74833186a74867aa7d8361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added options to include a CID Content Map during export and to process a CID Map during import.
  - Export now emits server definitions by reference (definition_cid) with an optional cid_values section.
  - Import validates CID content integrity and reports clear messages for mismatches or missing entries.
  - Updated export format to version 3 with improved content encoding handling.

- Tests
  - Expanded coverage for CID map export/import flows, validation messaging, and absence/presence of cid_values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->