### PR TITLE
Add integration coverage for source browser page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -390,7 +390,8 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_source_spec_report.py::test_source_serves_gauge_report`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_source_browser_page.py::test_source_browser_displays_file_content`
+- `tests/integration/test_source_browser_page.py::test_source_browser_lists_directories`
 
 **Specs:**
 - source_browser.spec — Source listing renders

--- a/tests/integration/test_source_browser_page.py
+++ b/tests/integration/test_source_browser_page.py
@@ -1,0 +1,40 @@
+"""Integration tests for the source browser page."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_source_browser_lists_directories(
+    client,
+    login_default_user,
+):
+    """The source browser should render a directory listing for the project root."""
+
+    login_default_user()
+
+    response = client.get("/source")
+
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Source Browser" in page
+    assert ">templates/</a>" in page
+
+
+def test_source_browser_displays_file_content(
+    client,
+    login_default_user,
+):
+    """Viewing an individual file should render its contents."""
+
+    login_default_user()
+
+    response = client.get("/source/README.md")
+
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Source Browser" in page
+    assert "Viewer is a Flask based web application" in page


### PR DESCRIPTION
## Summary
- add integration tests that exercise the source browser directory and file views
- regenerate the page test cross reference to include the new integration coverage

## Testing
- pytest -m "integration" tests/integration/test_source_browser_page.py
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f4103b96008331ab6266e5b22d4c40