### PR TITLE
Improve proxy template configuration handling

### DIFF
--- a/server_templates/definitions/proxy.py
+++ b/server_templates/definitions/proxy.py
@@ -1,0 +1,182 @@
+# ruff: noqa: F821, F706
+# This template executes inside the Viewer runtime where `request` and `context` are provided.
+from flask import request as flask_request
+import requests
+from urllib.parse import urlsplit, urlunsplit
+
+
+PLACEHOLDER_TARGET_URL = "https://example.com/replace-me"
+# Update this value to point at the upstream service you want to proxy to when
+# you do not plan to use Viewer variables or secrets for configuration.
+BASE_TARGET_URL = PLACEHOLDER_TARGET_URL
+
+
+def _split_server_path(path: str) -> tuple[str, str]:
+    """Return the server mount name and the remainder of the request path."""
+
+    if not isinstance(path, str):
+        return "", ""
+
+    stripped = path.lstrip("/")
+    if not stripped:
+        # Preserve a trailing slash when the request is just the mount point.
+        return "", "/" if path.endswith("/") else ""
+
+    if "/" in stripped:
+        server_name, remainder = stripped.split("/", 1)
+        suffix = f"/{remainder}"
+    else:
+        server_name = stripped
+        suffix = ""
+
+    if not suffix and path.endswith("/"):
+        suffix = "/"
+
+    return server_name, suffix
+
+
+def _build_target_url(base_url: str, path: str, query_string: str) -> str:
+    """Combine the base target URL with the incoming path and query string."""
+
+    parsed = urlsplit(base_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError("BASE_TARGET_URL must include a scheme (https://) and hostname")
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("BASE_TARGET_URL must start with http:// or https://")
+
+    _, suffix = _split_server_path(path or "")
+
+    base_path = parsed.path.rstrip("/")
+    if suffix == "/":
+        combined_path = f"{base_path}/"
+    elif suffix:
+        combined_path = f"{base_path}{suffix}"
+    else:
+        combined_path = base_path
+
+    if combined_path:
+        normalized_path = combined_path if combined_path.startswith("/") else f"/{combined_path}"
+    else:
+        normalized_path = parsed.path or ""
+
+    incoming_query = (query_string or "").lstrip("?")
+    if parsed.query and incoming_query:
+        combined_query = f"{parsed.query}&{incoming_query}"
+    elif incoming_query:
+        combined_query = incoming_query
+    else:
+        combined_query = parsed.query
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            normalized_path,
+            combined_query,
+            parsed.fragment,
+        )
+    )
+
+
+def _proxy_request(base_url: str, request_info: dict) -> dict:
+    """Proxy the incoming request to the configured base URL."""
+
+    headers = request_info.get("headers") or {}
+    filtered_headers = {}
+    for key, value in headers.items():
+        if key is None:
+            continue
+        lower_key = key.lower()
+        if lower_key in {"host", "content-length"}:
+            continue
+        filtered_headers[key] = value
+
+    body = flask_request.get_data(cache=False) or None
+
+    target_url = _build_target_url(
+        base_url,
+        request_info.get("path") or "",
+        request_info.get("query_string") or "",
+    )
+
+    response = requests.request(
+        request_info.get("method", "GET"),
+        target_url,
+        headers=filtered_headers,
+        data=body,
+        allow_redirects=False,
+        timeout=60,
+    )
+
+    content_type = response.headers.get("Content-Type", "application/octet-stream")
+    return {"output": response.content, "content_type": content_type}
+
+
+def _normalize_server_token(server_name: str) -> str:
+    if not isinstance(server_name, str):
+        return ""
+
+    sanitized = []
+    for character in server_name:
+        if character.isalnum():
+            sanitized.append(character.upper())
+        else:
+            if sanitized and sanitized[-1] != "_":
+                sanitized.append("_")
+    token = "".join(sanitized).strip("_")
+    return token
+
+
+def _coalesce_config_value(source: dict, keys: list[str]) -> str:
+    if not isinstance(source, dict):
+        return ""
+
+    for key in keys:
+        if key not in source:
+            continue
+        value = source.get(key)
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if trimmed:
+                return trimmed
+    return ""
+
+
+def _resolve_base_target_url(default_url: str, request_info: dict, context_info: dict) -> str:
+    request_info = request_info or {}
+    context_info = context_info or {}
+
+    server_name, _ = _split_server_path(request_info.get("path") or "")
+    lookup_keys = ["BASE_TARGET_URL"]
+
+    normalized = _normalize_server_token(server_name)
+    if normalized:
+        lookup_keys.insert(0, f"{normalized}_BASE_TARGET_URL")
+
+    for source_name in ("variables", "secrets"):
+        candidate = _coalesce_config_value(context_info.get(source_name), lookup_keys)
+        if candidate:
+            return candidate
+
+    return default_url.strip()
+
+
+resolved_base_url = _resolve_base_target_url(BASE_TARGET_URL, request, context)
+
+if not resolved_base_url or resolved_base_url == PLACEHOLDER_TARGET_URL:
+    return {
+        "output": "Configure BASE_TARGET_URL via the template, a variable, or a secret to enable proxying.",
+        "content_type": "text/plain",
+    }
+
+try:
+    result = _proxy_request(resolved_base_url, request)
+except ValueError as exc:
+    return {"output": str(exc), "content_type": "text/plain"}
+except requests.RequestException as exc:
+    message = f"Proxy request failed: {exc}"
+    return {"output": message, "content_type": "text/plain"}
+
+return result

