### PR TITLE
Add spec coverage for secrets page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -287,7 +287,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_secret_pages.py::test_secrets_list_page_displays_user_secrets`
 
 **Specs:**
-- _None_
+- secrets.spec — Secrets list is accessible
 
 ## templates/server_events.html
 

--- a/specs/secrets.spec
+++ b/specs/secrets.spec
@@ -1,0 +1,7 @@
+# Secrets page
+
+## Secrets list is accessible
+* When I request the page /secrets
+* The response status should be 200
+* The page should contain Secrets
+* The page should contain New Secret


### PR DESCRIPTION
## Summary
- add a Gauge spec that exercises the `/secrets` page
- regenerate the page test cross reference to include the new spec coverage

## Testing
- `python generate_page_test_cross_reference.py`


------
https://chatgpt.com/codex/tasks/task_b_68f436e4cb748331a57b8d22b964a8bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test specification for the Secrets page, verifying page accessibility and presence of key interface elements.

* **Documentation**
  * Updated test cross-reference documentation to reflect new Secrets page specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->