### PR TITLE
Add integration coverage for uploads page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -455,7 +455,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestFileUploadRoutes::test_uploads_list_excludes_server_events`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_upload_pages.py::test_uploads_page_displays_user_uploads`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_upload_pages.py
+++ b/tests/integration/test_upload_pages.py
@@ -1,0 +1,39 @@
+"""Integration coverage for upload-related pages."""
+from __future__ import annotations
+
+import pytest
+
+from database import db
+from models import CID
+
+pytestmark = pytest.mark.integration
+
+
+def test_uploads_page_displays_user_uploads(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The uploads list should show manual uploads created by the user."""
+
+    manual_cid_value = "bafyuploadcidexample"
+
+    with integration_app.app_context():
+        upload = CID(
+            path=f"/{manual_cid_value}",
+            file_data=b"Integration upload content",
+            file_size=27,
+            uploaded_by_user_id="default-user",
+        )
+        db.session.add(upload)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/uploads")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "My Uploads" in page
+    assert "Total Files" in page
+    assert f"#{manual_cid_value[:9]}..." in page


### PR DESCRIPTION
## Summary
- add an integration test that verifies the uploads page lists a user-uploaded CID
- regenerate the page test cross reference to document the new integration coverage

## Testing
- pytest -m integration tests/integration/test_upload_pages.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f40086fb84833184112c464b18d9ba