### PR TITLE
Add integration coverage for routes overview page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -235,7 +235,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_overview.py::RoutesOverviewTestCase::test_requires_login`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_routes_overview_page.py::test_routes_overview_lists_user_routes`
 
 **Specs:**
 - _None_

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,52 @@
+"""Shared integration test fixtures."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app import create_app
+from database import db
+from identity import ensure_default_user
+
+
+@pytest.fixture()
+def integration_app():
+    """Return a Flask app configured for integration testing."""
+
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+    os.environ.setdefault("SESSION_SECRET", "integration-secret-key")
+
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+
+    with app.app_context():
+        db.create_all()
+        ensure_default_user()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(integration_app):
+    """Return a test client bound to the integration app."""
+
+    return integration_app.test_client()
+
+
+@pytest.fixture()
+def login_default_user(client):
+    """Authenticate the default user within the test client session."""
+
+    def _login():
+        with client.session_transaction() as session:
+            session["_user_id"] = "default-user"
+            session["_fresh"] = True
+
+    return _login

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -1,57 +1,19 @@
 """Integration coverage for alias management pages."""
 from __future__ import annotations
 
-import os
-
 import pytest
 
-from app import create_app
 from database import db
-from identity import ensure_default_user
 from models import Alias
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.fixture()
-def integration_app():
-    """Return a Flask app configured for integration testing."""
-
-    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-    os.environ.setdefault("SESSION_SECRET", "integration-secret-key")
-
-    app = create_app(
-        {
-            "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-            "WTF_CSRF_ENABLED": False,
-        }
-    )
-
-    with app.app_context():
-        db.create_all()
-        ensure_default_user()
-        yield app
-        db.session.remove()
-        db.drop_all()
-
-
-@pytest.fixture()
-def client(integration_app):
-    """Return a test client bound to the integration app."""
-
-    return integration_app.test_client()
-
-
-def _login_default_user(client):
-    """Authenticate the default user for the request session."""
-
-    with client.session_transaction() as session:
-        session["_user_id"] = "default-user"
-        session["_fresh"] = True
-
-
-def test_aliases_page_lists_user_aliases(client, integration_app):
+def test_aliases_page_lists_user_aliases(
+    client,
+    integration_app,
+    login_default_user,
+):
     """The aliases index should render saved aliases for the default user."""
 
     with integration_app.app_context():
@@ -63,7 +25,7 @@ def test_aliases_page_lists_user_aliases(client, integration_app):
         db.session.add(alias)
         db.session.commit()
 
-    _login_default_user(client)
+    login_default_user()
 
     response = client.get("/aliases")
     assert response.status_code == 200

--- a/tests/integration/test_routes_overview_page.py
+++ b/tests/integration/test_routes_overview_page.py
@@ -1,0 +1,47 @@
+"""Integration tests for the routes overview page."""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+from identity import ensure_default_user
+from models import Alias, Server
+
+pytestmark = pytest.mark.integration
+
+
+def test_routes_overview_lists_user_routes(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The overview should include built-in, alias, and server entries."""
+
+    with integration_app.app_context():
+        user = ensure_default_user()
+        db.session.add(
+            Alias(
+                name="docs",
+                target_path="/docs",
+                user_id=user.id,
+            )
+        )
+        db.session.add(
+            Server(
+                name="toolbox",
+                definition="return {'output': 'ok', 'content_type': 'text/plain'}",
+                user_id=user.id,
+            )
+        )
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/routes")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Routes Overview" in page
+    assert "Alias: docs" in page
+    assert "Server: toolbox" in page
+    assert "Built-in route source" in page


### PR DESCRIPTION
## Summary
- centralize shared integration fixtures for application and client setup
- add an integration test that verifies the routes overview page renders alias and server entries
- regenerate the page/test cross reference so the new coverage is documented

## Testing
- pytest tests/integration/test_routes_overview_page.py -m integration -o addopts=
- pytest tests/integration/test_alias_pages.py -m integration -o addopts=
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3e756ea2483319dd4e6b18739dee2