--- a/server_templates/templates/proxy.json
+++ b/server_templates/templates/proxy.json
@@ -1,0 +1,6 @@
+{
+  "id": "proxy",
+  "name": "HTTP proxy server",
+  "description": "Forward requests to another base URL, preserving the path and query string.",
+  "definition_file": "definitions/proxy.py"
+}

--- a/test_proxy_template.py
+++ b/test_proxy_template.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app import app
+import requests
+import server_execution
+from text_function_runner import run_text_function
+
+
+TEMPLATE_PATH = Path("server_templates/definitions/proxy.py")
+
+
+@pytest.fixture()
+def proxy_template_code():
+    return TEMPLATE_PATH.read_text()
+
+
+def _set_base_url(template_code: str, new_url: str) -> str:
+    placeholder = "BASE_TARGET_URL = PLACEHOLDER_TARGET_URL"
+    replacement = f'BASE_TARGET_URL = "{new_url}"'
+    assert placeholder in template_code
+    return template_code.replace(placeholder, replacement)
+
+
+def test_proxy_template_forwards_request(monkeypatch, proxy_template_code):
+    code = _set_base_url(proxy_template_code, "https://foo.service-now.com/api")
+
+    captured = {}
+
+    def fake_request(method, url, headers=None, data=None, allow_redirects=True, timeout=None):
+        captured.update(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "data": data,
+                "allow_redirects": allow_redirects,
+                "timeout": timeout,
+            }
+        )
+        return SimpleNamespace(content=b"proxied", headers={"Content-Type": "application/json"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    with app.test_request_context(
+        "/servicenow/more/path/info?q=stuff",
+        method="POST",
+        data=b"{\"hello\": \"world\"}",
+        headers={"Content-Type": "application/json", "X-Test": "abc"},
+        base_url="https://viewer.example",
+    ):
+        details = server_execution.request_details()
+        assert "Content-Length" in details["headers"]
+        assert "Host" in details["headers"]
+
+        payload = {"context": {"variables": {}, "secrets": {}, "servers": {}}, "request": details}
+        result = run_text_function(code, payload)
+
+    assert captured["method"] == "POST"
+    assert (
+        captured["url"]
+        == "https://foo.service-now.com/api/more/path/info?q=stuff"
+    )
+    assert captured["allow_redirects"] is False
+    assert captured["timeout"] == 60
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["headers"]["X-Test"] == "abc"
+    assert "Host" not in captured["headers"]
+    assert "Content-Length" not in captured["headers"]
+    assert captured["data"] == b"{\"hello\": \"world\"}"
+    assert result["output"] == b"proxied"
+    assert result["content_type"] == "application/json"
+
+
+def test_proxy_template_requires_configuration(monkeypatch, proxy_template_code):
+    def fail_request(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("Proxy attempted an HTTP request without configuration")
+
+    monkeypatch.setattr(requests, "request", fail_request)
+
+    with app.test_request_context("/servicenow"):
+        payload = {
+            "context": {"variables": {}, "secrets": {}, "servers": {}},
+            "request": server_execution.request_details(),
+        }
+        result = run_text_function(proxy_template_code, payload)
+
+    assert "Configure BASE_TARGET_URL" in result["output"]
+    assert result["content_type"] == "text/plain"
+
+
+def test_proxy_template_handles_root_paths(monkeypatch, proxy_template_code):
+    code = _set_base_url(proxy_template_code, "https://foo.service-now.com/api")
+
+    captured = {}
+
+    def fake_request(method, url, headers=None, data=None, allow_redirects=True, timeout=None):
+        captured["url"] = url
+        return SimpleNamespace(content=b"root", headers={"Content-Type": "text/plain"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    with app.test_request_context("/servicenow/", base_url="https://viewer.example"):
+        payload = {
+            "context": {"variables": {}, "secrets": {}, "servers": {}},
+            "request": server_execution.request_details(),
+        }
+        result = run_text_function(code, payload)
+
+    assert captured["url"] == "https://foo.service-now.com/api/"
+    assert result["output"] == b"root"
+    assert result["content_type"] == "text/plain"
+
+
+def test_proxy_template_uses_global_variable_configuration(monkeypatch, proxy_template_code):
+    captured = {}
+
+    def fake_request(method, url, headers=None, data=None, allow_redirects=True, timeout=None):
+        captured.update({"method": method, "url": url})
+        return SimpleNamespace(content=b"configured", headers={"Content-Type": "application/json"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    with app.test_request_context(
+        "/servicenow/tasks", method="GET", base_url="https://viewer.example"
+    ):
+        payload = {
+            "context": {
+                "variables": {"BASE_TARGET_URL": "https://foo.service-now.com/api"},
+                "secrets": {},
+                "servers": {},
+            },
+            "request": server_execution.request_details(),
+        }
+        result = run_text_function(proxy_template_code, payload)
+
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://foo.service-now.com/api/tasks"
+    assert result["output"] == b"configured"
+    assert result["content_type"] == "application/json"
+
+
+def test_proxy_template_supports_server_specific_variable(monkeypatch, proxy_template_code):
+    captured = {}
+
+    def fake_request(method, url, headers=None, data=None, allow_redirects=True, timeout=None):
+        captured["url"] = url
+        return SimpleNamespace(content=b"specific", headers={"Content-Type": "text/plain"})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    with app.test_request_context(
+        "/service-now/tickets", method="GET", base_url="https://viewer.example"
+    ):
+        payload = {
+            "context": {
+                "variables": {"SERVICE_NOW_BASE_TARGET_URL": "https://foo.service-now.com/api"},
+                "secrets": {},
+                "servers": {},
+            },
+            "request": server_execution.request_details(),
+        }
+        run_text_function(proxy_template_code, payload)
+
+    assert captured["url"] == "https://foo.service-now.com/api/tickets"


### PR DESCRIPTION
## Summary
- allow the proxy template to resolve its base target URL from Viewer variables or secrets, including server-specific keys
- add scheme validation and clearer guidance when the proxy template is left unconfigured
- expand the proxy template tests to cover variable-based configuration paths

## Testing
- pytest test_proxy_template.py

------
https://chatgpt.com/codex/tasks/task_b_68e93b2c818c8331bcb56e702ebcf690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an HTTP proxy server template that forwards requests to a configurable base URL while preserving path and query parameters.
  - Supports per-endpoint overrides, validates target configuration, filters unsafe headers, applies sensible timeouts, and returns appropriate content types with clear error messages when configuration is missing or invalid.
- Tests
  - Added comprehensive tests for URL construction, method/headers/body forwarding, timeout/redirect behavior, root path handling, and configuration resolution via global and server-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->