### PR TITLE
Add integration test for server creation form

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -317,7 +317,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestServerRoutes::test_new_server_prefills_name_from_path_query`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_server_pages.py::test_new_server_form_renders_for_authenticated_user`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_server_pages.py
+++ b/tests/integration/test_server_pages.py
@@ -10,6 +10,24 @@ from models import Server
 pytestmark = pytest.mark.integration
 
 
+def test_new_server_form_renders_for_authenticated_user(
+    client,
+    login_default_user,
+):
+    """The new-server form should render the creation UI when logged in."""
+
+    login_default_user()
+
+    response = client.get("/servers/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Create New Server" in page
+    assert "Server Configuration" in page
+    assert "name=\"name\"" in page
+    assert "name=\"definition\"" in page
+
+
 def test_server_detail_page_displays_server_information(
     client,
     integration_app,


### PR DESCRIPTION
## Summary
- add integration test confirming the new server form renders for logged-in users
- regenerate the page-test cross-reference to include the new coverage entry

## Testing
- pytest tests/integration/test_server_pages.py -m integration
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f3fb21f59c83319dc25ad5fdafc816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test reference documentation.

* **Tests**
  * Added integration test verifying authenticated user access to the server form page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->