### PR TITLE
Add meta inspector navigation link

### DIFF
--- a/routes/core.py
+++ b/routes/core.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 from flask import (
     abort,
     current_app,
+    has_request_context,
     redirect,
     render_template,
     request,
@@ -603,6 +604,25 @@ def inject_observability_info():
         LANGSMITH_PROJECT_URL=status.get("langsmith_project_url"),
         LANGSMITH_UNAVAILABLE_REASON=status.get("langsmith_reason"),
     )
+
+
+@main_bp.app_context_processor
+def inject_meta_inspector_link():
+    """Expose the per-page /meta inspector link to templates."""
+
+    if has_request_context():
+        path = request.path or "/"
+    else:
+        path = "/"
+
+    stripped = path.strip("/")
+    if stripped:
+        requested_path = f"{stripped}.html"
+    else:
+        requested_path = ".html"
+
+    meta_url = url_for("main.meta_route", requested_path=requested_path)
+    return {"meta_inspector_url": meta_url}
 
 
 @main_bp.route('/')

--- a/specs/meta_navigation.spec
+++ b/specs/meta_navigation.spec
@@ -1,0 +1,7 @@
+# Meta navigation
+
+## Info icon links to metadata
+* When I request the page /
+* The response status should be 200
+* The page should contain href="/meta/.html"
+* The page should contain fa-circle-info

--- a/step_impl/source_steps.py
+++ b/step_impl/source_steps.py
@@ -34,6 +34,14 @@ def when_i_request_source() -> None:
     _scenario_state["response"] = response
 
 
+@step("When I request the page <path>")
+def when_i_request_the_page(path: str) -> None:
+    if _client is None:
+        raise RuntimeError("Gauge test client is not initialized.")
+    response = _client.get(path)
+    _scenario_state["response"] = response
+
+
 @step("The response status should be 200")
 def then_status_is_200() -> None:
     response = _scenario_state.get("response")
@@ -52,3 +60,11 @@ def then_response_contains_source_browser() -> None:
     body = response.get_data(as_text=True)
     expected_text = "Source Browser"
     assert expected_text in body, f"Expected to find {expected_text!r} in the response body."
+
+
+@step("The page should contain <text>")
+def then_page_should_contain(text: str) -> None:
+    response = _scenario_state.get("response")
+    assert response is not None, "No response recorded. Call `When I request ...` first."
+    body = response.get_data(as_text=True)
+    assert text in body, f"Expected to find {text!r} in the response body."

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,17 @@
                     </li>
                 </ul>
 
-                <ul class="navbar-nav">
+                <ul class="navbar-nav align-items-center">
+                    <li class="nav-item">
+                        <a
+                            class="nav-link text-light"
+                            href="{{ meta_inspector_url }}"
+                            title="View metadata for this page"
+                            aria-label="View metadata for this page"
+                        >
+                            <i class="fas fa-circle-info"></i>
+                        </a>
+                    </li>
                     <li class="nav-item">
                         <span class="nav-link text-light">
                             <i class="fas fa-user-circle me-1"></i>{{ current_user.username }}

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -132,6 +132,16 @@ class TestContextProcessors(BaseTestCase):
             "https://langsmith.example/project",
         )
 
+    def test_inject_meta_inspector_link(self):
+        """Expose a metadata inspector link for the active request path."""
+
+        from routes.core import inject_meta_inspector_link
+
+        with self.app.test_request_context('/servers/example'):
+            context = inject_meta_inspector_link()
+
+        self.assertEqual(context["meta_inspector_url"], "/meta/servers/example.html")
+
 
 class TestPublicRoutes(BaseTestCase):
     """Test routes that don't require authentication."""
@@ -426,6 +436,17 @@ class TestAuthenticatedRoutes(BaseTestCase):
         self.login_user()
         response = self.client.get('/profile')
         self.assertEqual(response.status_code, 200)
+
+    def test_navigation_includes_meta_inspector_link(self):
+        """Display a metadata inspector shortcut in the site navigation."""
+
+        self.login_user()
+        response = self.client.get('/profile')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('href="/meta/profile.html"', page)
+        self.assertIn('fa-circle-info', page)
 
     def test_content_route_returns_not_found(self):
         """Legacy /content endpoint should be unavailable."""


### PR DESCRIPTION
## Summary
- add a navigation info icon that links to the page-specific /meta inspector
- expose the inspector URL via a new context processor and cover it with tests
- extend Gauge coverage and steps to validate the new navigation link

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f3bff728388331b048fd68e799c25b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a metadata inspector feature accessible via a new info icon button in the navigation bar, enabling users to view metadata for the current page

* **Tests**
  * Added comprehensive test coverage validating metadata inspector integration across various pages and user states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->