### PR TITLE
Serve htmlcov files without template wrappers

### DIFF
--- a/routes/source.py
+++ b/routes/source.py
@@ -123,6 +123,11 @@ def _render_file(path: str, root_path: Path):
     if not file_path.is_file() or repository_root not in file_path.parents:
         abort(404)
 
+    # Coverage HTML reports already contain full HTML documents. Serve them
+    # directly so the content is not wrapped in the source browser template.
+    if path.startswith("htmlcov/"):
+        return send_file(file_path)
+
     try:
         file_content = file_path.read_text(encoding="utf-8")
     except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- return html coverage files from /source/htmlcov directly instead of wrapping them in the source browser template
- add a regression test ensuring htmlcov assets are served as-is

## Testing
- pytest test_routes_comprehensive.py::TestSourceRoutes::test_source_htmlcov_serves_raw_content

------
https://chatgpt.com/codex/tasks/task_b_68e863a45f188331bbca179cbf858d80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML coverage reports under /source/htmlcov are now served as raw files, preserving original formatting and interactivity instead of being wrapped in a template.

* **Tests**
  * Added a test to ensure htmlcov/index.html is returned verbatim with exact content, including setup and cleanup of test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->