### PR TITLE
Add integration coverage for upload page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -410,7 +410,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_upload_extensions.py::TestUploadExtensions::test_upload_text_gets_txt_extension`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_upload_pages.py::test_upload_page_allows_user_to_choose_upload_method`
 
 **Specs:**
 - _None_
@@ -445,6 +445,7 @@ This document maps site pages to the automated checks that exercise them.
 **Integration tests:**
 - `tests/integration/test_upload_pages.py::test_edit_cid_choices_page_prompts_for_selection`
 - `tests/integration/test_upload_pages.py::test_edit_cid_page_prefills_existing_content`
+- `tests/integration/test_upload_pages.py::test_upload_page_allows_user_to_choose_upload_method`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_upload_pages.py
+++ b/tests/integration/test_upload_pages.py
@@ -39,6 +39,25 @@ def test_uploads_page_displays_user_uploads(
     assert f"#{manual_cid_value[:9]}..." in page
 
 
+def test_upload_page_allows_user_to_choose_upload_method(
+    client,
+    login_default_user,
+):
+    """The upload form should render with options for file, text, and URL inputs."""
+
+    login_default_user()
+
+    response = client.get("/upload")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Upload Content" in page
+    assert "Upload a file or paste text content" in page
+    assert "upload_type_file" in page
+    assert "upload_type_text" in page
+    assert "upload_type_url" in page
+
+
 def test_edit_cid_page_prefills_existing_content(
     client,
     integration_app,


### PR DESCRIPTION
## Summary
- add an integration test that exercises the upload page render and verifies available upload methods
- regenerate the cross-reference documentation so the upload page is listed with integration coverage

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f411b313c083319a757cede456fc2f