### PR TITLE
Add integration coverage for profile page workspace link

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -219,7 +219,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestPageViewTracking::test_page_view_tracking_authenticated`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_profile_page.py::test_profile_page_links_to_workspace`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_profile_page.py
+++ b/tests/integration/test_profile_page.py
@@ -1,0 +1,24 @@
+"""Integration tests for the profile page."""
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_profile_page_links_to_workspace(
+    client,
+    login_default_user,
+):
+    """Authenticated users should see the workspace shortcut on the profile page."""
+
+    login_default_user()
+
+    response = client.get("/profile")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Account Profile" in page
+    assert "href=\"/uploads\"" in page
+    assert "Open Workspace" in page


### PR DESCRIPTION
## Summary
- add an integration test that verifies the profile page surfaces the workspace shortcut for logged-in users
- regenerate the page-to-test cross reference to include the new integration coverage

## Testing
- pytest -m integration tests/integration/test_profile_page.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3e963528883319e7846c9077f1369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test coverage for the profile page, validating authentication, page load, and workspace link functionality.
  * Updated test cross-reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->