### PR TITLE
Indent nested alias definitions across UI and previews

### DIFF
--- a/routes/aliases.py
+++ b/routes/aliases.py
@@ -19,13 +19,15 @@ from . import main_bp
 from .core import derive_name_from_path, get_existing_routes
 from interaction_log import load_interaction_history
 from alias_matching import evaluate_test_strings, matches_path
+from types import SimpleNamespace
+
 from alias_definition import (
     AliasDefinitionError,
     DefinitionLineSummary,
     ensure_primary_line,
     format_primary_alias_line,
     parse_alias_definition,
-    summarize_definition_lines,
+    resolve_alias_definition,
 )
 
 
@@ -277,10 +279,10 @@ def view_alias(alias_name: str):
         current_user.id,
     )
 
-    definition_summary = summarize_definition_lines(
-        getattr(alias, "definition", None), alias_name=getattr(alias, "name", None)
-    )
-    definition_lines = [_serialize_definition_line(entry) for entry in definition_summary]
+    definition_details = resolve_alias_definition(alias)
+    definition_lines = [
+        _serialize_definition_line(entry) for entry in definition_details.summary
+    ]
 
     return render_template(
         'alias_view.html',
@@ -300,6 +302,10 @@ def edit_alias(alias_name: str):
     form = AliasForm(obj=alias)
     change_message = (request.form.get('change_message') or '').strip()
     interaction_history = load_interaction_history(current_user.id, 'alias', alias.name)
+    definition_details = resolve_alias_definition(alias)
+    alias_definition_lines = [
+        _serialize_definition_line(entry) for entry in definition_details.summary
+    ]
 
     if request.method == 'GET':
         primary_line = _primary_definition_line_for_alias(alias)
@@ -322,6 +328,7 @@ def edit_alias(alias_name: str):
                     interaction_history=interaction_history,
                     ai_entity_name=alias.name,
                     ai_entity_name_field=form.name.id,
+                    alias_definition_lines=alias_definition_lines,
                 )
 
             if _alias_with_name_exists(current_user.id, new_name, exclude_id=alias.id):
@@ -334,6 +341,7 @@ def edit_alias(alias_name: str):
                     interaction_history=interaction_history,
                     ai_entity_name=alias.name,
                     ai_entity_name_field=form.name.id,
+                    alias_definition_lines=alias_definition_lines,
                 )
 
         alias.name = new_name
@@ -364,6 +372,7 @@ def edit_alias(alias_name: str):
         interaction_history=interaction_history,
         ai_entity_name=alias.name,
         ai_entity_name_field=form.name.id,
+        alias_definition_lines=alias_definition_lines,
     )
 
 
@@ -401,7 +410,16 @@ def alias_match_preview():
     except AliasDefinitionError as exc:
         return jsonify({'ok': False, 'error': str(exc)}), 400
 
-    definition_summary = summarize_definition_lines(definition_text, alias_name=alias_name)
+    temp_alias = SimpleNamespace(
+        name=alias_name,
+        match_type=parsed.match_type,
+        match_pattern=parsed.match_pattern,
+        target_path=parsed.target_path,
+        ignore_case=parsed.ignore_case,
+        definition=definition_text,
+    )
+    definition_details = resolve_alias_definition(temp_alias)
+    definition_summary = definition_details.summary
     has_active_paths = bool(candidate_paths)
 
     line_status = []
@@ -427,6 +445,7 @@ def alias_match_preview():
                 'matches_any': matches_any,
                 'has_error': bool(entry.parse_error),
                 'parse_error': entry.parse_error,
+                'depth': entry.depth,
             }
         )
 

