### PR TITLE
Add integration coverage for history page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -160,7 +160,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestHistoryRoutes::test_history_pagination`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_history_page.py::test_history_page_displays_recent_activity`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_history_page.py
+++ b/tests/integration/test_history_page.py
@@ -1,0 +1,52 @@
+"""Integration tests for the history page."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from database import db
+from models import PageView
+
+
+pytestmark = pytest.mark.integration
+
+
+
+def test_history_page_displays_recent_activity(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The history page should render recorded page views for the user."""
+
+    with integration_app.app_context():
+        now = datetime.now(timezone.utc)
+        page_views = [
+            PageView(
+                user_id="default-user",
+                path="/profile",
+                method="GET",
+                viewed_at=now - timedelta(minutes=5),
+            ),
+            PageView(
+                user_id="default-user",
+                path="/upload",
+                method="POST",
+                viewed_at=now - timedelta(minutes=1),
+            ),
+        ]
+        db.session.add_all(page_views)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/history")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Browse History" in page
+    assert "Recent Activity" in page
+    assert "/profile" in page
+    assert "/upload" in page
+    assert "POST" in page


### PR DESCRIPTION
## Summary
- add an integration test that ensures the history page renders saved page views for the default user
- regenerate the page test cross reference to document the new integration coverage

## Testing
- pytest -m integration tests/integration/test_history_page.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3ef3767b08331b075120cbc636b2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for the history page to verify recent activity display functionality.

* **Documentation**
  * Updated documentation to reference the new history page integration test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->