### PR TITLE
Centralize CID helpers ahead of length expansion

### DIFF
--- a/entity_references.py
+++ b/entity_references.py
@@ -8,6 +8,7 @@ from urllib.parse import urlsplit
 from flask import url_for
 
 from cid_presenter import cid_path, format_cid
+from cid_utils import CID_PATH_CAPTURE_PATTERN, is_probable_cid_component
 from db_access import (
     get_alias_by_name,
     get_user_aliases,
@@ -21,7 +22,6 @@ from models import CID
 ReferenceMap = Dict[str, List[Dict[str, str]]]
 
 _NAME_BOUNDARY = r"(?![A-Za-z0-9._-])"
-_CID_PATTERN = re.compile(r"/([A-Za-z0-9_-]{6,})(?:\.[A-Za-z0-9]+)?")
 _MAX_SCAN_LENGTH = 100_000
 
 
@@ -124,7 +124,11 @@ def _discover_server_references(text: str, servers: Sequence[str]) -> List[Dict[
 
 
 def _discover_cid_references(text: str) -> List[Dict[str, str]]:
-    candidates = {format_cid(match.group(1)) for match in _CID_PATTERN.finditer(text)}
+    candidates = {
+        format_cid(match.group(1))
+        for match in CID_PATH_CAPTURE_PATTERN.finditer(text)
+        if is_probable_cid_component(match.group(1))
+    }
     candidates = {value for value in candidates if value}
     if not candidates:
         return []

--- a/test_cid_functionality.py
+++ b/test_cid_functionality.py
@@ -5,9 +5,12 @@ from unittest.mock import patch, MagicMock
 from app import app, db
 from models import CID, User
 from cid_utils import (
+    CID_LENGTH,
+    CID_NORMALIZED_PATTERN,
     _looks_like_markdown,
     generate_cid,
     get_mime_type_from_extension,
+    is_normalized_cid,
     serve_cid_content,
 )
 from db_access import create_cid_record
@@ -53,9 +56,10 @@ class TestCIDFunctionality(unittest.TestCase):
         # Generate CID
         cid = generate_cid(file_data)
         
-        # Verify CID format: 43-char base64url
-        self.assertEqual(len(cid), 43)
-        self.assertRegex(cid, r'^[A-Za-z0-9_-]{43}$')
+        # Verify CID format matches the canonical specification
+        self.assertEqual(len(cid), CID_LENGTH)
+        self.assertTrue(CID_NORMALIZED_PATTERN.fullmatch(cid))
+        self.assertTrue(is_normalized_cid(cid))
         
         # Verify CID is deterministic (same input = same output)
         cid2 = generate_cid(file_data)

--- a/test_echo_functionality.py
+++ b/test_echo_functionality.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
 
+from cid_utils import CID_LENGTH, CID_NORMALIZED_PATTERN, is_normalized_cid
 from app import app, db
 from models import Server, User
 from routes.core import not_found_error, get_existing_routes
@@ -159,10 +160,11 @@ class TestEchoFunctionality(unittest.TestCase):
                     self.assertTrue(location.startswith('/'), "Should redirect to a CID path")
                     self.assertTrue(location.endswith('.html'), "Should redirect to .html URL for text/html content")
 
-                    # Validate CID format (base64url without padding, length 43)
+                    # Validate CID format using the canonical helpers
                     cid_part = location.lstrip('/').split('.')[0]
-                    self.assertEqual(len(cid_part), 43)
-                    self.assertRegex(cid_part, r'^[A-Za-z0-9_-]{43}$')
+                    self.assertEqual(len(cid_part), CID_LENGTH)
+                    self.assertTrue(CID_NORMALIZED_PATTERN.fullmatch(cid_part))
+                    self.assertTrue(is_normalized_cid(cid_part))
 
 
 if __name__ == '__main__':

--- a/test_routes_comprehensive.py
+++ b/test_routes_comprehensive.py
@@ -34,7 +34,7 @@ from models import (
     CURRENT_TERMS_VERSION,
     Alias,
 )
-from cid_utils import generate_cid
+from cid_utils import CID_LENGTH, generate_cid
 from server_templates import get_server_templates
 from routes.core import _build_cross_reference_data
 
@@ -92,8 +92,8 @@ class TestUtilityFunctions(BaseTestCase):
         test_data = b"Hello, World!"
         cid = generate_cid(test_data)
 
-        # Should be base64url (no padding) and deterministic
-        self.assertEqual(len(cid), 43)
+        # Should be the canonical length and deterministic
+        self.assertEqual(len(cid), CID_LENGTH)
 
         # Should be deterministic
         cid2 = generate_cid(test_data)
@@ -103,8 +103,8 @@ class TestUtilityFunctions(BaseTestCase):
         different_cid = generate_cid(b"Different data")
         self.assertNotEqual(cid, different_cid)
 
-        # Should be expected fixed length for SHA-256 base64url
-        self.assertEqual(len(cid), 43)
+        # Should be expected fixed length for generated CIDs
+        self.assertEqual(len(cid), CID_LENGTH)
 
 
 class TestContextProcessors(BaseTestCase):
@@ -715,8 +715,8 @@ class TestFileUploadRoutes(BaseTestCase):
         self.login_user()
 
         result_cid = generate_cid(b"result")
-        invocation_cid = "I" * 43
-        servers_cid = "S" * 43
+        invocation_cid = "I" * CID_LENGTH
+        servers_cid = "S" * CID_LENGTH
 
         request_payload = json.dumps({
             'headers': {
@@ -1128,8 +1128,8 @@ class TestHistoryRoutes(BaseTestCase):
     @patch('routes.history.get_user_history_statistics')
     def test_history_page(self, mock_stats):
         """Test history page."""
-        result_cid = 'A' * 43
-        invocation_cid = 'B' * 43
+        result_cid = 'A' * CID_LENGTH
+        invocation_cid = 'B' * CID_LENGTH
 
         # Mock the statistics function to avoid SQLAlchemy func issues
         mock_stats.return_value = {
@@ -1366,8 +1366,8 @@ class TestServerRoutes(BaseTestCase):
         db.session.add(server)
 
         result_cid = generate_cid(b"result")
-        invocation_cid = "I" * 43
-        servers_cid = "S" * 43
+        invocation_cid = "I" * CID_LENGTH
+        servers_cid = "S" * CID_LENGTH
 
         request_payload = json.dumps({
             'headers': {

--- a/test_server_cid_functionality.py
+++ b/test_server_cid_functionality.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from app import app, db
 from models import User, Server, CID
-from cid_utils import save_server_definition_as_cid
+from cid_utils import CID_LENGTH, save_server_definition_as_cid
 
 def test_server_cid_functionality():
     """Test that server definitions are saved as CIDs when created/updated"""
@@ -46,7 +46,7 @@ def test_server_cid_functionality():
 
         # Verify CID was generated
         assert cid1 is not None
-        assert len(cid1) == 43
+        assert len(cid1) == CID_LENGTH
         print(f"✓ CID generated: {cid1}")
 
         # Verify CID record was created in database
@@ -88,7 +88,7 @@ def test_server_cid_functionality():
         # Verify server was created with CID
         assert server.definition == "print('Server code')"
         assert server.definition_cid is not None
-        assert len(server.definition_cid) == 43
+        assert len(server.definition_cid) == CID_LENGTH
         print(f"✓ Server created with CID: {server.definition_cid}")
 
         # Verify CID record exists for server definition

--- a/test_upload_extensions.py
+++ b/test_upload_extensions.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import io
 from app import create_app, db
 from models import User
-from cid_utils import process_file_upload
+from cid_utils import CID_LENGTH, process_file_upload
 
 
 class TestUploadExtensions(unittest.TestCase):
@@ -156,9 +156,9 @@ class TestUploadExtensions(unittest.TestCase):
             
             # Should not have any extension in the view URL (no .txt, .pdf, etc.)
             response_text = response.data.decode('utf-8')
-            # The CID should appear without any extension and match base64url 43 chars
-            # Ensure next character is not a dot (no extension), allow quotes or other delimiters
-            self.assertRegex(response_text, r'/[A-Za-z0-9_-]{43}(?!\.)')  # CID without extension
+            # The CID should appear without any extension and match the canonical length
+            cid_pattern = rf'/[A-Za-z0-9_-]{{{CID_LENGTH}}}(?!\.)'
+            self.assertRegex(response_text, cid_pattern)  # CID without extension
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add canonical CID constants and helper utilities to `cid_utils` for consistent validation and path parsing
- update history and entity reference modules to rely on the shared CID helpers instead of bespoke regex logic
- refresh CID-related tests to reference the shared helpers, cover new utilities, and remove hard-coded length assumptions

## Testing
- pytest test_cid_generation.py test_cid_functionality.py test_routes_comprehensive.py test_echo_functionality.py test_upload_extensions.py test_server_cid_functionality.py

------
https://chatgpt.com/codex/tasks/task_b_68ec1c9272c083318da256939f2c1534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved CID path handling, including support for extensions and query parameters.

- Refactor
  - Centralized CID parsing and validation, improving consistency across routes and reference discovery.
  - Standardized CID length and format checks for more predictable behavior.

- Bug Fixes
  - Reduced false positives/negatives when detecting CIDs in content and URLs.
  - More reliable history/link generation when CIDs include path segments.

- Tests
  - Updated to use canonical CID length and patterns.
  - Expanded coverage for CID utilities and path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->