### PR TITLE
Add integration coverage for secrets list page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -284,7 +284,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestSecretRoutes::test_secrets_list`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_secret_pages.py::test_secrets_list_page_displays_user_secrets`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_secret_pages.py
+++ b/tests/integration/test_secret_pages.py
@@ -83,3 +83,36 @@ def test_secret_detail_page_displays_secret_information(
     assert "production-api-key" in page
     assert "super-secret-value" in page
     assert "Back to Secrets" in page
+
+
+def test_secrets_list_page_displays_user_secrets(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The secrets overview should list saved secrets for the user."""
+
+    with integration_app.app_context():
+        first_secret = Secret(
+            name="production-api-key",
+            definition="super-secret-value",
+            user_id="default-user",
+        )
+        second_secret = Secret(
+            name="staging-api-key",
+            definition="staging-secret-value",
+            user_id="default-user",
+        )
+        db.session.add_all([first_secret, second_secret])
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/secrets")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "My Secrets" in page
+    assert "production-api-key" in page
+    assert "staging-api-key" in page
+    assert "Create New Secret" in page


### PR DESCRIPTION
## Summary
- add an integration test that ensures the secrets overview lists a user's saved secrets
- regenerate the page-to-test cross reference to include the new integration test entry

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f40c97229c8331af8eb2e308d36b8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify the secrets list page correctly displays user-saved secrets, includes the page title, and provides the create new secret action.

* **Documentation**
  * Updated test cross-reference documentation for secrets management pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->