### PR TITLE
Add context variable and secret fallbacks to auto main mapping

### DIFF
--- a/server_templates/definitions/auto_main.py
+++ b/server_templates/definitions/auto_main.py
@@ -12,6 +12,13 @@ def render_row(label, value):
 
 def main(name, greeting="Hello", topic="Viewer", user_agent=None, context=None):
     """Render a greeting using values drawn from the request."""
+    # Parameters are resolved automatically using this fallback order:
+    # 1. Query string (?name=Alice)
+    # 2. JSON/form request body values
+    # 3. HTTP headers (case-insensitive with hyphen/underscore matching)
+    # 4. Values supplied directly via function arguments (request/context)
+    # 5. Saved variables from the user context
+    # 6. Saved secrets from the user context
     message = f"{greeting}, {name}!"
     details = [
         "<html><body>",


### PR DESCRIPTION
## Summary
- extend automatic main() parameter resolution to include user context variables and secrets when other sources are missing
- surface the additional value sources in missing-parameter guidance and document the fallback order in the template
- add tests covering variable and secret fallbacks alongside updated availability reporting

## Testing
- pytest test_server_auto_main.py

------
https://chatgpt.com/codex/tasks/task_b_68e9bfda7f808331a46964761a67bcc6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parameters can now be auto-filled from saved variables and saved secrets in your user context when not provided via query, body, headers, or direct arguments.
  - Expanded parameter source priority to include context variables and secrets.

- Documentation
  - Clarified the parameter resolution order in comments.
  - Updated missing-parameter guidance to mention saved variables and saved secrets as valid sources.

- Tests
  - Added tests validating fallback to context variables and secrets during parameter resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->