### PR TITLE
Fix integration test report template formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,10 +291,10 @@ index_path.write_text(
   <meta charset=\"utf-8\" />
   <title>Integration test results</title>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.6; }
-    pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow-x: auto; }
-    a { color: #0366d6; text-decoration: none; }
-    a:hover { text-decoration: underline; }
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.6; }}
+    pre {{ background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow-x: auto; }}
+    a {{ color: #0366d6; text-decoration: none; }}
+    a:hover {{ text-decoration: underline; }}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- escape CSS style braces in the integration test results template so the CI step can render the HTML page without errors

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68f2fbf570f08331999509df1c20c7f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CSS formatting in generated integration reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->