### PR TITLE
Enhance alias matcher preview highlighting

### DIFF
--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -106,7 +106,12 @@
                                 <label class="form-label" for="alias-live-matcher">Interactive Matcher</label>
                                 <textarea id="alias-live-matcher" class="form-control" rows="3" placeholder="/docs/latest" data-alias-matcher-input></textarea>
                                 <div class="form-text">Type URLs here to instantly check whether they match the current alias settings.</div>
-                                <div class="mt-2" data-alias-matcher-results role="status" aria-live="polite"></div>
+                                <div class="mt-3">
+                                    <label class="form-label mb-1">Alias Definition Preview</label>
+                                    <div class="alias-definition-preview border rounded bg-body-tertiary" data-alias-definition-display style="max-height: 240px; overflow-y: auto;"></div>
+                                    <div class="form-text">Highlights show how the definition responds to the paths above.</div>
+                                </div>
+                                <div class="mt-3" data-alias-matcher-results role="status" aria-live="polite"></div>
                             </div>
                         </div>
                     </div>
@@ -181,14 +186,104 @@ document.addEventListener('DOMContentLoaded', function () {
         var matcherEndpoint = matcherContainer.getAttribute('data-alias-matcher-endpoint');
         var nameField = document.getElementById({{ form.name.id|tojson }});
         var definitionField = document.getElementById({{ form.definition.id|tojson }});
+        var definitionPreview = matcherContainer.querySelector('[data-alias-definition-display]');
         var debounceTimer;
         var pendingController;
 
-        function renderPlaceholder() {
-            if (!matcherResults) {
+        function renderDefinitionPreviewFromText(definitionText) {
+            if (!definitionPreview) {
                 return;
             }
-            matcherResults.innerHTML = '<div class="text-muted small">Type a path above to preview matches instantly.</div>';
+
+            var lines = (definitionText || '').split(/\r?\n/);
+            var hasContent = lines.some(function (line) { return line.length > 0; });
+
+            if (!hasContent) {
+                definitionPreview.innerHTML = '<div class="px-2 py-3 text-muted small">Definition preview will appear here.</div>';
+                return;
+            }
+
+            var html = lines.map(function (line, index) {
+                var classes = ['d-flex', 'align-items-start', 'gap-2', 'px-2', 'py-1', 'font-monospace', 'bg-body-tertiary'];
+                if (index !== lines.length - 1) {
+                    classes.push('border-bottom', 'border-light');
+                }
+                var displayText = line ? escapeHtml(line) : '&nbsp;';
+                return '<div class="' + classes.join(' ') + '">' +
+                    '<span class="text-muted small pt-1" style="width: 2.5rem;">' + (index + 1) + '.</span>' +
+                    '<span class="text-muted pt-1"><i class="fas fa-circle"></i></span>' +
+                    '<span class="flex-grow-1">' + displayText + '</span>' +
+                '</div>';
+            }).join('');
+
+            definitionPreview.innerHTML = html;
+        }
+
+        function renderDefinitionPreview(definitionData) {
+            if (!definitionPreview) {
+                return;
+            }
+
+            if (!definitionData || !Array.isArray(definitionData.lines) || !definitionData.lines.length) {
+                renderDefinitionPreviewFromText(definitionField ? definitionField.value : '');
+                return;
+            }
+
+            var lines = definitionData.lines;
+            var hasActivePaths = !!definitionData.has_active_paths;
+
+            var html = lines.map(function (line, index) {
+                var classes = ['d-flex', 'align-items-start', 'gap-2', 'px-2', 'py-1', 'font-monospace'];
+                if (index !== lines.length - 1) {
+                    classes.push('border-bottom', 'border-light');
+                }
+
+                var indicatorClass = 'text-muted';
+                var indicatorIcon = 'fa-circle';
+
+                if (line.is_mapping) {
+                    if (line.has_error) {
+                        classes.push('bg-danger-subtle', 'border-start', 'border-4', 'border-danger');
+                        indicatorClass = 'text-danger';
+                        indicatorIcon = 'fa-triangle-exclamation';
+                    } else if (hasActivePaths) {
+                        if (line.matches_any) {
+                            classes.push('bg-success-subtle', 'border-start', 'border-4', 'border-success');
+                            indicatorClass = 'text-success';
+                            indicatorIcon = 'fa-check';
+                        } else {
+                            classes.push('bg-danger-subtle', 'border-start', 'border-4', 'border-danger');
+                            indicatorClass = 'text-danger';
+                            indicatorIcon = 'fa-times';
+                        }
+                    } else {
+                        classes.push('bg-body-secondary-subtle');
+                    }
+                } else {
+                    classes.push('bg-body-tertiary');
+                }
+
+                var lineText = line.text ? escapeHtml(line.text) : '&nbsp;';
+                var errorHtml = '';
+                if (line.has_error && line.parse_error) {
+                    errorHtml = '<span class="text-danger small ms-2">' + escapeHtml(String(line.parse_error)) + '</span>';
+                }
+
+                return '<div class="' + classes.join(' ') + '">' +
+                    '<span class="text-muted small pt-1" style="width: 2.5rem;">' + line.number + '.</span>' +
+                    '<span class="' + indicatorClass + ' pt-1"><i class="fas ' + indicatorIcon + '"></i></span>' +
+                    '<span class="flex-grow-1">' + lineText + errorHtml + '</span>' +
+                '</div>';
+            }).join('');
+
+            definitionPreview.innerHTML = html;
+        }
+
+        function renderPlaceholder() {
+            if (matcherResults) {
+                matcherResults.innerHTML = '<div class="text-muted small">Type a path above to preview matches instantly.</div>';
+            }
+            renderDefinitionPreviewFromText(definitionField ? definitionField.value : '');
         }
 
         function scheduleMatcherUpdate() {
@@ -246,6 +341,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 })
                 .then(function (result) {
                     pendingController = null;
+                    renderDefinitionPreview(result.data && result.data.definition);
+
                     if (!matcherResults) {
                         return;
                     }
@@ -285,6 +382,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         return;
                     }
                     pendingController = null;
+                    renderDefinitionPreviewFromText(definitionField ? definitionField.value : '');
                     if (!matcherResults) {
                         return;
                     }
@@ -296,7 +394,10 @@ document.addEventListener('DOMContentLoaded', function () {
             matcherInput.addEventListener('input', scheduleMatcherUpdate);
         }
         if (definitionField) {
-            definitionField.addEventListener('input', scheduleMatcherUpdate);
+            definitionField.addEventListener('input', function () {
+                renderDefinitionPreviewFromText(definitionField.value);
+                scheduleMatcherUpdate();
+            });
         }
         if (nameField) {
             nameField.addEventListener('input', scheduleMatcherUpdate);

--- a/tests/test_alias_definition.py
+++ b/tests/test_alias_definition.py
@@ -1,0 +1,56 @@
+import textwrap
+import unittest
+
+from alias_definition import summarize_definition_lines
+
+
+class SummarizeDefinitionLinesTests(unittest.TestCase):
+    def test_summarize_definition_lines_extracts_metadata(self):
+        definition = textwrap.dedent(
+            """
+            docs -> /docs
+            search/* -> /search [glob, ignore-case]
+            # comment line
+              guide -> /guides
+            """
+        ).strip("\n")
+
+        summary = summarize_definition_lines(definition, alias_name="docs")
+
+        self.assertEqual(len(summary), 4)
+
+        first = summary[0]
+        self.assertTrue(first.is_mapping)
+        self.assertEqual(first.match_type, "literal")
+        self.assertEqual(first.match_pattern, "/docs")
+        self.assertFalse(first.ignore_case)
+        self.assertIsNone(first.parse_error)
+
+        second = summary[1]
+        self.assertTrue(second.is_mapping)
+        self.assertEqual(second.match_type, "glob")
+        self.assertEqual(second.match_pattern, "/search/*")
+        self.assertTrue(second.ignore_case)
+
+        third = summary[2]
+        self.assertFalse(third.is_mapping)
+        self.assertEqual(third.text.strip(), "# comment line")
+
+        fourth = summary[3]
+        self.assertTrue(fourth.is_mapping)
+        self.assertEqual(fourth.text, "  guide -> /guides")
+        self.assertEqual(fourth.match_pattern, "/guide")
+
+    def test_summarize_definition_lines_reports_parse_errors(self):
+        definition = "docs -> /docs [regex, glob]"
+
+        summary = summarize_definition_lines(definition)
+
+        self.assertEqual(len(summary), 1)
+        self.assertTrue(summary[0].is_mapping)
+        self.assertIsNotNone(summary[0].parse_error)
+        self.assertIn("only one match type", summary[0].parse_error.lower())
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for direct execution
+    unittest.main()

--- a/tests/test_alias_routing.py
+++ b/tests/test_alias_routing.py
@@ -343,6 +343,16 @@ class TestAliasRouting(unittest.TestCase):
         self.assertTrue(results['/docs/api'])
         self.assertFalse(results['/blog'])
 
+        definition = data.get('definition')
+        self.assertIsNotNone(definition)
+        self.assertTrue(definition['has_active_paths'])
+        self.assertIn('lines', definition)
+        primary_line = definition['lines'][0]
+        self.assertTrue(primary_line['is_mapping'])
+        self.assertFalse(primary_line['has_error'])
+        self.assertTrue(primary_line['matches_any'])
+        self.assertEqual(primary_line['text'], 'docs/* -> /docs [glob]')
+
     def test_alias_match_preview_rejects_invalid_pattern(self):
         payload = {
             'name': 'docs',


### PR DESCRIPTION
## Summary
- add utilities to summarize alias definition lines for highlighting
- return definition line match state from the matcher preview endpoint and render a highlighted preview in the UI
- cover the new behaviour with unit tests for the parser and matcher endpoint

## Testing
- ./test

------
https://chatgpt.com/codex/tasks/task_b_68f629ee29948331b9a4250b29f4b15a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added line-by-line preview of alias definitions with visual indicators for mapping lines and parsing errors.
  * Integrated match status display for each definition line when paths are provided.
  * Enhanced UI with monospace formatting and line numbers for improved readability.

* **Tests**
  * Added comprehensive test coverage for definition line summarization and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->