### PR TITLE
Split test runners and publish reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   lint:
@@ -32,7 +34,7 @@ jobs:
       - name: Run Ruff
         run: ruff check .
 
-  tests:
+  unit-tests:
     name: Unit Tests and Coverage
     runs-on: ubuntu-latest
     env:
@@ -54,20 +56,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Install Gauge CLI
-        run: |
-          curl -fsSL https://downloads.gauge.org/stable | sh
-          echo "$HOME/.gauge/bin" >> "$GITHUB_PATH"
-
-      - name: Install Gauge plugins
-        run: |
-          gauge install python
-          gauge install html-report
-
       - name: Run tests with coverage
         id: run_tests
         run: |
-          python run_coverage.py --xml --html --summary-file coverage-report.txt
+          ./test-unit --coverage --summary-file coverage-report.txt
         continue-on-error: true
 
       - name: Publish coverage summary
@@ -104,16 +96,133 @@ jobs:
         if: always() && steps.coverage.outputs.generated == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
+          name: unit-tests-html
           path: htmlcov
-
-      - name: Run Gauge specs
-        run: gauge run specs
-        env:
-          GAUGE_PYTHON_COMMAND: python3
-          STEP_IMPL_DIR: "${{ github.workspace }}/step_impl"
-          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/step_impl:${{ github.workspace }}/tests"
 
       - name: Fail if tests failed
         if: steps.run_tests.outcome == 'failure'
         run: exit 1
