### PR TITLE
Add spec coverage for profile page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -224,7 +224,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_profile_page.py::test_profile_page_links_to_workspace`
 
 **Specs:**
-- _None_
+- profile.spec — Default workspace profile is accessible
 
 ## templates/routes_overview.html
 

--- a/specs/profile.spec
+++ b/specs/profile.spec
@@ -1,0 +1,7 @@
+# Profile page
+
+## Default workspace profile is accessible
+* When I request the page /profile
+* The response status should be 200
+* The page should contain Account Profile
+* The page should contain Open Workspace


### PR DESCRIPTION
## Summary
- add a Gauge specification that confirms the /profile page renders the profile workspace content
- regenerate the page/test cross-reference to document the new spec coverage

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f4148253ec8331b18bcb9ef52ed8e7