### PR TITLE
Add alias management spec coverage to cross-reference

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -22,7 +22,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_alias_pages.py::test_new_alias_form_renders_for_authenticated_user`
 
 **Specs:**
-- _None_
+- alias_management.spec — Users can create aliases through the form
 
 ## templates/alias_view.html
 

--- a/specs/alias_management.spec
+++ b/specs/alias_management.spec
@@ -1,0 +1,12 @@
+# Alias management
+
+## Users can create aliases through the form
+* Given I am signed in to the workspace
+* When I navigate to /aliases/new
+* Then I can enter an alias name and target path
+* And submitting the form creates the alias
+
+## Users can edit existing aliases
+* Given there is an alias named "docs" pointing to /guides
+* When I visit /aliases/docs/edit
+* Then I can update the alias target and save the changes


### PR DESCRIPTION
## Summary
- add an alias management spec covering creation and editing flows
- regenerate the page test cross reference so the alias form page lists the spec

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f4348b382c8331905e303a0858d4bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced cross-reference documentation by adding references to new alias management specifications

* **Tests**
  * Added comprehensive specification file outlining user workflows for alias management, including creating new aliases through a dedicated form and editing existing aliases with step-by-step navigation and submission processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->