### PR TITLE
Link meta inspector pages to page test cross reference

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -1,0 +1,505 @@
+# Page Test Cross Reference
+
+This document maps site pages to the automated checks that exercise them.
+
+## templates/alias_form.html
+
+**Routes:**
+- `routes/aliases.py::new_alias` (paths: `/aliases/new`)
+- `routes/aliases.py::edit_alias` (paths: `/aliases/<alias_name>/edit`)
+
+**Unit tests:**
+- `tests/test_alias_routing.py::TestAliasRouting::test_create_alias_rejects_conflicting_route`
+- `tests/test_alias_routing.py::TestAliasRouting::test_create_alias_via_form`
+- `tests/test_alias_routing.py::TestAliasRouting::test_create_alias_with_glob_match_type`
+- `tests/test_alias_routing.py::TestAliasRouting::test_edit_alias_rejects_conflicting_route_name`
+- `tests/test_alias_routing.py::TestAliasRouting::test_edit_alias_updates_record`
+- `tests/test_alias_routing.py::TestAliasRouting::test_new_alias_prefills_name_from_path_query`
+- `tests/test_alias_routing.py::TestAliasRouting::test_test_pattern_button_displays_results_without_saving`
+- `tests/test_routes_comprehensive.py::TestAliasRoutes::test_new_alias_form_includes_ai_controls`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/alias_view.html
+
+**Routes:**
+- `routes/aliases.py::view_alias` (paths: `/aliases/<alias_name>`)
+
+**Unit tests:**
+- `tests/test_alias_routing.py::TestAliasRouting::test_view_alias_page`
+- `tests/test_routes_comprehensive.py::TestAliasRoutes::test_alias_detail_displays_cid_link_for_cid_target`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/aliases.html
+
+**Routes:**
+- `routes/aliases.py::aliases` (paths: `/aliases`)
+
+**Unit tests:**
+- `tests/test_alias_routing.py::TestAliasRouting::test_aliases_route_lists_aliases`
+- `tests/test_alias_routing.py::TestAliasRouting::test_aliases_route_lists_aliases_for_default_user`
+- `tests/test_error_page_source_links.py::TestErrorPageSourceLinks::test_aliases_error_shows_source_links_in_stack_trace`
+- `tests/test_routes_comprehensive.py::TestAliasRoutes::test_alias_list_displays_cid_link_for_cid_target`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/edit_cid.html
+
+**Routes:**
+- `routes/uploads.py::edit_cid` (paths: `/edit/<cid_prefix>`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_alias_name_conflict_shows_error`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_full_match_preferred_over_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_full_match`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_unique_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_with_existing_alias_updates_button_text`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_without_alias_shows_alias_field`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_multiple_matches`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_not_found`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_allows_creating_new_alias`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_creates_new_record`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_existing_content`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_updates_existing_alias_target`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_requires_login`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/edit_cid_choices.html
+
+**Routes:**
+- `routes/uploads.py::edit_cid` (paths: `/edit/<cid_prefix>`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_alias_name_conflict_shows_error`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_full_match_preferred_over_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_full_match`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_unique_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_with_existing_alias_updates_button_text`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_without_alias_shows_alias_field`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_multiple_matches`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_not_found`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_allows_creating_new_alias`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_creates_new_record`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_existing_content`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_updates_existing_alias_target`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_requires_login`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/export.html
+
+**Routes:**
+- `routes/import_export.py::export_data` (paths: `/export`)
+
+**Unit tests:**
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_allows_runtime_only`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_excludes_unreferenced_cids_by_default`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_excludes_virtualenv_python_files`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_app_source_cids`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_runtime_section`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_selected_collections`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_unreferenced_cids_when_requested`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_without_cid_map_excludes_section`
+
+**Integration tests:**
+- `tests/integration/test_import_export_flow.py::test_user_can_transport_server_between_sites`
+
+**Specs:**
+- _None_
+
+## templates/export_result.html
+
+**Routes:**
+- `routes/import_export.py::export_data` (paths: `/export`)
+
+**Unit tests:**
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_allows_runtime_only`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_excludes_unreferenced_cids_by_default`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_excludes_virtualenv_python_files`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_app_source_cids`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_runtime_section`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_selected_collections`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_includes_unreferenced_cids_when_requested`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_export_without_cid_map_excludes_section`
+
+**Integration tests:**
+- `tests/integration/test_import_export_flow.py::test_user_can_transport_server_between_sites`
+
+**Specs:**
+- _None_
+
+## templates/history.html
+
+**Routes:**
+- `routes/history.py::history` (paths: `/history`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestHistoryRoutes::test_history_page`
+- `tests/test_routes_comprehensive.py::TestHistoryRoutes::test_history_pagination`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/import.html
+
+**Routes:**
+- `routes/import_export.py::import_data` (paths: `/import`)
+
+**Unit tests:**
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_change_history_creates_events`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_rejects_invalid_secret_key`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_rejects_mismatched_cid_map_entry`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_reports_mismatched_app_source`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_reports_missing_cid_content`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_reports_missing_selected_content`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_import_verifies_app_source_matches`
+- `tests/test_import_export.py::ImportExportRoutesTestCase::test_successful_import_creates_entries`
+- `tests/test_routes_comprehensive.py::TestSettingsRoutes::test_import_form_includes_ai_controls`
+
+**Integration tests:**
+- `tests/integration/test_import_export_flow.py::test_user_can_transport_server_between_sites`
+
+**Specs:**
+- _None_
+
+## templates/index.html
+
+**Routes:**
+- `routes/core.py::index` (paths: `/`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_alias_target_displays_cid_link_for_cid_path`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_authenticated_shows_cross_reference_dashboard`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_cross_reference_cids_include_incoming_highlight_metadata`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_cross_reference_lists_entities_and_relationships`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_cross_reference_shortcuts_link_to_entity_lists`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_cross_reference_skips_cids_without_named_alias`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_cross_reference_skips_cids_without_named_server`
+- `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_unauthenticated`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- meta_navigation.spec — Info icon links to metadata
+
+## templates/profile.html
+
+**Routes:**
+- `routes/core.py::profile` (paths: `/profile`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestAuthenticatedRoutes::test_navigation_includes_meta_inspector_link`
+- `tests/test_routes_comprehensive.py::TestAuthenticatedRoutes::test_profile_page`
+- `tests/test_routes_comprehensive.py::TestPageViewTracking::test_page_view_tracking_authenticated`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/routes_overview.html
+
+**Routes:**
+- `routes/routes_overview.py::routes_overview` (paths: `/routes`)
+
+**Unit tests:**
+- `tests/test_routes_overview.py::RoutesOverviewTestCase::test_frontend_filtering_orders_exact_partial_and_not_found`
+- `tests/test_routes_overview.py::RoutesOverviewTestCase::test_lists_builtin_alias_and_server_routes`
+- `tests/test_routes_overview.py::RoutesOverviewTestCase::test_requires_login`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/secret_form.html
+
+**Routes:**
+- `routes/secrets.py::new_secret` (paths: `/secrets/new`)
+- `routes/secrets.py::edit_secret` (paths: `/secrets/<secret_name>/edit`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_new_secret_form_includes_ai_controls`
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_new_secret_post`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/secret_view.html
+
+**Routes:**
+- `routes/secrets.py::view_secret` (paths: `/secrets/<secret_name>`)
+
+**Unit tests:**
+- _None_
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/secrets.html
+
+**Routes:**
+- `routes/secrets.py::secrets` (paths: `/secrets`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_new_secret_post`
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_secrets_list`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/server_events.html
+
+**Routes:**
+- `routes/uploads.py::server_events` (paths: `/server_events`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_server_events_page_shows_invocations`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/server_form.html
+
+**Routes:**
+- `routes/servers.py::new_server` (paths: `/servers/new`)
+- `routes/servers.py::edit_server` (paths: `/servers/<server_name>/edit`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_edit_server_get`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_edit_server_includes_test_form`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_edit_server_post`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_duplicate_name`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_get`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_post`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_prefills_name_from_path_query`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/server_view.html
+
+**Routes:**
+- `routes/servers.py::view_server` (paths: `/servers/<server_name>`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_nonexistent_server`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_server`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_server_falls_back_to_query_test_form`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_server_includes_main_test_form`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_server_invocation_history_table`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/servers.html
+
+**Routes:**
+- `routes/servers.py::servers` (paths: `/servers`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_post`
+- `tests/test_routes_comprehensive.py::TestServerRoutes::test_servers_list`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/settings.html
+
+**Routes:**
+- `routes/core.py::settings` (paths: `/settings`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestSettingsRoutes::test_settings_page`
+- `tests/test_routes_comprehensive.py::TestSettingsRoutes::test_settings_page_shows_direct_access_links`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/source_browser.html
+
+**Routes:**
+- `routes/source.py::source_browser` (paths: `/source`, `/source/<path:requested_path>`)
+
+**Unit tests:**
+- `tests/test_enhanced_error_pages.py::TestEnhancedErrorPageIntegration::test_source_browser_serves_comprehensive_files`
+- `tests/test_error_pages.py::TestEnhancedSourceBrowser::test_enhanced_source_browser_serves_untracked_files`
+- `tests/test_error_pages_e2e.py::TestErrorPagesEndToEnd::test_source_browser_accessibility_from_error_links`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_htmlcov_serves_raw_content`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_index_lists_tracked_files`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_rejects_files_outside_project`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_rejects_path_traversal`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_serves_file_content`
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_serves_untracked_project_files`
+- `tests/test_source_spec_report.py::test_source_serves_gauge_report`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- source_browser.spec — Source listing renders
+
+## templates/upload.html
+
+**Routes:**
+- `routes/uploads.py::upload` (paths: `/upload`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_duplicate_file`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_get`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_post_success`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_file_handles_no_extension`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_file_preserves_original_extension`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_text_gets_txt_extension`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/upload_success.html
+
+**Routes:**
+- `routes/uploads.py::upload` (paths: `/upload`)
+- `routes/uploads.py::edit_cid` (paths: `/edit/<cid_prefix>`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_alias_name_conflict_shows_error`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_full_match_preferred_over_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_full_match`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_unique_prefix`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_with_existing_alias_updates_button_text`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_get_without_alias_shows_alias_field`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_multiple_matches`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_not_found`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_allows_creating_new_alias`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_creates_new_record`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_existing_content`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_cid_save_updates_existing_alias_target`
+- `tests/test_routes_comprehensive.py::TestCidEditingRoutes::test_edit_requires_login`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_duplicate_file`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_get`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_upload_post_success`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_file_handles_no_extension`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_file_preserves_original_extension`
+- `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_text_gets_txt_extension`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/uploads.html
+
+**Routes:**
+- `routes/uploads.py::uploads` (paths: `/uploads`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_uploads_list`
+- `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_uploads_list_excludes_server_events`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/variable_form.html
+
+**Routes:**
+- `routes/variables.py::new_variable` (paths: `/variables/new`)
+- `routes/variables.py::edit_variable` (paths: `/variables/<variable_name>/edit`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_new_variable_form_includes_ai_controls`
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_new_variable_post`
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variable_edit_shows_404_matching_route`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/variable_view.html
+
+**Routes:**
+- `routes/variables.py::view_variable` (paths: `/variables/<variable_name>`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variable_view_shows_matching_route_summary`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_
+
+## templates/variables.html
+
+**Routes:**
+- `routes/variables.py::variables` (paths: `/variables`)
+
+**Unit tests:**
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_new_variable_post`
+- `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variables_list`
+
+**Integration tests:**
+- _None_
+
+**Specs:**
+- _None_

--- a/generate_page_test_cross_reference.py
+++ b/generate_page_test_cross_reference.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Generate a markdown cross reference between site pages and automated checks."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import contextlib
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import coverage
+import pytest
+
+from tests.test_support import ROOT_DIR, build_test_environment
+
+
+@dataclass
+class RouteFunctionInfo:
+    """Metadata about a Flask route function discovered via static analysis."""
+
+    module_path: Path
+    function_name: str
+    start_line: int
+    end_line: int
+    route_paths: list[str] = field(default_factory=list)
+    templates: set[str] = field(default_factory=set)
+    tests_by_suite: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+    specs: set[str] = field(default_factory=set)
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.module_path.as_posix()}::{self.function_name}"
+
+
+RouteCollection = list[RouteFunctionInfo]
+
+
+class TemplateCollector(ast.NodeVisitor):
+    """Collect template names referenced in a function body."""
+
+    TEMPLATE_FUNCTIONS = {
+        "render_template",
+        "render_template_string",
+    }
+
+    def __init__(self) -> None:
+        self.templates: set[str] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 (ast API)
+        func = node.func
+        func_name = None
+        if isinstance(func, ast.Name):
+            func_name = func.id
+        elif isinstance(func, ast.Attribute):
+            func_name = func.attr
+        if func_name in self.TEMPLATE_FUNCTIONS and node.args:
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                self.templates.add(arg.value)
+        self.generic_visit(node)
+
+
+class FunctionCallCollector(ast.NodeVisitor):
+    """Collect direct function calls made within a function body."""
+
+    def __init__(self) -> None:
+        self.called: set[str] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        func = node.func
+        if isinstance(func, ast.Name):
+            self.called.add(func.id)
+        self.generic_visit(node)
+
+
+@dataclass
+class FunctionDetails:
+    node: ast.FunctionDef
+    route_paths: list[str]
+    templates: set[str]
+    called_functions: set[str]
+
+
+def _route_paths_from_decorators(decorator_list: Iterable[ast.expr]) -> list[str]:
+    paths: list[str] = []
+    for decorator in decorator_list:
+        if isinstance(decorator, ast.Call):
+            target = decorator.func
+            attr = None
+            if isinstance(target, ast.Attribute):
+                attr = target.attr
+            if attr not in {"route", "get", "post", "put", "patch", "delete"}:
+                continue
+            for arg in decorator.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    paths.append(arg.value)
+            for keyword in decorator.keywords or []:
+                if keyword.arg == "rule" and isinstance(keyword.value, ast.Constant) and isinstance(
+                    keyword.value.value, str
+                ):
+                    paths.append(keyword.value.value)
+    return paths
+
+
+def _resolve_templates(
+    function_name: str,
+    functions: Mapping[str, FunctionDetails],
+    seen: set[str],
+) -> set[str]:
+    if function_name in seen:
+        return set()
+    details = functions.get(function_name)
+    if not details:
+        return set()
+
+    collected = set(details.templates)
+    next_seen = seen | {function_name}
+    for callee in details.called_functions:
+        if callee in functions:
+            collected.update(_resolve_templates(callee, functions, next_seen))
+    return collected
+
+
+def discover_route_functions(route_dir: Path) -> RouteCollection:
+    """Return information about Flask route functions under ``route_dir``."""
+
+    routes: RouteCollection = []
+    for path in sorted(route_dir.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+
+        functions: dict[str, FunctionDetails] = {}
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            route_paths = _route_paths_from_decorators(node.decorator_list)
+            template_collector = TemplateCollector()
+            template_collector.visit(node)
+            call_collector = FunctionCallCollector()
+            call_collector.visit(node)
+            functions[node.name] = FunctionDetails(
+                node=node,
+                route_paths=route_paths,
+                templates=template_collector.templates,
+                called_functions={
+                    callee for callee in call_collector.called if callee != node.name
+                },
+            )
+
+        for details in functions.values():
+            if not details.route_paths:
+                continue
+            templates = _resolve_templates(details.node.name, functions, set())
+            routes.append(
+                RouteFunctionInfo(
+                    module_path=path.relative_to(ROOT_DIR),
+                    function_name=details.node.name,
+                    start_line=details.node.lineno,
+                    end_line=details.node.end_lineno or details.node.lineno,
+                    route_paths=details.route_paths,
+                    templates=templates,
+                )
+            )
+    return routes
+
+
+def _apply_test_environment() -> contextlib.AbstractContextManager[None]:
+    """Temporarily apply test environment variables expected by the suites."""
+
+    env = build_test_environment()
+    relevant_keys = {"PYTHONPATH", "DATABASE_URL", "SESSION_SECRET", "TESTING"}
+
+    class _EnvGuard(contextlib.AbstractContextManager[None]):
+        def __enter__(self) -> None:
+            self._original: dict[str, str | None] = {key: os.environ.get(key) for key in relevant_keys}
+            for key in relevant_keys:
+                if key in env:
+                    os.environ[key] = env[key]
+                elif key in os.environ:
+                    del os.environ[key]
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+            for key, value in self._original.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    return _EnvGuard()
+
+
+def run_pytest_suite(name: str, pytest_args: list[str], data_file: Path) -> coverage.Coverage:
+    """Execute ``pytest`` under coverage for the given suite and return loaded data."""
+
+    print(f"[crossref] Running {name} suite with coverage...")
+    cov = coverage.Coverage(config_file=str(ROOT_DIR / ".coveragerc"), data_file=str(data_file))
+    cov.config.dynamic_context = "test_function"
+    cov.erase()
+
+    with _apply_test_environment():
+        cov.start()
+        try:
+            result = pytest.main(pytest_args)
+        finally:
+            cov.stop()
+            cov.save()
+    if result != 0:
+        raise RuntimeError(f"{name} suite failed with exit code {result}")
+
+    cov.load()
+    return cov
+
+
+def gather_suite_coverage(reuse: bool) -> dict[str, coverage.Coverage]:
+    """Run unit and integration suites, returning coverage objects keyed by suite."""
+
+    coverage_dir = ROOT_DIR / ".coverage_crossref"
+    coverage_dir.mkdir(exist_ok=True)
+
+    suites = {
+        "unit": {
+            "pytest_args": ["-m", "not integration"],
+            "data_file": coverage_dir / "unit.coverage",
+        },
+        "integration": {
+            "pytest_args": ["-m", "integration", "tests/integration"],
+            "data_file": coverage_dir / "integration.coverage",
+        },
+    }
+
+    collected: dict[str, coverage.Coverage] = {}
+    for name, cfg in suites.items():
+        data_file: Path = cfg["data_file"]
+        if reuse and data_file.exists():
+            cov = coverage.Coverage(data_file=str(data_file))
+            cov.load()
+            collected[name] = cov
+            print(f"[crossref] Reused existing coverage data for {name} suite.")
+            continue
+
+        cov = run_pytest_suite(name, cfg["pytest_args"], data_file)
+        collected[name] = cov
+    return collected
+
+
+def contexts_for_route(route: RouteFunctionInfo, cov: coverage.Coverage) -> set[str]:
+    data = cov.get_data()
+    absolute = str(ROOT_DIR / route.module_path)
+    contexts_by_line = data.contexts_by_lineno(absolute)
+    discovered: set[str] = set()
+    for line in range(route.start_line, route.end_line + 1):
+        for ctx in contexts_by_line.get(line, []):
+            if ctx:
+                discovered.add(ctx)
+    return discovered
+
+
+def format_context(context: str) -> str:
+    module_name = context
+    qual_parts: list[str] = []
+    while module_name:
+        candidate = ROOT_DIR / (module_name.replace(".", "/") + ".py")
+        if candidate.exists():
+            break
+        module_name, sep, last = module_name.rpartition(".")
+        if not sep:
+            qual_parts.insert(0, last)
+            module_name = ""
+            break
+        qual_parts.insert(0, last)
+    if not module_name:
+        module_name = context
+        qual_parts = []
+    display = module_name.replace(".", "/") + ".py"
+    if qual_parts:
+        display += "::" + "::".join(qual_parts)
+    return display
+
+
+def map_specs_by_route(spec_dir: Path) -> dict[str, set[str]]:
+    pattern = re.compile(r"/[^\s\"]*")
+    mapping: dict[str, set[str]] = defaultdict(set)
+    for spec_file in sorted(spec_dir.glob("*.spec")):
+        current_section = None
+        for raw_line in spec_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if line.startswith("## "):
+                current_section = line[3:].strip()
+                continue
+            for match in pattern.findall(line):
+                entry = f"{spec_file.name} — {current_section or 'Scenario'}"
+                mapping[match].add(entry)
+    return mapping
+
+
+def aggregate_pages(routes: RouteCollection, spec_mapping: Mapping[str, set[str]]) -> dict[str, dict[str, object]]:
+    pages: dict[str, dict[str, object]] = {}
+    for route in routes:
+        route_specs = set()
+        for path in route.route_paths:
+            route_specs.update(spec_mapping.get(path, set()))
+        if route_specs:
+            route.specs = route_specs
+        for template in sorted(route.templates):
+            entry = pages.setdefault(
+                template,
+                {
+                    "routes": [],
+                    "tests": defaultdict(set),
+                    "specs": set(),
+                },
+            )
+            entry["routes"].append(route)
+            entry["specs"].update(route.specs)
+            for suite, contexts in route.tests_by_suite.items():
+                entry["tests"][suite].update(contexts)
+    return pages
+
+
+def generate_markdown(pages: Mapping[str, dict[str, object]]) -> str:
+    lines = ["# Page Test Cross Reference", "", "This document maps site pages to the automated checks that exercise them.", ""]
+
+    for template in sorted(pages):
+        info = pages[template]
+        routes: list[RouteFunctionInfo] = info["routes"]  # type: ignore[assignment]
+        tests: Mapping[str, set[str]] = info["tests"]  # type: ignore[assignment]
+        specs: set[str] = info["specs"]  # type: ignore[assignment]
+
+        lines.append(f"## templates/{template}")
+        lines.append("")
+
+        lines.append("**Routes:**")
+        for route in routes:
+            route_desc = f"- `{route.identifier}`"
+            if route.route_paths:
+                route_desc += f" (paths: {', '.join(f'`{path}`' for path in route.route_paths)})"
+            lines.append(route_desc)
+        lines.append("")
+
+        for suite_name in ("unit", "integration"):
+            suite_tests = sorted(tests.get(suite_name, set()))
+            label = "Unit tests" if suite_name == "unit" else "Integration tests"
+            lines.append(f"**{label}:**")
+            if suite_tests:
+                for test in suite_tests:
+                    lines.append(f"- `{test}`")
+            else:
+                lines.append("- _None_")
+            lines.append("")
+
+        lines.append("**Specs:**")
+        if specs:
+            for spec in sorted(specs):
+                lines.append(f"- {spec}")
+        else:
+            lines.append("- _None_")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT_DIR / "docs" / "page_test_cross_reference.md",
+        help="Path to write the generated markdown.",
+    )
+    parser.add_argument(
+        "--reuse-coverage",
+        action="store_true",
+        help="Reuse coverage data from a previous run instead of executing the suites again.",
+    )
+    parser.add_argument(
+        "--keep-coverage",
+        action="store_true",
+        help="Keep the intermediate coverage data files instead of deleting them.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    route_functions = discover_route_functions(ROOT_DIR / "routes")
+    if not route_functions:
+        print("[crossref] No route functions found under routes/; nothing to do.")
+        return 0
+
+    coverages = gather_suite_coverage(reuse=args.reuse_coverage)
+
+    for suite_name, cov in coverages.items():
+        for route in route_functions:
+            contexts = {format_context(ctx) for ctx in contexts_for_route(route, cov)}
+            if contexts:
+                route.tests_by_suite.setdefault(suite_name, set()).update(contexts)
+
+    spec_mapping = map_specs_by_route(ROOT_DIR / "specs")
+    pages = aggregate_pages(route_functions, spec_mapping)
+
+    output_path = args.output if args.output.is_absolute() else ROOT_DIR / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown = generate_markdown(pages)
+    output_path.write_text(markdown, encoding="utf-8")
+    print(f"[crossref] Wrote cross reference to {output_path.relative_to(ROOT_DIR)}")
+
+    if not args.keep_coverage:
+        for cov in coverages.values():
+            data_file = Path(cov.config.data_file)
+            with contextlib.suppress(FileNotFoundError):
+                data_file.unlink()
+        coverage_dir = ROOT_DIR / ".coverage_crossref"
+        if coverage_dir.exists() and not any(coverage_dir.iterdir()):
+            coverage_dir.rmdir()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -5,6 +5,8 @@ import ast
 import inspect
 import os
 import textwrap
+from functools import lru_cache
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlsplit
 
@@ -672,9 +674,179 @@ def _render_value_html(value: Any) -> Markup:
     return _render_scalar_html(value)
 
 
+@lru_cache()
+def _load_page_test_cross_reference(app_root: str) -> Dict[str, Dict[str, List[str]]]:
+    """Return a mapping of templates to their documented automated checks."""
+
+    doc_path = Path(app_root) / "docs" / "page_test_cross_reference.md"
+    if not doc_path.is_file():
+        return {}
+
+    sections = {
+        "routes": "routes",
+        "unit tests": "unit_tests",
+        "integration tests": "integration_tests",
+        "specs": "specs",
+    }
+
+    mapping: Dict[str, Dict[str, List[str]]] = {}
+    current_template: Optional[str] = None
+    current_section: Optional[str] = None
+
+    with doc_path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("## "):
+                template_name = line[3:].strip()
+                current_template = template_name
+                mapping[current_template] = {key: [] for key in sections.values()}
+                current_section = None
+                continue
+
+            if line.startswith("**") and line.endswith("**"):
+                header_text = line[2:-2].strip()
+                if header_text.endswith(":"):
+                    header_text = header_text[:-1]
+                current_section = sections.get(header_text.lower())
+                continue
+
+            if not line.startswith("- ") or not current_template or not current_section:
+                continue
+
+            value = line[2:].strip()
+            if value == "_None_":
+                continue
+
+            if value.startswith("`") and value.endswith("`"):
+                value = value[1:-1]
+
+            mapping[current_template][current_section].append(value)
+
+    return mapping
+
+
+def _templates_for_metadata(metadata: Dict[str, Any]) -> List[str]:
+    """Return templates referenced by the supplied metadata in declaration order."""
+
+    templates: List[str] = []
+    for link in metadata.get("source_links", []) or []:
+        if not isinstance(link, str):
+            continue
+        if not link.startswith("/source/"):
+            continue
+        relative = link[len("/source/") :]
+        if not relative.startswith("templates/"):
+            continue
+        if relative not in templates:
+            templates.append(relative)
+
+    return templates
+
+
+def _reference_to_source_link(reference: str, category: str) -> Optional[str]:
+    """Return a /source URL for the supplied reference if available."""
+
+    if category in {"unit_tests", "integration_tests"}:
+        file_part = reference.split("::", 1)[0]
+        if file_part.endswith(".py"):
+            return f"/source/{file_part}"
+        return None
+
+    if category == "specs":
+        file_part = reference.split(" — ", 1)[0].strip()
+        if file_part and not file_part.startswith("specs/"):
+            file_part = f"specs/{file_part}"
+        if file_part:
+            return f"/source/{file_part}"
+
+    return None
+
+
+def _render_reference_item(reference: str, category: str) -> Markup:
+    """Return HTML for a single documented automated check."""
+
+    href = _reference_to_source_link(reference, category)
+    if category == "specs" and " — " in reference:
+        name, description = reference.split(" — ", 1)
+        link_html = Markup(f"<code>{escape(name)}</code>")
+        if href:
+            link_html = Markup(f'<a href="{escape(href)}">{link_html}</a>')
+        return Markup(f"{link_html} — {escape(description)}")
+
+    content = Markup(f"<code>{escape(reference)}</code>")
+    if href:
+        return Markup(f'<a href="{escape(href)}">{content}</a>')
+    return content
+
+
+def _render_related_tests_section(metadata: Dict[str, Any]) -> str:
+    """Return an HTML section linking to tests that exercise the page."""
+
+    templates = _templates_for_metadata(metadata)
+    if not templates:
+        return ""
+
+    cross_reference = _load_page_test_cross_reference(current_app.root_path)
+    categories = [
+        ("unit_tests", "Unit tests"),
+        ("integration_tests", "Integration tests"),
+        ("specs", "Specs"),
+    ]
+
+    aggregated: Dict[str, List[str]] = {key: [] for key, _ in categories}
+    for template in templates:
+        data = cross_reference.get(template)
+        if not data:
+            continue
+        for key, _ in categories:
+            aggregated[key].extend(data.get(key, []))
+
+    if not any(aggregated[key] for key, _ in categories):
+        return ""
+
+    for key in aggregated:
+        aggregated[key] = list(dict.fromkeys(aggregated[key]))
+
+    template_links = [
+        Markup('<li><a href="{href}"><code>{label}</code></a></li>').format(
+            href=escape(f"/source/{template}"), label=escape(template)
+        )
+        for template in templates
+    ]
+
+    sections_html: List[str] = [
+        '<section class="meta-related-tests">',
+        '<h2>Related automated coverage</h2>',
+        '<p>Tests below are sourced from <code>docs/page_test_cross_reference.md</code> for templates rendered by this page.</p>',
+        '<h3>Templates</h3>',
+        '<ul class="meta-related-tests-templates">',
+        "".join(str(item) for item in template_links),
+        "</ul>",
+    ]
+
+    for key, label in categories:
+        sections_html.append(f'<h3>{escape(label)}</h3>')
+        items = aggregated[key]
+        if items:
+            sections_html.append('<ul class="meta-related-tests-list">')
+            for reference in items:
+                rendered = _render_reference_item(reference, key)
+                sections_html.append(f"<li>{rendered}</li>")
+            sections_html.append("</ul>")
+        else:
+            sections_html.append('<p><em>None documented.</em></p>')
+
+    sections_html.append("</section>")
+    return "".join(sections_html)
+
+
 def _render_metadata_html(metadata: Dict[str, Any]) -> str:
     """Return an HTML page for the supplied metadata."""
     body = _render_value_html(metadata)
+    related_tests = _render_related_tests_section(metadata)
     styles = """
     body { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 2rem; }
     h1 { font-size: 1.5rem; margin-bottom: 1rem; }
@@ -684,8 +856,14 @@ def _render_metadata_html(metadata: Dict[str, Any]) -> str:
     .meta-key { font-weight: 600; }
     code { background: #f5f5f5; padding: 0.1rem 0.3rem; border-radius: 0.25rem; }
     a code { color: inherit; }
+    .meta-related-tests { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #ddd; }
+    .meta-related-tests h2 { margin-bottom: 0.5rem; }
+    .meta-related-tests h3 { margin-top: 1.25rem; margin-bottom: 0.5rem; }
+    .meta-related-tests ul { list-style: disc; padding-left: 1.5rem; }
+    .meta-related-tests-templates { list-style: none; padding-left: 0; display: flex; flex-wrap: wrap; gap: 0.5rem 1.5rem; }
+    .meta-related-tests-templates li { list-style: none; }
     """
-    return f"""<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Meta Inspector</title><style>{styles}</style></head><body><h1>Meta inspector</h1>{body}</body></html>"""
+    return f"""<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Meta Inspector</title><style>{styles}</style></head><body><h1>Meta inspector</h1>{body}{related_tests}</body></html>"""
 
 
 def _handle_not_found(

--- a/tests/test_meta_route.py
+++ b/tests/test_meta_route.py
@@ -178,6 +178,17 @@ class TestMetaRoute(unittest.TestCase):
             self.assertIn('<a href="/settings"><code>/settings</code></a>', body)
             self.assertIn('<a href="/source/templates/settings.html"><code>/source/templates/settings.html</code></a>', body)
 
+    def test_meta_route_html_includes_related_tests_links(self):
+        with self.app.app_context():
+            response = self.client.get('/meta/settings.html')
+            self.assertEqual(response.status_code, 200)
+
+            body = response.data.decode('utf-8')
+            self.assertIn('Related automated coverage', body)
+            self.assertIn('/source/templates/settings.html', body)
+            self.assertIn('/source/tests/test_routes_comprehensive.py', body)
+            self.assertIn('TestSettingsRoutes::test_settings_page', body)
+
     def test_meta_route_reports_alias_redirect_metadata(self):
         with self.app.app_context():
             user = self._create_test_user()


### PR DESCRIPTION
## Summary
- parse `docs/page_test_cross_reference.md` to map templates to their documented automated checks
- render a related automated coverage section on `/meta/...html` pages that links to the referenced tests and specs
- verify the HTML meta inspector output includes the new coverage links

## Testing
- pytest tests/test_meta_route.py

------
https://chatgpt.com/codex/tasks/task_b_68f3c4151a248331a2439110e3e05d18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata pages now display "Related automated coverage" sections with links to associated unit tests, integration tests, and specifications.

* **Documentation**
  * Added comprehensive cross-reference documentation mapping site pages to their test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->