### PR TITLE
Remove alias test strings field and redesign form tabs

### DIFF
--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -15,7 +15,6 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_alias_routing.py::TestAliasRouting::test_edit_alias_rejects_conflicting_route_name`
 - `tests/test_alias_routing.py::TestAliasRouting::test_edit_alias_updates_record`
 - `tests/test_alias_routing.py::TestAliasRouting::test_new_alias_prefills_name_from_path_query`
-- `tests/test_alias_routing.py::TestAliasRouting::test_test_pattern_button_displays_results_without_saving`
 - `tests/test_routes_comprehensive.py::TestAliasRoutes::test_new_alias_form_includes_ai_controls`
 
 **Integration tests:**

--- a/forms.py
+++ b/forms.py
@@ -4,7 +4,6 @@ from wtforms import BooleanField, SelectField, SubmitField, StringField, TextAre
 from wtforms.validators import DataRequired, Optional, Regexp, ValidationError
 import re
 
-from alias_matching import evaluate_test_strings
 from alias_definition import AliasDefinitionError, parse_alias_definition
 
 
@@ -124,12 +123,7 @@ class AliasForm(FlaskForm):
             'placeholder': 'pattern -> /target [glob]\n# Add related aliases or notes on following lines',
         },
     )
-    test_strings = TextAreaField(
-        'Test Strings',
-        render_kw={'rows': 4, 'placeholder': '/users/alice'},
-    )
     submit = SubmitField('Save Alias')
-    test_pattern = SubmitField('Test Pattern')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -154,17 +148,6 @@ class AliasForm(FlaskForm):
 
         return True
 
-    def evaluated_tests(self):
-        parsed = self._parsed_definition
-        if not parsed:
-            return []
-        raw_values = (self.test_strings.data or '').splitlines()
-        return evaluate_test_strings(
-            parsed.match_type,
-            parsed.match_pattern,
-            raw_values,
-            ignore_case=parsed.ignore_case,
-        )
 
 class SecretForm(FlaskForm):
     name = StringField('Secret Name', validators=[

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -4,25 +4,48 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-lg-8 col-xl-6">
-            <div class="d-flex justify-content-between align-items-center mb-4">
-                <h2><i class="fas fa-link me-2"></i>{{ title }}</h2>
-                <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
-                    <i class="fas fa-arrow-left me-1"></i>Back to Aliases
-                </a>
-            </div>
+<div class="container-fluid py-4 px-4">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+        <h2 class="mb-0"><i class="fas fa-link me-2"></i>{{ title }}</h2>
+        <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
+            <i class="fas fa-arrow-left me-1"></i>Back to Aliases
+        </a>
+    </div>
 
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="card-title mb-0">Alias Configuration</h5>
-                </div>
-                <div class="card-body">
-                    <form method="POST">
-                        {{ form.hidden_tag() }}
+    <form method="POST" class="card shadow-sm">
+        {{ form.hidden_tag() }}
+        <div class="card-header">
+            <ul class="nav nav-tabs card-header-tabs" id="alias-form-tabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="alias-form-config-tab" data-bs-toggle="tab" data-bs-target="#alias-form-config" type="button" role="tab" aria-controls="alias-form-config" aria-selected="true">
+                        <i class="fas fa-sliders-h me-1"></i>Configuration
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="alias-form-matcher-tab" data-bs-toggle="tab" data-bs-target="#alias-form-matcher" type="button" role="tab" aria-controls="alias-form-matcher" aria-selected="false">
+                        <i class="fas fa-vial me-1"></i>Interactive Matcher
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="alias-form-guidance-tab" data-bs-toggle="tab" data-bs-target="#alias-form-guidance" type="button" role="tab" aria-controls="alias-form-guidance" aria-selected="false">
+                        <i class="fas fa-lightbulb me-1"></i>Guidance
+                    </button>
+                </li>
+                {% if alias %}
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="alias-form-current-tab" data-bs-toggle="tab" data-bs-target="#alias-form-current" type="button" role="tab" aria-controls="alias-form-current" aria-selected="false">
+                        <i class="fas fa-circle-info me-1"></i>Current Alias
+                    </button>
+                </li>
+                {% endif %}
+            </ul>
+        </div>
 
-                        <div class="mb-3">
+        <div class="card-body">
+            <div class="tab-content" id="alias-form-tabs-content">
+                <div class="tab-pane fade show active" id="alias-form-config" role="tabpanel" aria-labelledby="alias-form-config-tab">
+                    <div class="row g-4">
+                        <div class="col-12">
                             {{ form.name.label(class="form-label") }}
                             {{ form.name(class="form-control" + (" is-invalid" if form.name.errors else "")) }}
                             {% if form.name.errors %}
@@ -44,7 +67,7 @@
                             {% endif %}
                         </div>
 
-                        <div class="mb-3">
+                        <div class="col-12">
                             {{ form.definition.label(class="form-label") }}
                             {{ form.definition(class="form-control" + (" is-invalid" if form.definition.errors else "")) }}
                             {% if form.definition.errors %}
@@ -58,94 +81,72 @@
                             {% endif %}
                         </div>
 
-                        <div class="mb-3" data-alias-testing>
-                            {{ form.test_strings.label(class="form-label") }}
-                            {{ form.test_strings(class="form-control") }}
-                            <div class="form-text">Enter one path per line to try the current configuration without saving.</div>
-                        </div>
-                        <div data-alias-testing>
-                        {{ ai_text_controls(
-                            form.test_strings.id,
-                            'test strings',
-                            request_label='Ask AI to edit the test paths',
-                            helper_text='Describe how the AI should update the test paths before trying them.',
-                            context={'form': 'alias_form'},
-                            entity_type='alias',
-                            entity_name=ai_entity_name|default(''),
-                            entity_name_field=ai_entity_name_field|default(''),
-                            interactions=interaction_history|default([]),
-                            history_label='Recent alias edits and requests'
-                        ) }}
-                        </div>
-
-                        {% if test_results %}
-                        <div class="mb-3" data-alias-testing>
-                            <div class="alert alert-secondary mb-0">
-                                <h6 class="alert-heading">Test Results</h6>
-                                <ul class="list-unstyled mb-0 small">
-                                    {% for value, matches in test_results %}
-                                    <li>
-                                        {% if matches %}
-                                            <span class="badge bg-success me-2"><i class="fas fa-check"></i></span>
-                                        {% else %}
-                                            <span class="badge bg-danger me-2"><i class="fas fa-times"></i></span>
-                                        {% endif %}
-                                        <code>{{ value.strip() }}</code>
-                                    </li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        </div>
-                        {% endif %}
-
-                        <div class="mb-3" data-alias-matcher data-alias-matcher-endpoint="{{ url_for('main.alias_match_preview') }}">
-                            <label class="form-label" for="alias-live-matcher">Interactive Matcher</label>
-                            <textarea id="alias-live-matcher" class="form-control" rows="3" placeholder="/docs/latest" data-alias-matcher-input></textarea>
-                            <div class="form-text">Type URLs here to instantly check whether they match the current alias settings without leaving the page.</div>
-                            <div class="mt-2" data-alias-matcher-results role="status" aria-live="polite"></div>
-                        </div>
-
-                        <div class="mb-3">
-                            {% include "_alias_definition_help.html" %}
-                        </div>
-
-                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                            <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
-                                <i class="fas fa-times me-1"></i>Cancel
-                            </a>
-                            <div class="d-flex gap-2 flex-wrap align-items-center">
-                                <div data-alias-testing>
-                                    {{ form.test_pattern(class="btn btn-outline-primary") }}
-                                </div>
-                                {{ ai_action_button(form.test_strings.id, button_label='AI', extra_classes='btn-outline-primary') }}
-                                {{ form.submit(class="btn btn-primary") }}
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
-            {% if alias %}
-            <div class="card mt-4">
-                <div class="card-header">
-                    <h5 class="card-title mb-0">Current Alias</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row">
-                        <div class="col-md-6">
-                            <strong>Name:</strong><br>
-                            <code>{{ alias.name }}</code>
-                        </div>
-                        <div class="col-md-6">
-                            <strong>Last Updated:</strong><br>
-                            {{ alias.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                        <div class="col-12">
+                            {{ ai_text_controls(
+                                form.definition.id,
+                                'alias definition',
+                                request_label='Ask AI to edit the alias definition',
+                                helper_text='Describe how the AI should adjust the alias definition before saving.',
+                                context={'form': 'alias_form'},
+                                entity_type='alias',
+                                entity_name=ai_entity_name|default(''),
+                                entity_name_field=ai_entity_name_field|default(''),
+                                interactions=interaction_history|default([]),
+                                history_label='Recent alias edits and requests'
+                            ) }}
                         </div>
                     </div>
                 </div>
+
+                <div class="tab-pane fade" id="alias-form-matcher" role="tabpanel" aria-labelledby="alias-form-matcher-tab">
+                    <div class="mb-3">
+                        <p class="text-muted">Use the live matcher to try paths without leaving the page. Results refresh automatically as you change the alias name or definition.</p>
+                        <div class="card border-0 shadow-sm">
+                            <div class="card-body" data-alias-matcher data-alias-matcher-endpoint="{{ url_for('main.alias_match_preview') }}">
+                                <label class="form-label" for="alias-live-matcher">Interactive Matcher</label>
+                                <textarea id="alias-live-matcher" class="form-control" rows="3" placeholder="/docs/latest" data-alias-matcher-input></textarea>
+                                <div class="form-text">Type URLs here to instantly check whether they match the current alias settings.</div>
+                                <div class="mt-2" data-alias-matcher-results role="status" aria-live="polite"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="tab-pane fade" id="alias-form-guidance" role="tabpanel" aria-labelledby="alias-form-guidance-tab">
+                    {% include "_alias_definition_help.html" %}
+                </div>
+
+                {% if alias %}
+                <div class="tab-pane fade" id="alias-form-current" role="tabpanel" aria-labelledby="alias-form-current-tab">
+                    <div class="row g-4">
+                        <div class="col-md-6">
+                            <div class="bg-light border rounded p-3 h-100">
+                                <strong>Name:</strong><br>
+                                <code>{{ alias.name }}</code>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="bg-light border rounded p-3 h-100">
+                                <strong>Last Updated:</strong><br>
+                                {{ alias.updated_at.strftime('%Y-%m-%d %H:%M:%S') }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
             </div>
-            {% endif %}
         </div>
-    </div>
+
+        <div class="card-footer d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <a href="{{ url_for('main.aliases') }}" class="btn btn-secondary">
+                <i class="fas fa-times me-1"></i>Cancel
+            </a>
+            <div class="d-flex gap-2 flex-wrap align-items-center">
+                {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
+                {{ form.submit(class="btn btn-primary") }}
+            </div>
+        </div>
+    </form>
 </div>
 {% endblock %}
 

--- a/tests/test_alias_routing.py
+++ b/tests/test_alias_routing.py
@@ -357,22 +357,6 @@ class TestAliasRouting(unittest.TestCase):
         self.assertFalse(data['ok'])
         self.assertIn('Invalid regular expression', data['error'])
 
-    def test_test_pattern_button_displays_results_without_saving(self):
-        response = self.client.post(
-            '/aliases/new',
-            data={
-                'name': 'preview',
-                'definition': r'^/preview-\d+$ -> /cid999 [regex]',
-                'test_strings': '/preview-1\n/preview-x',
-                'test_pattern': 'Test Pattern',
-            },
-            follow_redirects=True,
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Test Results', response.data)
-        self.assertIsNone(Alias.query.filter_by(user_id=self.default_user.id, name='preview').first())
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -1685,9 +1685,9 @@ class TestAliasRoutes(BaseTestCase):
         self.assertEqual(response.status_code, 200)
 
         page = response.get_data(as_text=True)
-        self.assertIn('test_strings-ai-input', page)
-        self.assertIn('data-ai-target-id="test_strings"', page)
-        self.assertIn('Ask AI to edit the test paths', page)
+        self.assertIn('definition-ai-input', page)
+        self.assertIn('data-ai-target-id="definition"', page)
+        self.assertIn('Ask AI to edit the alias definition', page)
 
     def test_alias_list_displays_cid_link_for_cid_target(self):
         """Alias listings should render CID targets with the standard link widget."""


### PR DESCRIPTION
## Summary
- remove the obsolete alias test strings controls and backend plumbing
- restructure the alias editor into tabbed sections with AI controls on the definition
- update docs and tests to reflect the streamlined workflow

## Testing
- pytest tests/test_alias_routing.py tests/test_routes_comprehensive.py

------
https://chatgpt.com/codex/tasks/task_b_68f57aea37408331b1e9174ddc6320fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned alias form interface with tabbed layout: Configuration, Interactive Matcher, Guidance, and Current Alias tabs.

* **Improvements**
  * Enhanced form validation with earlier detection of alias name conflicts against existing routes and aliases.
  * Interactive matcher moved to dedicated tab within the form interface.

* **Removed Features**
  * Removed test strings and test results functionality from the alias creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->