### PR TITLE
Add integration coverage for aliases page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -51,7 +51,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestAliasRoutes::test_alias_list_displays_cid_link_for_cid_target`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_alias_pages.py::test_aliases_page_lists_user_aliases`
 
 **Specs:**
 - _None_
@@ -262,8 +262,8 @@ This document maps site pages to the automated checks that exercise them.
 - `routes/secrets.py::view_secret` (paths: `/secrets/<secret_name>`)
 
 **Unit tests:**
-- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_page_displays_secret_details`
 - `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_missing_returns_404`
+- `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_page_displays_secret_details`
 
 **Integration tests:**
 - _None_

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -1,0 +1,73 @@
+"""Integration coverage for alias management pages."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app import create_app
+from database import db
+from identity import ensure_default_user
+from models import Alias
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def integration_app():
+    """Return a Flask app configured for integration testing."""
+
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+    os.environ.setdefault("SESSION_SECRET", "integration-secret-key")
+
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+
+    with app.app_context():
+        db.create_all()
+        ensure_default_user()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(integration_app):
+    """Return a test client bound to the integration app."""
+
+    return integration_app.test_client()
+
+
+def _login_default_user(client):
+    """Authenticate the default user for the request session."""
+
+    with client.session_transaction() as session:
+        session["_user_id"] = "default-user"
+        session["_fresh"] = True
+
+
+def test_aliases_page_lists_user_aliases(client, integration_app):
+    """The aliases index should render saved aliases for the default user."""
+
+    with integration_app.app_context():
+        alias = Alias(
+            name="docs",
+            target_path="/docs",
+            user_id="default-user",
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    _login_default_user(client)
+
+    response = client.get("/aliases")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "docs" in page
+    assert "/docs" in page


### PR DESCRIPTION
## Summary
- add an integration test to ensure the aliases index renders saved aliases for the default user
- regenerate the page/test cross-reference so aliases.html lists the new integration coverage

## Testing
- pytest tests/integration/test_alias_pages.py -m integration
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3e5665e7c8331b555c1b493534bc5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for aliases page functionality
  * Reorganized unit tests for secret view template

* **Documentation**
  * Updated test cross-reference documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->