### PR TITLE
Link search result headers to relevant pages

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -34,6 +34,13 @@
         }
 
         const categoryOrder = filterInputs.map((input) => input.dataset.searchCategory);
+        const categoryLinks = {
+            aliases: '/aliases',
+            servers: '/servers',
+            variables: '/variables',
+            secrets: '/secrets/',
+            cids: '/uploads',
+        };
         let debounceHandle = null;
         let activeController = null;
         let requestSequence = 0;
@@ -124,7 +131,16 @@
 
                 const heading = document.createElement('h2');
                 heading.className = 'h5 mb-3 text-uppercase text-muted';
-                heading.textContent = `${label}`;
+                const destination = categoryLinks[key];
+                if (destination) {
+                    const link = document.createElement('a');
+                    link.href = destination;
+                    link.className = 'text-decoration-none text-muted';
+                    link.textContent = `${label}`;
+                    heading.appendChild(link);
+                } else {
+                    heading.textContent = `${label}`;
+                }
                 section.appendChild(heading);
 
                 items.forEach((item) => {


### PR DESCRIPTION
## Summary
- add URL mappings for each search category
- render search result headers as links to their corresponding pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f51feb3e1883318a2e697b831c21c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search result category headings are now clickable links, enabling direct navigation to specific categories (aliases, servers, variables, secrets, CIDs) from search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->