### PR TITLE
Add tests for secret view route

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -262,7 +262,8 @@ This document maps site pages to the automated checks that exercise them.
 - `routes/secrets.py::view_secret` (paths: `/secrets/<secret_name>`)
 
 **Unit tests:**
-- _None_
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_page_displays_secret_details`
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_missing_returns_404`
 
 **Integration tests:**
 - _None_

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -1494,6 +1494,34 @@ class TestSecretRoutes(BaseTestCase):
         self.assertIn('definition-ai-input', page)
         self.assertIn('Ask AI to edit the secret definition', page)
 
+    def test_view_secret_page_displays_secret_details(self):
+        """Secret detail page should render secret metadata and definition."""
+        self.login_user()
+
+        secret = Secret(
+            name='production-api-key',
+            definition='super-secret-value',
+            user_id=self.test_user.id,
+        )
+        db.session.add(secret)
+        db.session.commit()
+
+        response = self.client.get('/secrets/production-api-key')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('Secret Definition', page)
+        self.assertIn('super-secret-value', page)
+        self.assertIn('Direct URL', page)
+        self.assertIn('/secrets/production-api-key', page)
+
+    def test_view_secret_missing_returns_404(self):
+        """Requesting a secret that does not exist should return 404."""
+        self.login_user()
+
+        response = self.client.get('/secrets/nonexistent-secret')
+        self.assertEqual(response.status_code, 404)
+
 
 class TestAliasRoutes(BaseTestCase):
     """Test alias management AI helpers."""


### PR DESCRIPTION
## Summary
- add unit tests covering the secret detail view happy path and 404 handling
- document the new tests in the page-to-test cross reference

## Testing
- pytest tests/test_routes_comprehensive.py -k secret

------
https://chatgpt.com/codex/tasks/task_b_68f3e406c2d48331b8d480f1b72a2416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for secret detail page rendering and metadata display
  * Added tests for 404 error handling when accessing non-existent secrets

* **Documentation**
  * Updated test documentation with new test case references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->