### PR TITLE
Add integration coverage for index page cross reference

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -203,7 +203,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestPublicRoutes::test_index_unauthenticated`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_index_page.py::test_index_page_displays_cross_reference_dashboard`
 
 **Specs:**
 - meta_navigation.spec — Info icon links to metadata

--- a/tests/integration/test_index_page.py
+++ b/tests/integration/test_index_page.py
@@ -1,0 +1,55 @@
+"""Integration tests for the index (homepage) view."""
+from __future__ import annotations
+
+import pytest
+
+from cid_utils import generate_cid
+from database import db
+from models import Alias, CID, Server
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_index_page_displays_cross_reference_dashboard(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Authenticated users should see saved entities on the cross-reference dashboard."""
+
+    with integration_app.app_context():
+        cid_value = generate_cid(b"Integration cross-reference sample")
+        cid_record = CID(
+            path=f"/{cid_value}",
+            file_data=b"Integration cross-reference sample", 
+            uploaded_by_user_id="default-user",
+        )
+        alias = Alias(
+            name="sample-alias",
+            target_path="/servers/sample-server",
+            user_id="default-user",
+        )
+        server = Server(
+            name="sample-server",
+            definition=(
+                "def main(request):\n"
+                "    return \"Visit /aliases/sample-alias\"\n"
+            ),
+            definition_cid=f"/{cid_value}",
+            user_id="default-user",
+        )
+
+        db.session.add_all([cid_record, alias, server])
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Workspace Cross Reference" in page
+    assert 'href="/aliases/sample-alias"' in page
+    assert 'href="/servers/sample-server"' in page
+    assert "crossref-reference" in page


### PR DESCRIPTION
## Summary
- add an integration test that verifies the index dashboard renders stored entities
- regenerate the page-to-test cross reference documentation to include the new test

## Testing
- pytest -m integration tests/integration/test_index_page.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f403b688808331a6341c6440266867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added integration test to verify the homepage displays the cross-reference dashboard with appropriate links and elements.

* **Documentation**
  * Updated test cross-reference documentation with new test reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->