### PR TITLE
Allow runtime-only exports and include dependency metadata

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -226,18 +226,6 @@ class ExportForm(FlaskForm):
         if not super().validate(extra_validators):
             return False
 
-        if not any([
-            self.include_aliases.data,
-            self.include_servers.data,
-            self.include_variables.data,
-            self.include_secrets.data,
-            self.include_history.data,
-            self.include_source.data,
-        ]):
-            message = 'Select at least one data type to export.'
-            self.include_aliases.errors.append(message)
-            return False
-
         if self.include_secrets.data and not (self.secret_key.data and self.secret_key.data.strip()):
             self.secret_key.errors.append('Encryption key is required when exporting secrets.')
             return False


### PR DESCRIPTION
## Summary
- allow the export form to submit without selecting data collections so runtime metadata can be exported alone
- gather project dependency versions and include pyproject.toml/requirements.txt CIDs in every export
- extend the export route tests to cover the new runtime-only flow and metadata expectations

## Testing
- pytest test_import_export.py

------
https://chatgpt.com/codex/tasks/task_b_68ec33986b308331b5498b47f613e43a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export now captures runtime dependency versions from your project and embeds project files with content IDs for reliable round‑trip imports.
  * Import recognizes and validates embedded project files via their content IDs.
  * Export form no longer requires selecting at least one data type to proceed.
* **Tests**
  * Added checks for runtime dependency version accuracy and project file CID integrity across various export/import options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->