### PR TITLE
Add tests covering Formdown showcase query string behavior

### DIFF
--- a/test_formdown_showcase_template.py
+++ b/test_formdown_showcase_template.py
@@ -136,7 +136,9 @@ def test_formdown_showcase_fields_are_parsed_with_attributes():
 
     field_map = _fields_by_name(fields)
     assert field_map["name"].type == "text"
+    assert field_map["name"].attributes["placeholder"] == "Enter your full name"
     assert field_map["bio"].type == "textarea"
+    assert field_map["bio"].attributes["placeholder"] == "Tell us about yourself"
     assert field_map["skills"].type == "checkbox"
     assert field_map["resume"].is_file_input
 


### PR DESCRIPTION
## Summary
- add tests that parse the Formdown showcase upload template and simulate query-string serialization
- assert that textual, select, and checkbox inputs appear in the encoded query string while upload/buttons are excluded
- cover multi-value checkbox behavior to document current omissions

## Testing
- pytest test_formdown_showcase_template.py

------
https://chatgpt.com/codex/tasks/task_b_68ea8f8973bc8331b801a10c3fa0fadd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests for Formdown showcase GET query behavior.
  * Validates parsing of fields and their attributes (placeholders, options).
  * Verifies correct serialization of included fields and sample values into query strings.
  * Ensures file and submission/reset controls are excluded from generated queries.
  * Confirms multi-value fields expand to multiple parameters and preserves parsing.
  * Adds a regression case capturing observed text vs. textarea submission differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->