### PR TITLE
Add integration coverage for alias form page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -19,7 +19,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestAliasRoutes::test_new_alias_form_includes_ai_controls`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_alias_pages.py::test_new_alias_form_renders_for_authenticated_user`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -33,3 +33,20 @@ def test_aliases_page_lists_user_aliases(
     page = response.get_data(as_text=True)
     assert "docs" in page
     assert "/docs" in page
+
+
+def test_new_alias_form_renders_for_authenticated_user(
+    client,
+    login_default_user,
+):
+    """The new-alias form should render when the user is logged in."""
+
+    login_default_user()
+
+    response = client.get("/aliases/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Create New Alias" in page
+    assert "name=\"name\"" in page
+    assert "name=\"target_path\"" in page


### PR DESCRIPTION
## Summary
- add an integration test to ensure the new-alias form renders for logged-in users
- regenerate the page/test cross-reference documentation to include the new coverage

## Testing
- pytest tests/integration/test_alias_pages.py -m integration
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3eaa13da083319ba448080c709b63