### PR TITLE
Add integration test for secret detail page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -269,7 +269,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestSecretRoutes::test_view_secret_page_displays_secret_details`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_secret_pages.py::test_secret_detail_page_displays_secret_information`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_secret_pages.py
+++ b/tests/integration/test_secret_pages.py
@@ -54,3 +54,32 @@ def test_edit_secret_form_displays_existing_secret(
     assert "super-secret-value" in page
     assert "Current Secret Name" in page
     assert "<code>production-api-key</code>" in page
+
+
+def test_secret_detail_page_displays_secret_information(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Viewing a secret should show its metadata and controls."""
+
+    with integration_app.app_context():
+        secret = Secret(
+            name="production-api-key",
+            definition="super-secret-value",
+            user_id="default-user",
+        )
+        db.session.add(secret)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/secrets/production-api-key")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Secret Definition" in page
+    assert "Secret Information" in page
+    assert "production-api-key" in page
+    assert "super-secret-value" in page
+    assert "Back to Secrets" in page


### PR DESCRIPTION
## Summary
- add an integration test that exercises the secret detail page
- regenerate the page/test cross reference documentation

## Testing
- pytest -m integration tests/integration/test_secret_pages.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f40aa180cc83319b0073d5280c627a