### PR TITLE
Add Gauge spec coverage for routes overview page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -240,7 +240,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_routes_overview_page.py::test_routes_overview_lists_user_routes`
 
 **Specs:**
-- _None_
+- routes_overview.spec — Routes overview highlights available route types
 
 ## templates/secret_form.html
 

--- a/specs/routes_overview.spec
+++ b/specs/routes_overview.spec
@@ -1,0 +1,8 @@
+# Routes overview page
+
+## Routes overview highlights available route types
+* When I request the page /routes
+* The response status should be 200
+* The page should contain Routes Overview
+* The page should contain Show route types
+* The page should contain Highlight routes matching URL


### PR DESCRIPTION
## Summary
- add a Gauge specification that verifies the /routes overview page renders key UI elements
- regenerate the cross-reference documentation so the new spec appears for the routes overview template

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f43d5f226c8331b31edba99d2f3ba6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New test suite added for Routes overview page, covering page accessibility verification, display of available route types, and URL pattern highlighting functionality

* **Documentation**
  * Test cross-reference documentation updated to include Routes overview specification entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->