--- a/templates/_alias_definition_lines.html
+++ b/templates/_alias_definition_lines.html
@@ -1,0 +1,66 @@
+{% set lines = lines or [] %}
+{% if lines %}
+<div class="border rounded overflow-hidden mb-3">
+    {% for line in lines %}
+    {% set is_last = loop.last %}
+    {% set indent = (line.depth or 0) * 1.5 %}
+    {% set indent_value = '%.2f' | format(indent) %}
+    {% if indent == 0 %}
+    {% set indent_value = '0' %}
+    {% endif %}
+    <div class="d-flex align-items-start gap-3 px-3 py-2 {% if not is_last %}border-bottom border-light{% endif %} {{ 'bg-body' if line.is_mapping and not line.parse_error else 'bg-body-tertiary' }}">
+        <div class="text-muted small pt-1" style="width: 2.5rem;">{{ line.number }}.</div>
+        <div class="flex-grow-1" data-alias-definition-depth="{{ line.depth or 0 }}">
+            <div class="alias-definition-line-content" style="margin-left: {{ indent_value }}rem;">
+                {% if line.is_mapping and not line.parse_error %}
+                <div class="d-flex flex-wrap align-items-center gap-2 font-monospace">
+                    <span class="text-primary">{{ line.pattern_text or line.match_pattern or line.text }}</span>
+                    {% if line.alias_path and line.alias_path not in (line.pattern_text or '') %}
+                    <span class="badge text-bg-light border">/{{ line.alias_path }}</span>
+                    {% endif %}
+                    <span class="text-muted">&rarr;</span>
+                    {% set target = line.target_details %}
+                    {% if target %}
+                        {% if target.kind == 'cid' %}
+                            {{ render_cid_link(target.cid) }}
+                            {% if target.suffix %}
+                            <code class="small text-muted ms-1">{{ target.suffix }}</code>
+                            {% endif %}
+                        {% elif target.kind == 'server' %}
+                            <a href="{{ target.url }}" class="text-decoration-none">
+                                <i class="fas fa-server me-1 text-primary"></i>{{ target.display or ('/servers/' ~ target.name) }}
+                            </a>
+                        {% elif target.kind == 'alias' %}
+                            <a href="{{ target.url }}" class="text-decoration-none">
+                                <i class="fas fa-link me-1 text-secondary"></i>{{ target.display or ('/aliases/' ~ target.name) }}
+                            </a>
+                        {% else %}
+                            <code>{{ target.display or line.target_path }}</code>
+                        {% endif %}
+                    {% elif line.target_path %}
+                        <code>{{ line.target_path }}</code>
+                    {% else %}
+                        <span class="text-muted">No target</span>
+                    {% endif %}
+                    {% if line.options %}
+                        {% for option in line.options %}
+                            <span class="badge text-bg-light border ms-1">{{ option }}</span>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+                {% elif line.text %}
+                <div class="font-monospace text-muted">{{ line.text }}</div>
+                {% else %}
+                <div class="font-monospace text-muted">&nbsp;</div>
+                {% endif %}
+                {% if line.parse_error %}
+                <div class="text-danger small mt-1">{{ line.parse_error }}</div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p class="text-muted small mb-0">No alias definition lines available.</p>
+{% endif %}

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -137,6 +137,21 @@
                             </div>
                         </div>
                     </div>
+                    <div class="mt-4">
+                        <h6 class="fw-semibold">Alias Definition</h6>
+                        {% if alias_definition_lines %}
+                            {% set lines = alias_definition_lines %}
+                            {% include "_alias_definition_lines.html" %}
+                            {% if alias.definition %}
+                            <details>
+                                <summary class="small text-muted">View raw definition</summary>
+                                <pre class="mt-3 mb-0 bg-body-tertiary border rounded p-3"><code>{{ alias.definition }}</code></pre>
+                            </details>
+                            {% endif %}
+                        {% else %}
+                            <p class="text-muted small mb-0">No multi-line definition has been documented for this alias yet.</p>
+                        {% endif %}
+                    </div>
                 </div>
                 {% endif %}
             </div>
@@ -269,10 +284,19 @@ document.addEventListener('DOMContentLoaded', function () {
                     errorHtml = '<span class="text-danger small ms-2">' + escapeHtml(String(line.parse_error)) + '</span>';
                 }
 
+                var depth = Number(line.depth || 0);
+                var indentRaw = depth * 1.5;
+                var indent = indentRaw === 0 ? '0' : indentRaw.toFixed(2);
+                var content = '<div class="flex-grow-1" data-alias-definition-depth="' + depth + '">' +
+                    '<div class="d-inline-block w-100" style="margin-left: ' + indent + 'rem;">' +
+                        lineText + errorHtml +
+                    '</div>' +
+                '</div>';
+
                 return '<div class="' + classes.join(' ') + '">' +
                     '<span class="text-muted small pt-1" style="width: 2.5rem;">' + line.number + '.</span>' +
                     '<span class="' + indicatorClass + ' pt-1"><i class="fas ' + indicatorIcon + '"></i></span>' +
-                    '<span class="flex-grow-1">' + lineText + errorHtml + '</span>' +
+                    content +
                 '</div>';
             }).join('');
 

