### PR TITLE
Add integration coverage for secret form pages

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -251,7 +251,8 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestSecretRoutes::test_new_secret_post`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_secret_pages.py::test_edit_secret_form_displays_existing_secret`
+- `tests/integration/test_secret_pages.py::test_new_secret_form_renders_for_authenticated_user`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_secret_pages.py
+++ b/tests/integration/test_secret_pages.py
@@ -1,0 +1,56 @@
+"""Integration coverage for secret management pages."""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+from models import Secret
+
+pytestmark = pytest.mark.integration
+
+
+def test_new_secret_form_renders_for_authenticated_user(
+    client,
+    login_default_user,
+):
+    """The new-secret form should render when the user is logged in."""
+
+    login_default_user()
+
+    response = client.get("/secrets/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Create New Secret" in page
+    assert "Secret Configuration" in page
+    assert "name=\"name\"" in page
+    assert "name=\"definition\"" in page
+
+
+def test_edit_secret_form_displays_existing_secret(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Editing a secret should show the saved metadata and preview."""
+
+    with integration_app.app_context():
+        secret = Secret(
+            name="production-api-key",
+            definition="super-secret-value",
+            user_id="default-user",
+        )
+        db.session.add(secret)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/secrets/production-api-key/edit")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Edit Secret" in page
+    assert "production-api-key" in page
+    assert "super-secret-value" in page
+    assert "Current Secret Name" in page
+    assert "<code>production-api-key</code>" in page


### PR DESCRIPTION
## Summary
- add integration tests that exercise rendering of the secret creation and edit pages
- regenerate the page-to-test cross reference to include the new coverage details

## Testing
- pytest tests/integration/test_secret_pages.py -m integration
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3f417f4248331b57415b7901300ef