### PR TITLE
Add integration tests for variable form pages

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -477,7 +477,8 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestVariableRoutes::test_variable_edit_shows_404_matching_route`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_variable_pages.py::test_edit_variable_form_displays_existing_variable_details`
+- `tests/integration/test_variable_pages.py::test_new_variable_form_renders_for_authenticated_user`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_variable_pages.py
+++ b/tests/integration/test_variable_pages.py
@@ -61,3 +61,48 @@ def test_variable_detail_page_displays_variable_information(
     assert "Variable Definition" in page
     assert "super-secret-token" in page
     assert "Variable Information" in page
+
+
+def test_new_variable_form_renders_for_authenticated_user(
+    client,
+    login_default_user,
+):
+    """The new-variable form should render for logged-in users."""
+
+    login_default_user()
+
+    response = client.get("/variables/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Create New Variable" in page
+    assert "Variable Configuration" in page
+    assert 'name="name"' in page
+    assert 'name="definition"' in page
+
+
+def test_edit_variable_form_displays_existing_variable_details(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Editing a variable should prefill the form with its saved details."""
+
+    with integration_app.app_context():
+        variable = Variable(
+            name="API_TOKEN",
+            definition="super-secret-token",
+            user_id="default-user",
+        )
+        db.session.add(variable)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/variables/API_TOKEN/edit")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Edit Variable" in page
+    assert "<code>API_TOKEN</code>" in page
+    assert "super-secret-token" in page


### PR DESCRIPTION
## Summary
- add integration tests to cover the variable creation and edit pages
- regenerate the page-to-test cross reference to include the new coverage

## Testing
- pytest tests/integration/test_variable_pages.py -m integration
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f41304e99c83319ce2e903c671bd71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for variable form functionality, verifying authenticated user access and form rendering for creating and editing variables.

**Note:** These changes represent internal testing enhancements with no user-visible functionality updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->