### PR TITLE
Render CID links for alias targets

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,8 +14,10 @@ from ai_defaults import ensure_ai_stub_for_all_users
 from cid_presenter import (
     cid_full_url,
     cid_path,
+    extract_cid_from_path,
     format_cid,
     format_cid_short,
+    is_probable_cid_path,
     render_cid_link,
 )
 
@@ -81,8 +83,10 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
     app.jinja_env.globals.update(
         cid_full_url=cid_full_url,
         cid_path=cid_path,
+        extract_cid_from_path=extract_cid_from_path,
         format_cid=format_cid,
         format_cid_short=format_cid_short,
+        is_probable_cid_path=is_probable_cid_path,
         render_cid_link=render_cid_link,
     )
 

--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -6,6 +6,7 @@
 <div class="container">
     <div class="row">
         <div class="col-12">
+            {% set alias_target_cid = extract_cid_from_path(alias.target_path) %}
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2><i class="fas fa-link me-2"></i>{{ alias.name }}</h2>
                 <div class="btn-group">
@@ -28,7 +29,13 @@
                         <dd class="col-sm-9"><code>{{ alias.name }}</code></dd>
 
                         <dt class="col-sm-3">Redirect Path</dt>
-                        <dd class="col-sm-9"><code>{{ alias.target_path }}</code></dd>
+                        <dd class="col-sm-9">
+                            {% if alias_target_cid %}
+                                {{ render_cid_link(alias_target_cid) }}
+                            {% else %}
+                                <code>{{ alias.target_path }}</code>
+                            {% endif %}
+                        </dd>
 
                         <dt class="col-sm-3">Match Pattern</dt>
                         <dd class="col-sm-9"><code>{{ alias.match_pattern }}</code></dd>
@@ -118,7 +125,12 @@
                 </div>
                 <div class="card-body">
                     <p class="text-muted mb-3">
-                        Visiting <code>{{ request.url_root }}{{ alias.name }}</code> redirects browsers to <code>{{ alias.target_path }}</code>.
+                        Visiting <code>{{ request.url_root }}{{ alias.name }}</code> redirects browsers to
+                        {% if alias_target_cid %}
+                            {{ render_cid_link(alias_target_cid) }}
+                        {% else %}
+                            <code>{{ alias.target_path }}</code>
+                        {% endif %}.
                         Any query string on the incoming request is preserved and merged with query parameters already present on the target URL.
                     </p>
                     <p class="mb-0">

--- a/templates/aliases.html
+++ b/templates/aliases.html
@@ -35,7 +35,14 @@
                                 <div><code>{{ alias.match_pattern }}</code></div>
                                 <div class="small text-muted text-capitalize">{{ alias.match_type }}{% if alias.ignore_case %} · ignore case{% endif %}</div>
                             </td>
-                            <td><code>{{ alias.target_path }}</code></td>
+                            <td>
+                                {% set cid_target = extract_cid_from_path(alias.target_path) %}
+                                {% if cid_target %}
+                                    {{ render_cid_link(cid_target) }}
+                                {% else %}
+                                    <code>{{ alias.target_path }}</code>
+                                {% endif %}
+                            </td>
                             <td class="text-end">
                                 <a href="{{ url_for('main.view_alias', alias_name=alias.name) }}" class="btn btn-outline-primary btn-sm">
                                     <i class="fas fa-eye me-1"></i>View

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,14 @@
                             <i class="fas fa-link text-muted"></i>
                         </div>
                         {% if alias.target_path %}
-                        <div class="small text-muted mt-1">{{ alias.target_path }}</div>
+                        {% set cid_target = extract_cid_from_path(alias.target_path) %}
+                        <div class="small text-muted mt-1">
+                            {% if cid_target %}
+                                {{ render_cid_link(cid_target) }}
+                            {% else %}
+                                <code>{{ alias.target_path }}</code>
+                            {% endif %}
+                        </div>
                         {% endif %}
                     </div>
                     {% endfor %}

--- a/test_cid_presenter_render.py
+++ b/test_cid_presenter_render.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cid_presenter import render_cid_link
+from cid_presenter import extract_cid_from_path, is_probable_cid_path, render_cid_link
 
 
 @pytest.mark.parametrize("value", [None, "", "   ", "/ "])
@@ -40,3 +40,26 @@ def test_render_cid_link_strips_leading_slash():
 
     assert 'href="/bafybeigdyr.txt"' in rendered
     assert '>#bafybeigd...<' in rendered
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("/" , None),
+        ("/alpha/beta", None),
+        ("/bafybeigdyr.txt", "bafybeigdyr"),
+        ("bafybeigdyr", "bafybeigdyr"),
+        ("/bafybeigdyr?download=1", "bafybeigdyr"),
+    ],
+)
+def test_extract_cid_from_path(value, expected):
+    assert extract_cid_from_path(value) == expected
+
+
+def test_is_probable_cid_path_filters_non_cid_targets():
+    assert is_probable_cid_path("/bafybeigdyr")
+    assert not is_probable_cid_path("/servers/example")
+    assert not is_probable_cid_path("/demo/path")


### PR DESCRIPTION
## Summary
- add helpers to extract CID components from alias targets and expose them to Jinja
- render alias targets that point at CIDs with the standard CID link widget across list, detail, and dashboard views
- extend unit tests to cover CID extraction helpers and the updated alias rendering behaviour

## Testing
- pytest test_cid_presenter_render.py
- pytest test_routes_comprehensive.py::TestPublicRoutes::test_index_alias_target_displays_cid_link_for_cid_path test_routes_comprehensive.py::TestAliasRoutes::test_alias_list_displays_cid_link_for_cid_target test_routes_comprehensive.py::TestAliasRoutes::test_alias_detail_displays_cid_link_for_cid_target


------
https://chatgpt.com/codex/tasks/task_b_68ef034c6b748331839e7bf791d8f991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Alias targets now auto-detect CIDs and display a clickable CID link instead of a raw path when applicable.
  * Applied across the dashboard, aliases list, alias detail, and “How it Works” sections, with graceful fallback to the original path when no CID is detected.

* Tests
  * Added comprehensive tests to verify CID detection and link rendering across index, aliases list, and alias detail views.
  * Introduced unit tests for CID path parsing and path-type detection to ensure robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->