### PR TITLE
Render mermaid diagrams as stored SVG assets

### DIFF
--- a/test_markdown_rendering.py
+++ b/test_markdown_rendering.py
@@ -151,6 +151,24 @@ class TestImagesAndEmbeds:
         assert '<figure class="mermaid-diagram"' in fragment
         assert 'src="/diagramcid123.svg"' in fragment
 
+    def test_mermaid_renderer_falls_back_to_remote_svg_on_error(self):
+        with (
+            patch('cid_utils._mermaid_renderer._fetch_svg', side_effect=RuntimeError('network down')),
+            patch('cid_utils._mermaid_renderer._store_svg') as store_svg,
+        ):
+            fragment = _render_fragment(
+                """
+                ```mermaid
+                graph TD
+                    A --> B
+                ```
+                """
+            )
+
+        store_svg.assert_not_called()
+        assert '<figure class="mermaid-diagram"' in fragment
+        assert 'src="https://mermaid.ink/svg/' in fragment
+
 
 class TestFormIdeasAndDividers:
     def test_form_sketch_preserves_literal_characters_in_code_block(self):


### PR DESCRIPTION
## Summary
- render Mermaid fenced code blocks by calling the mermaid.ink SVG API and persisting the result as a CID-backed asset
- wrap rendered diagrams in semantic figure markup with styling so Markdown pages embed the generated SVGs
- adjust Markdown rendering tests to expect the new image output while stubbing network and storage calls

## Testing
- pytest test_markdown_rendering.py
- pytest test_cid_functionality.py -k markdown

------
https://chatgpt.com/codex/tasks/task_b_68ec67b9d8b48331a2118536f0abfcb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Mermaid diagram support in Markdown: diagrams render to SVG images and are embedded as <figure class="mermaid-diagram"> with styling.
  - Uses caching and multiple source fallbacks (CID/data URL/remote) to improve availability and preserve original content on errors.

- **Tests**
  - Updated tests to verify Mermaid blocks render as SVG figures and to assert fallback behavior when rendering/storage fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->