### PR TITLE
Enhance alias definition target rendering

### DIFF
--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -79,7 +79,65 @@
                     <h5 class="card-title mb-0">Alias Definition</h5>
                 </div>
                 <div class="card-body">
+                    {% if alias_definition_lines %}
+                    <div class="border rounded overflow-hidden mb-3">
+                        {% for line in alias_definition_lines %}
+                        {% set is_last = loop.last %}
+                        <div class="d-flex align-items-start gap-3 px-3 py-2 {% if not is_last %}border-bottom border-light{% endif %} {{ 'bg-body' if line.is_mapping and not line.parse_error else 'bg-body-tertiary' }}">
+                            <div class="text-muted small pt-1" style="width: 2.5rem;">{{ line.number }}.</div>
+                            <div class="flex-grow-1">
+                                {% if line.is_mapping and not line.parse_error %}
+                                <div class="d-flex flex-wrap align-items-center gap-2 font-monospace">
+                                    <span class="text-primary">{{ line.pattern_text or line.match_pattern or line.text }}</span>
+                                    <span class="text-muted">&rarr;</span>
+                                    {% set target = line.target_details %}
+                                    {% if target %}
+                                        {% if target.kind == 'cid' %}
+                                            {{ render_cid_link(target.cid) }}
+                                            {% if target.suffix %}
+                                            <code class="small text-muted ms-1">{{ target.suffix }}</code>
+                                            {% endif %}
+                                        {% elif target.kind == 'server' %}
+                                            <a href="{{ target.url }}" class="text-decoration-none">
+                                                <i class="fas fa-server me-1 text-primary"></i>{{ target.display or ('/servers/' ~ target.name) }}
+                                            </a>
+                                        {% elif target.kind == 'alias' %}
+                                            <a href="{{ target.url }}" class="text-decoration-none">
+                                                <i class="fas fa-link me-1 text-secondary"></i>{{ target.display or ('/aliases/' ~ target.name) }}
+                                            </a>
+                                        {% else %}
+                                            <code>{{ target.display or line.target_path }}</code>
+                                        {% endif %}
+                                    {% elif line.target_path %}
+                                        <code>{{ line.target_path }}</code>
+                                    {% else %}
+                                        <span class="text-muted">No target</span>
+                                    {% endif %}
+                                    {% if line.options %}
+                                        {% for option in line.options %}
+                                            <span class="badge text-bg-light border ms-1">{{ option }}</span>
+                                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                                {% elif line.text %}
+                                <div class="font-monospace text-muted">{{ line.text }}</div>
+                                {% else %}
+                                <div class="font-monospace text-muted">&nbsp;</div>
+                                {% endif %}
+                                {% if line.parse_error %}
+                                <div class="text-danger small mt-1">{{ line.parse_error }}</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
                     {% if alias.definition %}
+                    <details>
+                        <summary class="small text-muted">View raw definition</summary>
+                        <pre class="mt-3 mb-0 bg-body-tertiary border rounded p-3"><code>{{ alias.definition }}</code></pre>
+                    </details>
+                    {% endif %}
+                    {% elif alias.definition %}
                     <pre class="mb-3"><code>{{ alias.definition }}</code></pre>
                     {% else %}
                     <p class="text-muted mb-3">No multi-line definition has been documented for this alias yet.</p>

--- a/tests/test_alias_definition.py
+++ b/tests/test_alias_definition.py
@@ -24,6 +24,7 @@ class SummarizeDefinitionLinesTests(unittest.TestCase):
         self.assertEqual(first.match_type, "literal")
         self.assertEqual(first.match_pattern, "/docs")
         self.assertFalse(first.ignore_case)
+        self.assertEqual(first.target_path, "/docs")
         self.assertIsNone(first.parse_error)
 
         second = summary[1]
@@ -31,6 +32,7 @@ class SummarizeDefinitionLinesTests(unittest.TestCase):
         self.assertEqual(second.match_type, "glob")
         self.assertEqual(second.match_pattern, "/search/*")
         self.assertTrue(second.ignore_case)
+        self.assertEqual(second.target_path, "/search")
 
         third = summary[2]
         self.assertFalse(third.is_mapping)
@@ -40,6 +42,7 @@ class SummarizeDefinitionLinesTests(unittest.TestCase):
         self.assertTrue(fourth.is_mapping)
         self.assertEqual(fourth.text, "  guide -> /guides")
         self.assertEqual(fourth.match_pattern, "/guide")
+        self.assertEqual(fourth.target_path, "/guides")
 
     def test_summarize_definition_lines_reports_parse_errors(self):
         definition = "docs -> /docs [regex, glob]"

--- a/tests/test_alias_view_definition_targets.py
+++ b/tests/test_alias_view_definition_targets.py
@@ -1,0 +1,55 @@
+import unittest
+
+from app import create_app
+from routes.aliases import _describe_target_path
+
+
+class AliasDefinitionTargetRenderingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app({'TESTING': True})
+        self.app_ctx = self.app.app_context()
+        self.app_ctx.push()
+        self.request_ctx = self.app.test_request_context()
+        self.request_ctx.push()
+
+    def tearDown(self) -> None:
+        self.request_ctx.pop()
+        self.app_ctx.pop()
+
+    def test_describe_target_path_handles_cids(self):
+        result = _describe_target_path('/ABC12345')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('kind'), 'cid')
+        self.assertEqual(result.get('cid'), 'ABC12345')
+        self.assertFalse(result.get('suffix'))
+
+    def test_describe_target_path_handles_cids_with_prefix(self):
+        result = _describe_target_path('/CID/ABC12345.txt?download=1')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('kind'), 'cid')
+        self.assertEqual(result.get('cid'), 'ABC12345')
+        self.assertEqual(result.get('suffix'), '?download=1')
+
+    def test_describe_target_path_handles_servers(self):
+        result = _describe_target_path('/servers/example')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('kind'), 'server')
+        self.assertEqual(result.get('name'), 'example')
+        self.assertEqual(result.get('url'), '/servers/example')
+
+    def test_describe_target_path_handles_aliases(self):
+        result = _describe_target_path('/aliases/docs')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('kind'), 'alias')
+        self.assertEqual(result.get('name'), 'docs')
+        self.assertEqual(result.get('url'), '/aliases/docs')
+
+    def test_describe_target_path_handles_generic_paths(self):
+        result = _describe_target_path('/docs/latest')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('kind'), 'path')
+        self.assertEqual(result.get('display'), '/docs/latest')
+
+
+if __name__ == '__main__':  # pragma: no cover - convenience for direct execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- capture alias definition target paths during parsing to expose metadata for rendering
- classify alias definition targets into CID, server, or alias links and display them prominently in the alias detail view
- cover the new target classification helper and updated summary output with unit tests

## Testing
- pytest tests/test_alias_definition.py tests/test_alias_view_definition_targets.py

------
https://chatgpt.com/codex/tasks/task_b_68f62f3a50808331a751459efbbb830a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced alias definition view with detailed per-line rendering, including automatic target path resolution and detection (CID, server, or alias targets)
  * Improved multi-line definition display with line numbers, options badges, and parse error handling
  * Added "View raw definition" section for viewing complete definition text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->