### PR TITLE
Add integration test workflow and supporting utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,69 @@ jobs:
         if: steps.run_tests.outcome == 'failure'
         run: exit 1
 
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite:////tmp/secureapp-ci.db
+      SESSION_SECRET: test-secret-key
+      TESTING: "True"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run integration tests
+        id: run_integration
+        run: |
+          set -o pipefail
+          python run_integration_tests.py -- --junitxml=integration-tests-report.xml | tee integration-tests.log
+        continue-on-error: true
+
+      - name: Publish integration summary
+        if: always()
+        run: |
+          if [ -f integration-tests.log ]; then
+            {
+              echo "### Integration tests"
+              echo
+              echo '```'
+              tail -n 50 integration-tests.log
+              echo '```'
+              echo
+              echo "JUnit XML: integration-tests-report.xml"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Integration tests"
+              echo
+              echo "No integration test log was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload integration test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-results
+          path: |
+            integration-tests-report.xml
+            integration-tests.log
+
+      - name: Fail if integration tests failed
+        if: steps.run_integration.outcome == 'failure'
+        run: exit 1
+
   gauge-specs:
     name: Gauge Specs
     runs-on: ubuntu-latest
@@ -159,11 +222,13 @@ jobs:
     name: Publish Test Reports
     needs:
       - unit-tests
+      - integration-tests
       - gauge-specs
     if: >-
       ${{ github.event_name == 'push' &&
           github.ref == 'refs/heads/main' &&
           needs['unit-tests'].result == 'success' &&
+          needs['integration-tests'].result == 'success' &&
           needs['gauge-specs'].result == 'success' }}
     runs-on: ubuntu-latest
     environment:
@@ -183,9 +248,15 @@ jobs:
           name: gauge-html
           path: site/gauge-specs
 
+      - name: Download integration test results
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-tests-results
+          path: site/integration-tests
+
       - name: Prepare site content
         run: |
-          mkdir -p site/unit-tests site/gauge-specs
+          mkdir -p site/unit-tests site/gauge-specs site/integration-tests
           if [ -d site/unit-tests/htmlcov ]; then
             mv site/unit-tests/htmlcov/* site/unit-tests/
             rmdir site/unit-tests/htmlcov
@@ -194,6 +265,48 @@ jobs:
             mv site/gauge-specs/reports/html-report/* site/gauge-specs/
             rm -rf site/gauge-specs/reports
           fi
+          python <<'PY'
+from html import escape
+from pathlib import Path
+
+base = Path("site/integration-tests")
+base.mkdir(parents=True, exist_ok=True)
+
+log_path = base / "integration-tests.log"
+xml_path = base / "integration-tests-report.xml"
+index_path = base / "index.html"
+
+log_content = "No log output was captured."
+if log_path.exists():
+    log_content = escape(log_path.read_text())
+
+xml_link = ""
+if xml_path.exists():
+    xml_link = '<p><a href="integration-tests-report.xml">Download the JUnit XML report</a></p>'
+
+index_path.write_text(
+    """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>Integration test results</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.6; }
+    pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>Integration test results</h1>
+  {xml_link}
+  <h2>Latest log excerpt</h2>
+  <pre>{log_content}</pre>
+</body>
+</html>
+""".format(xml_link=xml_link, log_content=log_content)
+)
+PY
           cat <<'HTML' > site/index.html
           <!DOCTYPE html>
           <html lang="en">
@@ -212,6 +325,7 @@ jobs:
             <h1>SecureApp Test Reports</h1>
             <ul>
               <li><a href="unit-tests/index.html">Unit test coverage report</a></li>
+              <li><a href="integration-tests/index.html">Integration test results</a></li>
               <li><a href="gauge-specs/index.html">Gauge HTML report</a></li>
             </ul>
           </body>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Visit the [published GitHub Pages site](https://curtcox.github.io/Viewer/) for t
 ./test      # run the full test suite (pytest + Gauge specs)
 ./test-unit  # run only the pytest suite (add --coverage for coverage reports)
 ./test-gauge # run only the Gauge specs
+python run_integration_tests.py  # run the dedicated integration test suite
 python run_coverage.py --xml --html  # run tests with coverage reports (optional)
 ```
 
@@ -45,6 +46,7 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
 * `test-unit` – execute the pytest suite (`--coverage` forwards to `run_coverage.py`).
 * `test-gauge` – run the Gauge specifications.
 * `test` – invoke both `test-unit` and `test-gauge` sequentially.
+* `run_integration_tests.py` – execute only the integration tests under `tests/integration`.
 * `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
 
 ### Gauge specs
@@ -67,8 +69,9 @@ both the pytest suite and the Gauge specs succeed.
 After changing the configuration or dependencies re‑run `./doctor` to ensure your setup is healthy.  Use `Ctrl+C` to stop
  the development server started with `./run`.
 
-Run `pytest` (or the `./test` wrapper) before opening a pull request so you catch regressions locally.  The test runner will
-execute every `test_*.py` module in the repository.
+Run `pytest` (or the `./test` wrapper) before opening a pull request so you catch regressions locally.  Integration scenarios
+live under `tests/integration` and are skipped by default; run `python run_integration_tests.py` when you need to validate
+end-to-end behaviour.
 
 ### Observability
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@ pythonpath = .
 testpaths = tests
 python_files = test_*.py
 norecursedirs = .git build dist venv install run doctor static templates
+addopts = -m "not integration"
+markers =
+    integration: Integration tests that exercise the full application stack.

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run the integration test suite via pytest."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+from tests.test_support import ROOT_DIR, build_test_environment
+
+
+def parse_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the integration test suite.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to pytest (prefix with --).",
+    )
+    args = parser.parse_args(argv)
+    if args.pytest_args and args.pytest_args[0] == "--":
+        args.pytest_args = args.pytest_args[1:]
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = parse_arguments(list(argv))
+    env = build_test_environment()
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--override-ini",
+        "addopts=",
+        "-m",
+        "integration",
+        "tests/integration",
+        *args.pytest_args,
+    ]
+    return subprocess.call(command, cwd=str(ROOT_DIR), env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test package for end-to-end scenarios."""

--- a/tests/integration/test_interactions_api.py
+++ b/tests/integration/test_interactions_api.py
@@ -1,0 +1,82 @@
+"""Integration tests for the interactions API."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app import create_app
+from database import db
+from db_access import get_recent_entity_interactions
+from identity import ensure_default_user
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def integration_app():
+    """Return a Flask app configured for integration testing."""
+
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+    os.environ.setdefault("SESSION_SECRET", "test-secret-key")
+
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+
+    with app.app_context():
+        db.create_all()
+        ensure_default_user()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(integration_app):
+    """Return a test client bound to the integration app."""
+
+    return integration_app.test_client()
+
+
+def test_interaction_endpoint_records_history(client, integration_app):
+    """The interactions API should persist requests and return updated history."""
+
+    payload = {
+        "entity_type": "server",
+        "entity_name": "demo-server",
+        "action": "ai",
+        "message": "format response",
+        "content": "print('hello world')",
+    }
+
+    response = client.post("/api/interactions", json=payload)
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data is not None
+    assert data.get("interaction") is not None
+    assert data["interaction"]["action"] == "ai"
+    assert data["interaction"]["message"] == payload["message"]
+    assert data["interaction"]["content"] == payload["content"]
+    assert data.get("interactions")
+    assert any(item.get("action") == "ai" for item in data["interactions"])
+
+    with integration_app.app_context():
+        history = get_recent_entity_interactions(
+            "default-user",
+            payload["entity_type"],
+            payload["entity_name"],
+            limit=1,
+        )
+
+    assert history, "The integration endpoint should create a database record."
+    record = history[0]
+    assert record.action == payload["action"]
+    assert record.message == payload["message"]
+    assert record.content == payload["content"]


### PR DESCRIPTION
## Summary
- add a dedicated integration test package with an interactions API test
- provide a helper script and pytest configuration to isolate integration runs
- extend the CI workflow to execute integration tests and publish their artifacts

## Testing
- python run_integration_tests.py

------
https://chatgpt.com/codex/tasks/task_b_68f2e80c9740833197b223640064c576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration testing for end-to-end scenarios
  * Integration tests are excluded from default test runs but can be executed separately

* **Documentation**
  * Updated testing guidance with integration test execution instructions

* **Chores**
  * Integrated testing framework into CI pipeline
  * Enhanced test reporting and artifact publication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->