### PR TITLE
Add integration coverage for variable pages

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -486,7 +486,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variable_view_shows_matching_route_summary`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_variable_pages.py::test_variable_detail_page_displays_variable_information`
 
 **Specs:**
 - _None_
@@ -501,7 +501,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variables_list`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_variable_pages.py::test_variables_page_lists_user_variables`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_variable_pages.py
+++ b/tests/integration/test_variable_pages.py
@@ -1,0 +1,63 @@
+"""Integration coverage for variable management pages."""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+from models import Variable
+
+pytestmark = pytest.mark.integration
+
+
+def test_variables_page_lists_user_variables(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The variables index page should list the user's variables."""
+
+    with integration_app.app_context():
+        variable = Variable(
+            name="API_URL",
+            definition="https://example.com/api",
+            user_id="default-user",
+        )
+        db.session.add(variable)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/variables")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "My Variables" in page
+    assert "API_URL" in page
+    assert "https://example.com/api" in page
+
+
+def test_variable_detail_page_displays_variable_information(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The variable detail page should render the variable metadata."""
+
+    with integration_app.app_context():
+        variable = Variable(
+            name="API_TOKEN",
+            definition="super-secret-token",
+            user_id="default-user",
+        )
+        db.session.add(variable)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/variables/API_TOKEN")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Variable Definition" in page
+    assert "super-secret-token" in page
+    assert "Variable Information" in page


### PR DESCRIPTION
## Summary
- add integration tests covering the variables index and detail pages
- regenerate the page-to-test cross reference to include the new coverage

## Testing
- pytest tests/integration/test_variable_pages.py -m integration --override-ini addopts=
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3f86f68c48331ad40f5c1b921aaa9