### PR TITLE
Link import/export checkbox labels to entity pages

### DIFF
--- a/templates/export.html
+++ b/templates/export.html
@@ -34,28 +34,32 @@
                         <div class="form-check mb-2">
                             {{ form.include_aliases(class="form-check-input", id="include-aliases") }}
                             <label class="form-check-label" for="include-aliases">
-                                <i class="fas fa-link me-1 text-info"></i>{{ form.include_aliases.label.text }}
+                                <i class="fas fa-link me-1 text-info"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.aliases') }}">{{ form.include_aliases.label.text }}</a>
                             </label>
                         </div>
 
                         <div class="form-check mb-2">
                             {{ form.include_servers(class="form-check-input", id="include-servers") }}
                             <label class="form-check-label" for="include-servers">
-                                <i class="fas fa-server me-1 text-primary"></i>{{ form.include_servers.label.text }}
+                                <i class="fas fa-server me-1 text-primary"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.servers') }}">{{ form.include_servers.label.text }}</a>
                             </label>
                         </div>
 
                         <div class="form-check mb-2">
                             {{ form.include_variables(class="form-check-input", id="include-variables") }}
                             <label class="form-check-label" for="include-variables">
-                                <i class="fas fa-code me-1 text-success"></i>{{ form.include_variables.label.text }}
+                                <i class="fas fa-code me-1 text-success"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.variables') }}">{{ form.include_variables.label.text }}</a>
                             </label>
                         </div>
 
                         <div class="form-check mb-2">
                             {{ form.include_secrets(class="form-check-input", id="include-secrets") }}
                             <label class="form-check-label" for="include-secrets">
-                                <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                                <i class="fas fa-key me-1 text-warning"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.secrets') }}">{{ form.include_secrets.label.text }}</a>
                             </label>
                         </div>
 

--- a/templates/import.html
+++ b/templates/import.html
@@ -106,25 +106,29 @@
                         <div class="form-check mb-2">
                             {{ form.include_aliases(class="form-check-input", id="import-aliases") }}
                             <label class="form-check-label" for="import-aliases">
-                                <i class="fas fa-link me-1 text-info"></i>{{ form.include_aliases.label.text }}
+                                <i class="fas fa-link me-1 text-info"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.aliases') }}">{{ form.include_aliases.label.text }}</a>
                             </label>
                         </div>
                         <div class="form-check mb-2">
                             {{ form.include_servers(class="form-check-input", id="import-servers") }}
                             <label class="form-check-label" for="import-servers">
-                                <i class="fas fa-server me-1 text-primary"></i>{{ form.include_servers.label.text }}
+                                <i class="fas fa-server me-1 text-primary"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.servers') }}">{{ form.include_servers.label.text }}</a>
                             </label>
                         </div>
                         <div class="form-check mb-2">
                             {{ form.include_variables(class="form-check-input", id="import-variables") }}
                             <label class="form-check-label" for="import-variables">
-                                <i class="fas fa-code me-1 text-success"></i>{{ form.include_variables.label.text }}
+                                <i class="fas fa-code me-1 text-success"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.variables') }}">{{ form.include_variables.label.text }}</a>
                             </label>
                         </div>
                         <div class="form-check mb-2">
                             {{ form.include_secrets(class="form-check-input", id="import-secrets") }}
                             <label class="form-check-label" for="import-secrets">
-                                <i class="fas fa-key me-1 text-warning"></i>{{ form.include_secrets.label.text }}
+                                <i class="fas fa-key me-1 text-warning"></i>
+                                <a class="text-reset text-decoration-none" href="{{ url_for('main.secrets') }}">{{ form.include_secrets.label.text }}</a>
                             </label>
                         </div>
 


### PR DESCRIPTION
## Summary
- link the alias, server, variable, and secret labels on the import form to their management pages
- apply the same label links on the export form for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ec097b63c48331998a3003c9b23c95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export and Import pages now display clickable labels for options (Aliases, Servers, Variables, Secrets). Each label links to its corresponding page, making it easier to review details before proceeding.
  * Icons remain unchanged; labels are now both descriptive and navigable, improving discoverability and workflow.
  * No changes to form submission, validation, or error handling—only the label text behavior is enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->