+
+  gauge-specs:
+    name: Gauge Specs
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite:////tmp/secureapp-ci.db
+      SESSION_SECRET: test-secret-key
+      TESTING: "True"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Gauge CLI
+        run: |
+          curl -fsSL https://downloads.gauge.org/stable | sh
+          echo "$HOME/.gauge/bin" >> "$GITHUB_PATH"
+
+      - name: Install Gauge plugins
+        run: |
+          gauge install python
+          gauge install html-report
+
+      - name: Run Gauge specs
+        id: run_gauge
+        run: ./test-gauge
+        env:
+          GAUGE_PYTHON_COMMAND: python3
+          STEP_IMPL_DIR: "${{ github.workspace }}/step_impl"
+          PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/step_impl:${{ github.workspace }}/tests"
+        continue-on-error: true
+
+      - name: Upload Gauge HTML report
+        if: always() && steps.run_gauge.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gauge-html
+          path: reports/html-report
+
+      - name: Fail if Gauge specs failed
+        if: steps.run_gauge.outcome == 'failure'
+        run: exit 1
+
+  deploy-reports:
+    name: Publish Test Reports
+    needs:
+      - unit-tests
+      - gauge-specs
+    if: >-
+      ${{ github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          needs['unit-tests'].result == 'success' &&
+          needs['gauge-specs'].result == 'success' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download unit test report
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-tests-html
+          path: site/unit-tests
+
+      - name: Download Gauge report
+        uses: actions/download-artifact@v4
+        with:
+          name: gauge-html
+          path: site/gauge-specs
+
+      - name: Prepare site content
+        run: |
+          mkdir -p site/unit-tests site/gauge-specs
+          if [ -d site/unit-tests/htmlcov ]; then
+            mv site/unit-tests/htmlcov/* site/unit-tests/
+            rmdir site/unit-tests/htmlcov
+          fi
+          if [ -d site/gauge-specs/reports/html-report ]; then
+            mv site/gauge-specs/reports/html-report/* site/gauge-specs/
+            rm -rf site/gauge-specs/reports
+          fi
+          cat <<'HTML' > site/index.html
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <title>SecureApp Test Reports</title>
+            <style>
+              body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.6; }
+              h1 { font-size: 2rem; margin-bottom: 1rem; }
+              ul { list-style: disc; padding-left: 1.5rem; }
+              a { color: #0366d6; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+            </style>
+          </head>
+          <body>
+            <h1>SecureApp Test Reports</h1>
+            <ul>
+              <li><a href="unit-tests/index.html">Unit test coverage report</a></li>
+              <li><a href="gauge-specs/index.html">Gauge HTML report</a></li>
+            </ul>
+          </body>
+          </html>
+          HTML
+
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The project includes simple helper scripts so you can get up and running quickly
 ./doctor    # verify your environment
 ./run       # start the development server on http://localhost:5000
 ./test      # run the full test suite (pytest + Gauge specs)
+./test-unit  # run only the pytest suite (add --coverage for coverage reports)
+./test-gauge # run only the Gauge specs
 python run_coverage.py --xml --html  # run tests with coverage reports (optional)
 ```
 
@@ -37,14 +39,16 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
 * `install` – create a virtual environment and install the required Python packages.
 * `run` – activate the environment and run the application.
 * `doctor` – check for common installation issues and suggest how to fix them.
-* `test` – execute the automated test suite via pytest.
+* `test-unit` – execute the pytest suite (`--coverage` forwards to `run_coverage.py`).
+* `test-gauge` – run the Gauge specifications.
+* `test` – invoke both `test-unit` and `test-gauge` sequentially.
 * `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
 
 ### Gauge specs
 
 Gauge specs exercise key user flows alongside the pytest suite. Install the
 [Gauge CLI](https://docs.gauge.org/getting_started/installing-gauge.html) and the
-`python` and `html-report` plugins, then run `./test` to execute both pytest and
+`python` and `html-report` plugins, then run `./test-gauge` to execute just Gauge or `./test` to run both pytest and
 Gauge. The HTML report generated at `reports/html-report/index.html` is available
 through the running app's source browser at `/source/reports/html-report/index.html`,
 alongside unit test and coverage results. A build is only considered passing when

--- a/test
+++ b/test
@@ -1,60 +1,29 @@
 #!/usr/bin/env python3
-"""Run the project's test suite via pytest."""
+"""Run both the pytest suite and Gauge specifications."""
 
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import sys
 from collections.abc import Sequence
-from pathlib import Path
 
-ROOT_DIR = Path(__file__).resolve().parent
-DEFAULT_ENV = {
-    "DATABASE_URL": "sqlite:///:memory:",
-    "SESSION_SECRET": "test-secret-key",
-    "TESTING": "True",
-}
+from test_support import ROOT_DIR, build_test_environment
 
 
-def build_environment() -> dict[str, str]:
-    """Return a copy of the current environment with sensible defaults."""
+def main(argv: Sequence[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
 
-    env = os.environ.copy()
-    # Ensure the repository root is on the Python path so pytest can import modules.
-    python_path = env.get("PYTHONPATH")
-    search_paths = [str(ROOT_DIR), str(ROOT_DIR / "step_impl"), str(ROOT_DIR / "tests")]
-    if python_path:
-        search_paths.append(python_path)
-    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(search_paths))
+    env = build_test_environment()
 
-    for key, value in DEFAULT_ENV.items():
-        env.setdefault(key, value)
+    unit_command = [str(ROOT_DIR / "test-unit"), *argv]
+    unit_result = subprocess.call(unit_command, cwd=str(ROOT_DIR), env=env)
+    if unit_result != 0:
+        return unit_result
 
-    return env
-
-
-def main(args: Sequence[str]) -> int:
-    env = build_environment()
-    cmd = [sys.executable, "-m", "pytest", *args]
-    result = subprocess.call(cmd, cwd=str(ROOT_DIR), env=env)
-    if result != 0:
-        return result
-
-    gauge_cmd = shutil.which("gauge")
-    if gauge_cmd is None:
-        print(
-            "Gauge CLI not found. Install Gauge from https://docs.gauge.org/getting_started/installing-gauge.html",
-            file=sys.stderr,
-        )
-        return 1
-
-    env.setdefault("GAUGE_PYTHON_COMMAND", sys.executable)
-    env.setdefault("STEP_IMPL_DIR", str(ROOT_DIR / "step_impl"))
-    gauge_args = [gauge_cmd, "run", "specs"]
-    return subprocess.call(gauge_args, cwd=str(ROOT_DIR), env=env)
+    gauge_command = [str(ROOT_DIR / "test-gauge")]
+    return subprocess.call(gauge_command, cwd=str(ROOT_DIR), env=env)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    raise SystemExit(main())

--- a/test-gauge
+++ b/test-gauge
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run the Gauge specification suite."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+from test_support import ROOT_DIR, build_test_environment, locate_gauge
+
+
+def parse_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Execute Gauge specs using the repository configuration.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--specs-dir",
+        default="specs",
+        help="Path to the Gauge specifications to run.",
+    )
+    parser.add_argument(
+        "gauge_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to 'gauge run' (prefix with --).",
+    )
+    args = parser.parse_args(argv)
+    if args.gauge_args and args.gauge_args[0] == "--":
+        args.gauge_args = args.gauge_args[1:]
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = parse_arguments(list(argv))
+    env = build_test_environment()
+    env.setdefault("GAUGE_PYTHON_COMMAND", sys.executable)
+    env.setdefault("STEP_IMPL_DIR", str(ROOT_DIR / "step_impl"))
+
+    try:
+        gauge_cmd = locate_gauge()
+    except FileNotFoundError as error:
+        print(error.args[0], file=sys.stderr)
+        return 1
+
+    command = [gauge_cmd, "run", args.specs_dir, *args.gauge_args]
+    return subprocess.call(command, cwd=str(ROOT_DIR), env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test-unit
+++ b/test-unit
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Run the unit test suite via pytest."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+from test_support import ROOT_DIR, build_test_environment
+
+
+def parse_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run pytest with optional coverage reporting.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="Execute the test suite with coverage enabled.",
+    )
+    parser.add_argument(
+        "--summary-file",
+        dest="summary_file",
+        help="Write the textual coverage summary to the specified file (only with --coverage).",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to pytest (prefix with --).",
+    )
+    args = parser.parse_args(argv)
+    if args.pytest_args and args.pytest_args[0] == "--":
+        args.pytest_args = args.pytest_args[1:]
+    return args
+
+
+def run_with_coverage(env: dict[str, str], args: argparse.Namespace) -> int:
+    command = [
+        sys.executable,
+        str(ROOT_DIR / "run_coverage.py"),
+        "--all",
+    ]
+    if args.summary_file:
+        command.extend(["--summary-file", args.summary_file])
+    if args.pytest_args:
+        command.append("--")
+        command.extend(args.pytest_args)
+    return subprocess.call(command, cwd=str(ROOT_DIR), env=env)
+
+
+def run_pytest(env: dict[str, str], args: argparse.Namespace) -> int:
+    command = [sys.executable, "-m", "pytest", *args.pytest_args]
+    return subprocess.call(command, cwd=str(ROOT_DIR), env=env)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = parse_arguments(list(argv))
+    env = build_test_environment()
+
+    if args.coverage:
+        return run_with_coverage(env, args)
+
+    return run_pytest(env, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_support.py
+++ b/test_support.py
@@ -1,0 +1,44 @@
+"""Helper utilities shared by test runner scripts."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent
+
+DEFAULT_ENV = {
+    "DATABASE_URL": "sqlite:///:memory:",
+    "SESSION_SECRET": "test-secret-key",
+    "TESTING": "True",
+}
+
+
+def build_test_environment() -> dict[str, str]:
+    """Return a copy of the environment with repository defaults applied."""
+
+    env = os.environ.copy()
+    python_path = env.get("PYTHONPATH")
+    search_paths = [str(ROOT_DIR), str(ROOT_DIR / "step_impl"), str(ROOT_DIR / "tests")]
+    if python_path:
+        search_paths.append(python_path)
+    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(search_paths))
+
+    for key, value in DEFAULT_ENV.items():
+        env.setdefault(key, value)
+
+    return env
+
+
+def locate_gauge() -> str:
+    """Return the path to the Gauge CLI or raise ``FileNotFoundError``."""
+
+    gauge_cmd = shutil.which("gauge")
+    if gauge_cmd is None:
+        msg = (
+            "Gauge CLI not found. Install Gauge from "
+            "https://docs.gauge.org/getting_started/installing-gauge.html"
+        )
+        raise FileNotFoundError(msg)
+    return gauge_cmd


### PR DESCRIPTION
## Summary
- add standalone `test-unit` and `test-gauge` entrypoints plus shared helpers
- update CI to run pytest and Gauge specs in separate jobs and deploy HTML reports to GitHub Pages
- document the new scripts in the README

## Testing
- ./test-unit -- --maxfail=1 -k does_not_exist
- ruff check test_support.py test-unit test-gauge test

------
https://chatgpt.com/codex/tasks/task_b_68f2bbed3c5c8331aaf203db94d9da03

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced separate test execution commands for unit tests and Gauge specifications.
  * Added automated test report publishing to GitHub Pages.

* **Documentation**
  * Updated README with quick-start test scripts for selective test suite execution.

* **Chores**
  * Refactored CI/CD workflow to modularize unit and specification testing jobs.
  * Reorganized test infrastructure for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->