### PR TITLE
Add upload button for server test formdown pages

### DIFF
--- a/templates/_server_test_card.html
+++ b/templates/_server_test_card.html
@@ -14,6 +14,9 @@
               class="server-test-form"
               data-mode="{{ server_test_config.mode }}"
               data-action="{{ server_test_config.action }}"
+              {% if server_test_upload_url is defined and server_test_upload_url %}
+              data-upload-url="{{ server_test_upload_url }}"
+              {% endif %}
               onsubmit="submitServerTestForm(event)">
             <div id="server-test-result" class="alert mt-3 d-none" role="alert"></div>
 
@@ -76,6 +79,11 @@
                 <button type="button" class="btn btn-outline-secondary" onclick="resetServerTestForm(this.form)">
                     <i class="fas fa-undo me-1"></i>Clear Inputs
                 </button>
+                {% if server_test_upload_url is defined and server_test_upload_url %}
+                <button type="button" class="btn btn-outline-primary" onclick="uploadServerTestForm(this)">
+                    <i class="fas fa-upload me-1"></i>Upload test page
+                </button>
+                {% endif %}
             </div>
         </form>
     </div>
@@ -328,6 +336,78 @@ if (!window.submitServerTestForm) {
                 popup.close();
             }
             _renderServerTestNetworkError(resultContainer, error);
+        }
+    };
+}
+
+if (!window.uploadServerTestForm) {
+    window.uploadServerTestForm = async function(trigger) {
+        const button = trigger instanceof HTMLElement ? trigger : null;
+        const form = button ? button.closest('form') : null;
+        if (!form) {
+            return;
+        }
+
+        const uploadUrl = form.dataset.uploadUrl;
+        if (!uploadUrl) {
+            return;
+        }
+
+        const values = {};
+        const mode = form.dataset.mode || 'query';
+        if (mode === 'main') {
+            form.querySelectorAll('input[name]').forEach((input) => {
+                values[input.name] = input.value;
+            });
+        } else {
+            const textarea = form.querySelector('textarea');
+            if (textarea) {
+                values.query = textarea.value;
+            }
+        }
+
+        const resultContainer = document.getElementById('server-test-result');
+        const originalContent = button ? button.innerHTML : '';
+        if (button) {
+            button.disabled = true;
+            button.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Uploading…';
+        }
+
+        try {
+            const response = await fetch(uploadUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify({ values }),
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(errorText || 'Unable to upload test page.');
+            }
+
+            const data = await response.json();
+            if (data && data.redirect_url) {
+                window.location.assign(data.redirect_url);
+                return;
+            }
+
+            throw new Error('Upload response did not include a redirect URL.');
+        } catch (error) {
+            if (resultContainer) {
+                _prepareServerTestResult(resultContainer);
+                resultContainer.classList.add('alert-danger');
+                const message = error && error.message ? error.message : 'Unable to upload test page.';
+                resultContainer.innerHTML = `<strong>Unable to upload test page.</strong><div class="mt-2">${_escapeServerTestHtml(message)}</div>`;
+            }
+        } finally {
+            if (button) {
+                button.disabled = false;
+                button.innerHTML = originalContent;
+            }
         }
     };
 }

--- a/test_server_test_page_upload.py
+++ b/test_server_test_page_upload.py
@@ -1,0 +1,141 @@
+"""Tests for uploading server test forms as reusable formdown pages."""
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from app import create_app
+from database import db
+from models import CID, Server, User
+
+
+class TestServerTestPageUpload(unittest.TestCase):
+    """Ensure the upload endpoint mirrors the server test form."""
+
+    def setUp(self):
+        self.app = create_app(
+            {
+                "TESTING": True,
+                "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                "WTF_CSRF_ENABLED": False,
+            }
+        )
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        self.user = User(
+            id="user-1",
+            email="user@example.com",
+            is_paid=True,
+            current_terms_accepted=True,
+            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+        db.session.add(self.user)
+        db.session.commit()
+
+        self.client = self.app.test_client()
+        with self.client.session_transaction() as session:
+            session["_user_id"] = self.user.id
+            session["_fresh"] = True
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def _create_server(self, name: str, definition: str) -> Server:
+        server = Server(
+            id=None,
+            name=name,
+            definition=definition,
+            user_id=self.user.id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.session.add(server)
+        db.session.commit()
+        return server
+
+    def test_upload_generates_formdown_for_main_parameters(self):
+        """Uploading should create a formdown page with defaults for main() parameters."""
+
+        server = self._create_server(
+            "greet",
+            """
+def main(name, times: int = 1):
+    return {"output": name * int(times)}
+""".strip(),
+        )
+
+        response = self.client.post(
+            f"/servers/{server.name}/upload-test-page",
+            json={"values": {"name": "Ada", "times": "3"}},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn("redirect_url", payload)
+        redirect_url = payload["redirect_url"]
+        self.assertTrue(redirect_url.endswith(".md.html"))
+
+        cid_value = redirect_url.split("/", 1)[1].split(".", 1)[0]
+        cid_record = CID.query.filter_by(path=f"/{cid_value}").first()
+        self.assertIsNotNone(cid_record)
+
+        content = cid_record.file_data.decode("utf-8")
+        self.assertIn("@form", content)
+        self.assertIn("action=\"/greet\"", content)
+        self.assertIn("@name(name): [text", content)
+        self.assertIn("value=\"Ada\"", content)
+        self.assertIn("@times(times): [text", content)
+        self.assertIn("value=\"3\"", content)
+
+    def test_upload_generates_formdown_for_query_mode(self):
+        """Servers without auto main should render query textarea defaults."""
+
+        server = self._create_server(
+            "lookup",
+            """
+def helper():
+    return "ok"
+""".strip(),
+        )
+
+        response = self.client.post(
+            f"/servers/{server.name}/upload-test-page",
+            json={"values": {"query": "foo=bar\npage=2"}},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        redirect_url = payload["redirect_url"]
+        cid_value = redirect_url.split("/", 1)[1].split(".", 1)[0]
+        cid_record = CID.query.filter_by(path=f"/{cid_value}").first()
+        self.assertIsNotNone(cid_record)
+
+        content = cid_record.file_data.decode("utf-8")
+        self.assertIn("@query_parameters(Query parameters):", content)
+        self.assertIn("value=\"foo=bar\\npage=2\"", content)
+
+    def test_upload_requires_authentication(self):
+        """Anonymous users should be redirected to authenticate."""
+
+        server = self._create_server(
+            "echo",
+            """
+def main(message: str):
+    return message
+""".strip(),
+        )
+
+        anonymous_client = self.app.test_client()
+        response = anonymous_client.post(
+            f"/servers/{server.name}/upload-test-page",
+            json={"values": {"message": "hi"}},
+        )
+
+        self.assertEqual(response.status_code, 302)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an endpoint that turns the inline server test form into a reusable formdown upload
- surface an "Upload test page" action on the test card and wire it to the new endpoint
- cover the upload workflow with new tests

## Testing
- pytest test_server_test_page_upload.py
- pytest test_server_definition_validation_route.py

------
https://chatgpt.com/codex/tasks/task_b_68ea84ab1ca483318f73276669e0d6d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an “Upload test page” button to server test cards, enabling users to create reusable test pages from current form values or query input.
  - Introduced an asynchronous upload flow with loading state, robust error messages, and automatic redirection to the generated page.
  - Upload option appears only when available for the server, without changing existing submit/reset behaviors.

- Tests
  - Added comprehensive tests covering main and query modes, successful uploads with correct defaults, and authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->