### PR TITLE
Support nested alias routing

### DIFF
--- a/routes/aliases.py
+++ b/routes/aliases.py
@@ -187,6 +187,8 @@ def _serialize_definition_line(entry: DefinitionLineSummary) -> Dict[str, Any]:
         "target_path": entry.target_path,
         "target_details": target_details,
         "options": options,
+        "alias_path": entry.alias_path,
+        "depth": entry.depth,
         "pattern_text": (pattern_text or entry.match_pattern or ""),
     }
 

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -283,18 +283,19 @@ def _resolve_alias_path(path: str, *, include_target_metadata: bool = True) -> O
         },
     }
 
-    alias_obj = find_matching_alias(path)
-    if not alias_obj:
+    alias_match = find_matching_alias(path)
+    if not alias_match:
         return None
 
-    base_payload["resolution"]["alias"] = alias_obj.name
+    alias_name = alias_match.route.alias_path or getattr(alias_match.alias, "name", None)
+    base_payload["resolution"]["alias"] = alias_name
 
-    redirect_response = try_alias_redirect(path)
+    redirect_response = try_alias_redirect(path, alias_match=alias_match)
     if redirect_response is None:
         return None
 
     base_payload["status_code"] = redirect_response.status_code
-    target_path = getattr(alias_obj, "target_path", None)
+    target_path = alias_match.route.target_path
     base_payload["resolution"].update(
         {
             "available": True,

--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -89,6 +89,9 @@
                                 {% if line.is_mapping and not line.parse_error %}
                                 <div class="d-flex flex-wrap align-items-center gap-2 font-monospace">
                                     <span class="text-primary">{{ line.pattern_text or line.match_pattern or line.text }}</span>
+                                    {% if line.alias_path and line.alias_path not in (line.pattern_text or '') %}
+                                    <span class="badge text-bg-light border">/{{ line.alias_path }}</span>
+                                    {% endif %}
                                     <span class="text-muted">&rarr;</span>
                                     {% set target = line.target_details %}
                                     {% if target %}


### PR DESCRIPTION
## Summary
- expand alias definition parsing to compute nested alias routes and expose them via a shared helper
- update alias redirect handling, metadata resolution, and the alias view to use the expanded routes
- add coverage for nested alias routing, view rendering, and shared parsing utilities

## Testing
- pytest tests/test_alias_definition.py tests/test_alias_routing.py tests/test_meta_route.py

------
https://chatgpt.com/codex/tasks/task_b_68f643b220688331a7735c45af41e20e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nested alias definitions now supported, enabling hierarchical path routing and organization (e.g., docs/api, docs/guide under docs)
  * Alias view displays canonical paths and hierarchical context information for each definition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->