### PR TITLE
Add spec coverage for aliases list page

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -37,7 +37,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_alias_pages.py::test_alias_detail_page_displays_alias_information`
 
 **Specs:**
-- alias_management.spec — Users can view alias details
+- _None_
 
 ## templates/aliases.html
 
@@ -54,7 +54,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_alias_pages.py::test_aliases_page_lists_user_aliases`
 
 **Specs:**
-- _None_
+- alias_management.spec — Aliases list shows available shortcuts
 
 ## templates/edit_cid.html
 

--- a/specs/alias_management.spec
+++ b/specs/alias_management.spec
@@ -17,3 +17,10 @@
 * The response status should be 200
 * The page should contain Alias Details
 * The page should contain Edit Alias
+
+## Aliases list shows available shortcuts
+* When I request the page /aliases
+* Path coverage: /aliases
+* The response status should be 200
+* The page should contain Aliases
+* The page should contain New Alias


### PR DESCRIPTION
## Summary
- add a gauge scenario that exercises the /aliases list page
- regenerate the page/test cross reference to include the new spec entry

## Testing
- python generate_page_test_cross_reference.py

------
https://chatgpt.com/codex/tasks/task_b_68f4f2e074708331af625668ced3d599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the documentation cross-reference index to reorganize specification entries for template alias pages, including adjustments to specification mappings.

* **Tests**
  * Added new test scenario to verify the aliases index page loads successfully and contains the Aliases and New Alias sections as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->