### PR TITLE
Replace remaining SecureApp branding with Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SecureApp
+# Viewer
 
-SecureApp is a Flask based web application that demonstrates multi layer access control and integrates with OAuth providers.  
+Viewer is a Flask based web application that demonstrates multi layer access control and integrates with OAuth providers.
 The project includes simple helper scripts so you can get up and running quickly.
 
 ## Quick start
@@ -69,7 +69,7 @@ execute every `test_*.py` module in the repository.
 
 ### Observability
 
-SecureApp now ships with Logfire support (including LangSmith instrumentation) so local development mirrors production
+Viewer now ships with Logfire support (including LangSmith instrumentation) so local development mirrors production
 tracing.  Install dependencies with `./install`, set your `LOGFIRE_*` and `LANGSMITH_*` values in `.env`, and then use `./run`
 to start the server.  The `./install` script installs the required OpenTelemetry instrumentations (`opentelemetry-
 instrumentation-flask` and `opentelemetry-instrumentation-sqlalchemy`) so Logfire can attach to the framework automatically.

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"
 
-echo "Setting up SecureApp..."
+echo "Setting up Viewer..."
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "Python 3 is required. https://www.python.org/downloads/"

--- a/replit.md
+++ b/replit.md
@@ -1,6 +1,6 @@
 # Overview
 
-SecureApp is a Flask-based web application that demonstrates a multi-layered access control system. The application provides secure content access through user authentication, payment verification, and terms acceptance tracking. It features detailed HTTP request analysis as its core functionality, allowing authenticated and subscribed users to view comprehensive information about their web requests including headers, metadata, and network details.
+Viewer is a Flask-based web application that demonstrates a multi-layered access control system. The application provides secure content access through user authentication, payment verification, and terms acceptance tracking. It features detailed HTTP request analysis as its core functionality, allowing authenticated and subscribed users to view comprehensive information about their web requests including headers, metadata, and network details.
 
 # User Preferences
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,4 +1,4 @@
-/* Custom styles for SecureApp */
+/* Custom styles for Viewer */
 
 /* Body and general styles */
 body {

--- a/step_impl/__init__.py
+++ b/step_impl/__init__.py
@@ -1,4 +1,4 @@
-"""Gauge step implementations for SecureApp specs.
+"""Gauge step implementations for Viewer specs.
 
 The Gauge Python runner imports this package directly. Without explicitly
 importing the step modules the decorated functions never register, which causes

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if title %}{{ title }} - {% endif %}SecureApp</title>
+    <title>{% if title %}{{ title }} - {% endif %}Viewer</title>
 
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -19,7 +19,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand fw-bold" href="{{ url_for('main.index') }}">
-                <i class="fas fa-shield-alt me-2"></i>SecureApp
+                <i class="fas fa-shield-alt me-2"></i>Viewer
             </a>
 
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -120,7 +120,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-6">
-                    <h5>SecureApp</h5>
+                    <h5>Viewer</h5>
                     <p class="text-muted">Secure content management platform</p>
                 </div>
                 <div class="col-md-6 text-md-end">
@@ -129,7 +129,7 @@
             </div>
             <hr class="my-3">
             <div class="text-center text-muted">
-                <small>&copy; 2025 SecureApp. All rights reserved.</small>
+                <small>&copy; 2025 Viewer. All rights reserved.</small>
             </div>
         </div>
     </footer>

--- a/templates/import.html
+++ b/templates/import.html
@@ -51,7 +51,7 @@
                                     {% endfor %}
                                 </div>
                             {% else %}
-                                <div class="form-text">Upload a JSON export file from SecureApp.</div>
+                                <div class="form-text">Upload a JSON export file from Viewer.</div>
                             {% endif %}
                         </div>
 
@@ -90,7 +90,7 @@
                                     {% endfor %}
                                 </div>
                             {% else %}
-                                <div class="form-text">Provide a URL that returns a SecureApp JSON export.</div>
+                                <div class="form-text">Provide a URL that returns a Viewer JSON export.</div>
                             {% endif %}
                         </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -197,7 +197,7 @@
         <div class="col-lg-8">
             <h1 class="display-5 fw-bold text-primary mb-4">Workspace ready for you</h1>
             <p class="lead text-muted mb-4">
-                SecureApp now keeps a default workspace signed in so you can upload content,
+                Viewer now keeps a default workspace signed in so you can upload content,
                 create aliases, and run servers without a login step.
             </p>
             <p class="text-muted mb-4">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -6,7 +6,7 @@
         <div class="col-lg-8 text-center text-lg-start">
             <h1 class="mb-3"><i class="fas fa-user me-2"></i>Account Profile</h1>
             <p class="lead text-muted">
-                User accounts are now managed outside of SecureApp. This workspace automatically operates on a default profile so you can continue working without signing in.
+                User accounts are now managed outside of Viewer. This workspace automatically operates on a default profile so you can continue working without signing in.
             </p>
             <p class="text-muted">
                 Future releases may link to external account management tools here once they are available.


### PR DESCRIPTION
## Summary
- update documentation and helper scripts to refer to the project as Viewer
- refresh template text so the UI shows Viewer branding throughout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f2c3d3c8d083318ffcf5755cb0d552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product branding from SecureApp to Viewer throughout documentation, UI text, and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->