### PR TITLE
Add integration test coverage for server view page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -335,7 +335,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestServerRoutes::test_view_server_invocation_history_table`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_server_pages.py::test_server_detail_page_displays_server_information`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_server_pages.py
+++ b/tests/integration/test_server_pages.py
@@ -1,0 +1,43 @@
+"""Integration coverage for server detail pages."""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+from models import Server
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_server_detail_page_displays_server_information(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Server detail page should render the saved definition and metadata."""
+
+    with integration_app.app_context():
+        server = Server(
+            name="weather",
+            definition=(
+                "def main(city: str) -> str:\n"
+                "    return f\"Forecast for {city}\"\n"
+            ),
+            definition_cid="bafyweatherdefinition",
+            user_id="default-user",
+        )
+        db.session.add(server)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/servers/weather")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Server Definition" in page
+    assert "weather" in page
+    assert "Forecast for" in page
+    assert "Definition Length:" in page
+    assert "Run Test" in page


### PR DESCRIPTION
## Summary
- add an integration test that exercises the server detail view and verifies key content renders
- regenerate the page test cross reference documentation to include the new integration coverage

## Testing
- pytest -m "integration" tests/integration/test_server_pages.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3f6c7b8e88331a754c73ac6cd09a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating that the server detail page renders correctly and displays server information, definition content, and critical UI components.

* **Documentation**
  * Updated test cross-reference documentation to include mapping for the new server detail page integration test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->