### PR TITLE
Add spec coverage for server events page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -301,7 +301,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_server_events_page.py::test_server_events_page_lists_recent_invocations`
 
 **Specs:**
-- _None_
+- server_events.spec — Server events dashboard is accessible
 
 ## templates/server_form.html
 

--- a/specs/server_events.spec
+++ b/specs/server_events.spec
@@ -1,0 +1,7 @@
+# Server events page
+
+## Server events dashboard is accessible
+* When I request the page /server_events
+* The response status should be 200
+* The page should contain Server Events
+* The page should contain Invocation History


### PR DESCRIPTION
## Summary
- add an acceptance spec covering the /server_events dashboard
- regenerate the page test cross reference to record the new spec coverage

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f41676a7188331abc96a3c911f5fce