--- a/templates/alias_view.html
+++ b/templates/alias_view.html
@@ -80,60 +80,8 @@
                 </div>
                 <div class="card-body">
                     {% if alias_definition_lines %}
-                    <div class="border rounded overflow-hidden mb-3">
-                        {% for line in alias_definition_lines %}
-                        {% set is_last = loop.last %}
-                        <div class="d-flex align-items-start gap-3 px-3 py-2 {% if not is_last %}border-bottom border-light{% endif %} {{ 'bg-body' if line.is_mapping and not line.parse_error else 'bg-body-tertiary' }}">
-                            <div class="text-muted small pt-1" style="width: 2.5rem;">{{ line.number }}.</div>
-                            <div class="flex-grow-1">
-                                {% if line.is_mapping and not line.parse_error %}
-                                <div class="d-flex flex-wrap align-items-center gap-2 font-monospace">
-                                    <span class="text-primary">{{ line.pattern_text or line.match_pattern or line.text }}</span>
-                                    {% if line.alias_path and line.alias_path not in (line.pattern_text or '') %}
-                                    <span class="badge text-bg-light border">/{{ line.alias_path }}</span>
-                                    {% endif %}
-                                    <span class="text-muted">&rarr;</span>
-                                    {% set target = line.target_details %}
-                                    {% if target %}
-                                        {% if target.kind == 'cid' %}
-                                            {{ render_cid_link(target.cid) }}
-                                            {% if target.suffix %}
-                                            <code class="small text-muted ms-1">{{ target.suffix }}</code>
-                                            {% endif %}
-                                        {% elif target.kind == 'server' %}
-                                            <a href="{{ target.url }}" class="text-decoration-none">
-                                                <i class="fas fa-server me-1 text-primary"></i>{{ target.display or ('/servers/' ~ target.name) }}
-                                            </a>
-                                        {% elif target.kind == 'alias' %}
-                                            <a href="{{ target.url }}" class="text-decoration-none">
-                                                <i class="fas fa-link me-1 text-secondary"></i>{{ target.display or ('/aliases/' ~ target.name) }}
-                                            </a>
-                                        {% else %}
-                                            <code>{{ target.display or line.target_path }}</code>
-                                        {% endif %}
-                                    {% elif line.target_path %}
-                                        <code>{{ line.target_path }}</code>
-                                    {% else %}
-                                        <span class="text-muted">No target</span>
-                                    {% endif %}
-                                    {% if line.options %}
-                                        {% for option in line.options %}
-                                            <span class="badge text-bg-light border ms-1">{{ option }}</span>
-                                        {% endfor %}
-                                    {% endif %}
-                                </div>
-                                {% elif line.text %}
-                                <div class="font-monospace text-muted">{{ line.text }}</div>
-                                {% else %}
-                                <div class="font-monospace text-muted">&nbsp;</div>
-                                {% endif %}
-                                {% if line.parse_error %}
-                                <div class="text-danger small mt-1">{{ line.parse_error }}</div>
-                                {% endif %}
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
+                    {% set lines = alias_definition_lines %}
+                    {% include "_alias_definition_lines.html" %}
                     {% if alias.definition %}
                     <details>
                         <summary class="small text-muted">View raw definition</summary>


### PR DESCRIPTION
## Summary
- indent alias definition rendering using recorded depth so nested routes stand out in view and edit pages
- expose definition line depth through the match preview API and surface it in the live preview widget
- extend alias routing tests to cover the new depth metadata and UI output

## Testing
- pytest tests/test_alias_definition.py tests/test_alias_routing.py

------
https://chatgpt.com/codex/tasks/task_b_68f668d6645883318fe3062feedd5d4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved alias definition display with multi-line rendering and depth-based indentation for nested mappings
  * Added visual support for multiple target types including CID links and server/alias badges
  * Display of parse errors and configuration options for each definition line

* **Refactor**
  * Streamlined alias definition template structure for better code organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->