### PR TITLE
Expand CID format to include encoded length prefix

### DIFF
--- a/test_cid_functionality.py
+++ b/test_cid_functionality.py
@@ -8,6 +8,7 @@ from cid_utils import (
     CID_LENGTH,
     CID_NORMALIZED_PATTERN,
     _looks_like_markdown,
+    encode_cid_length,
     generate_cid,
     get_mime_type_from_extension,
     is_normalized_cid,
@@ -74,12 +75,11 @@ class TestCIDFunctionality(unittest.TestCase):
         """Test that CID generation produces expected hash"""
         file_data = b"test content"
         
-        # Calculate expected hash manually
-        hasher = hashlib.sha256()
-        hasher.update(file_data)
-        sha256_hash = hasher.digest()
-        encoded = base64.urlsafe_b64encode(sha256_hash).decode('ascii').rstrip('=')
-        expected_cid = encoded
+        # Calculate expected CID manually
+        length_prefix = encode_cid_length(len(file_data))
+        digest = hashlib.sha512(file_data).digest()
+        digest_part = base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')
+        expected_cid = f"{length_prefix}{digest_part}"
         
         # Generate CID using function
         actual_cid = generate_cid(file_data)


### PR DESCRIPTION
## Summary
- expand CID encoding to include an 8-character length prefix and SHA-512 digest components
- add comprehensive round-trip CID tests covering byte lengths 0-512 and representative repository files
- align CID functionality tests with the new format expectations

## Testing
- pytest test_cid_generation.py
- pytest test_cid_functionality.py

------
https://chatgpt.com/codex/tasks/task_b_68ec2e9982208331b9a4682b01d295f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated CID format to include a length prefix and SHA‑512 digest using URL‑safe base64.
  - Added CID parsing and validation with clearer error messages and enforced size limits.

- Refactor
  - Replaced the previous SHA‑256 scheme with a two‑part CID structure. Previously generated CIDs will differ and may need regeneration.

- Tests
  - Expanded coverage for round‑trip integrity, determinism, format validation, edge cases, and representative repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->