### PR TITLE
Enhance server execution error page diagnostics

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 
 {% block content %}
+{% if syntax_css %}
+<style>{{ syntax_css | safe }}</style>
+{% endif %}
 <div class="container py-4">
     <div class="row justify-content-center">
         <div class="col-lg-10">
@@ -16,6 +19,59 @@
                     </a>
                 </div>
             </div>
+
+            {% if server_name or server_definition_url or server_args_json %}
+                <div class="card mb-4">
+                    <div class="card-header bg-light">
+                        <h5 class="mb-0">
+                            <i class="fas fa-server me-2"></i>
+                            Server invocation details
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        {% if server_name %}
+                            <p class="mb-3">
+                                <strong>Server:</strong>
+                                {% if server_definition_url %}
+                                    <a href="{{ server_definition_url }}" class="text-decoration-none">
+                                        <i class="fas fa-external-link-alt me-1"></i>{{ server_name }}
+                                    </a>
+                                {% else %}
+                                    <code>{{ server_name }}</code>
+                                {% endif %}
+                            </p>
+                        {% endif %}
+                        {% if server_args_json %}
+                            <div>
+                                <h6 class="text-uppercase text-muted small">Arguments passed to server</h6>
+                                <pre class="bg-light p-3 rounded border"><code>{{ server_args_json }}</code></pre>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if highlighted_server_code or server_definition %}
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="mb-0">
+                            <i class="fas fa-code me-2"></i>
+                            Server source code
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        {% if highlighted_server_code %}
+                            <div class="codehilite border rounded" style="max-height: 500px; overflow: auto;">
+                                <pre class="mb-0 px-3 py-2" style="overflow:auto;">{{ highlighted_server_code | safe }}</pre>
+                            </div>
+                        {% elif server_definition %}
+                            <pre class="bg-light p-3 rounded border" style="white-space: pre-wrap; max-height: 500px; overflow-y: auto;">{{ server_definition | e }}</pre>
+                        {% else %}
+                            <p class="text-muted mb-0">Server definition was empty.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
 
             {% if stack_trace %}
                 <div class="card">

--- a/test_server_auto_main.py
+++ b/test_server_auto_main.py
@@ -88,6 +88,27 @@ def test_auto_main_reads_headers_when_query_and_body_missing():
     assert result["output"] == "HeaderUA"
 
 
+def test_auto_main_error_page_includes_debug_details():
+    definition = """
+ def main(name):
+     raise RuntimeError(f"failure for {name}")
+ """
+
+    with app.test_request_context("/boom?name=Auto"):
+        response = server_execution.execute_server_code_from_definition(definition, "boom")
+
+    assert response.status_code == 500
+
+    html = response.get_data(as_text=True)
+
+    assert "Server source code" in html
+    assert "codehilite" in html
+    assert "Arguments passed to server" in html
+    assert "/servers/boom" in html
+    assert "Stack trace with source links" in html
+    assert "Auto" in html
+
+
 def test_auto_main_matches_hyphenated_headers():
     definition = """
  def main(x_custom_token):

--- a/test_server_execution_error_pages.py
+++ b/test_server_execution_error_pages.py
@@ -131,6 +131,29 @@ class TestServerExecutionErrorPages(unittest.TestCase):
             msg="Server execution frame should expose a /source link",
         )
 
+    def test_error_page_includes_server_details_and_arguments(self) -> None:
+        self.server.definition = """
+def main(request):
+    raise ValueError("boom")
+"""
+        db.session.commit()
+
+        response = self.client.get("/jinja_renderer?color=blue")
+
+        self.assertEqual(response.status_code, 500)
+
+        html = response.get_data(as_text=True)
+
+        self.assertIn("Server source code", html)
+        self.assertIn("codehilite", html)
+        self.assertIn("ValueError", html)
+        self.assertIn("Arguments passed to server", html)
+        self.assertIn("/servers/jinja_renderer", html)
+        self.assertIn("Stack trace with source links", html)
+
+        # Arguments section should include the provided query parameter.
+        self.assertIn("color", html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enrich server execution error page with highlighted source, invocation arguments, and a link back to the server definition
- collect highlighting, argument JSON, and definition URL while rendering execution errors
- cover the new error details with dedicated tests for both standard and auto_main server definitions

## Testing
- pytest test_server_execution_error_pages.py test_server_auto_main.py

------
https://chatgpt.com/codex/tasks/task_b_68eaf406b6b48331ba55f1a225e5ebb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced 500 error page with server invocation details: server name (with link when available), arguments passed, and highlighted server source code.
  - Injects syntax styling for improved readability.
  - Retains existing stack trace and debugging tips, now presented with richer context.

- Tests
  - Added tests verifying the error page includes server details, code highlighting, arguments, server path, and stack trace with source links, ensuring robust diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->