### PR TITLE
Add integration coverage for alias detail page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -34,7 +34,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestAliasRoutes::test_alias_detail_displays_cid_link_for_cid_target`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_alias_pages.py::test_alias_detail_page_displays_alias_information`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -50,3 +50,30 @@ def test_new_alias_form_renders_for_authenticated_user(
     assert "Create New Alias" in page
     assert "name=\"name\"" in page
     assert "name=\"target_path\"" in page
+
+
+def test_alias_detail_page_displays_alias_information(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Viewing an alias should show its saved details."""
+
+    with integration_app.app_context():
+        alias = Alias(
+            name="docs",
+            target_path="/docs",
+            user_id="default-user",
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/aliases/docs")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Alias Details" in page
+    assert "<code>docs</code>" in page
+    assert "<code>/docs</code>" in page


### PR DESCRIPTION
## Summary
- add an integration test that exercises the alias detail view page
- regenerate the page/test cross reference documentation so the new coverage is listed

## Testing
- pytest
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3ec72d1d883318da1bb1ce7b76817