### PR TITLE
Improve CID edit alias management

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -124,6 +124,18 @@ def get_alias_by_target_path(user_id: str, target_path: str):
     )
 
 
+def get_aliases_by_target_path(user_id: str, target_path: str) -> List[Alias]:
+    return (
+        Alias.query.filter_by(
+            user_id=user_id,
+            target_path=target_path,
+            match_type='literal',
+        )
+        .order_by(Alias.name.asc())
+        .all()
+    )
+
+
 def get_user_variables(user_id: str):
     return Variable.query.filter_by(user_id=user_id).order_by(Variable.name).all()
 

--- a/templates/edit_cid.html
+++ b/templates/edit_cid.html
@@ -64,7 +64,7 @@
                         </div>
                     </div>
                     {% endif %}
-                    <form method="POST">
+                    <form method="POST" id="edit-cid-form">
                         {{ form.hidden_tag() }}
                         <div class="mb-3">
                             {{ form.text_content.label(class="form-label") }}
@@ -91,30 +91,29 @@
                             interactions=interaction_history|default([]),
                             history_label='Recent edits and requests'
                         ) }}
-                        {% if not show_alias_field and current_alias_name %}
+                        {% if existing_alias_names %}
                             <div class="alert alert-info" role="alert">
                                 <i class="fas fa-link me-1"></i>
-                                Saving will update the <strong>{{ current_alias_name }}</strong> alias to point at the new CID.
+                                Saving will update the following aliases to point at the new CID:
+                                <strong>{{ existing_alias_names|join(', ') }}</strong>.
                             </div>
                         {% endif %}
-                        {% if show_alias_field %}
-                            <div class="mb-3">
-                                {{ form.alias_name.label(class="form-label") }}
-                                {{ form.alias_name(class="form-control" + (" is-invalid" if form.alias_name.errors else "")) }}
-                                {% if form.alias_name.errors %}
-                                    <div class="invalid-feedback d-block">
-                                        {% for error in form.alias_name.errors %}
-                                            <div>{{ error }}</div>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                                <small class="form-text text-muted">
-                                    Optionally supply a new alias to point at the saved content. Alias names are case sensitive.
-                                </small>
-                            </div>
-                        {% endif %}
+                        <div class="mb-3">
+                            {{ form.alias_names.label(class="form-label") }}
+                            {{ form.alias_names(class="form-control" + (" is-invalid" if form.alias_names.errors else "")) }}
+                            {% if form.alias_names.errors %}
+                                <div class="invalid-feedback d-block">
+                                    {% for error in form.alias_names.errors %}
+                                        <div>{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                            <small class="form-text text-muted">
+                                Provide a space-delimited list of aliases that should reference the saved content. Alias names are case sensitive.
+                            </small>
+                        </div>
                         <div class="d-flex gap-2 align-items-center flex-wrap">
-                            {{ form.submit(class="btn btn-primary", value=submit_label) }}
+                            {{ form.submit(class="btn btn-primary", value=submit_label, disabled=True) }}
                             {{ ai_action_button(form.text_content.id, button_label='AI', extra_classes='btn-outline-primary') }}
                             {{ render_cid_link(cid) }}
                         </div>
@@ -130,4 +129,51 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('edit-cid-form');
+    if (!form) {
+        return;
+    }
+
+    const textField = document.getElementById('{{ form.text_content.id }}');
+    const aliasField = document.getElementById('{{ form.alias_names.id }}');
+    const submitButton = document.getElementById('{{ form.submit.id }}');
+
+    if (!textField || !submitButton) {
+        return;
+    }
+
+    const originalText = {{ original_text|tojson }};
+    const originalAliases = {{ (original_aliases or '')|tojson }};
+
+    const normalizeText = (value) => (value || '').replace(/\r\n/g, '\n');
+    const normalizeAliases = (value) => {
+        return (value || '')
+            .trim()
+            .split(/\s+/)
+            .filter(Boolean)
+            .join(' ');
+    };
+
+    const updateButtonState = () => {
+        const textChanged = normalizeText(textField.value) !== normalizeText(originalText);
+        let aliasChanged = false;
+        if (aliasField) {
+            aliasChanged = normalizeAliases(aliasField.value) !== normalizeAliases(originalAliases);
+        }
+        submitButton.disabled = !(textChanged || aliasChanged);
+    };
+
+    updateButtonState();
+    textField.addEventListener('input', updateButtonState);
+    if (aliasField) {
+        aliasField.addEventListener('input', updateButtonState);
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support multiple alias names in the CID edit form with validation and updated UI messaging
- refresh the edit handler to preload existing aliases, gate updates on content changes, and call CID/alias reference helpers as needed
- add a database helper for fetching aliases by target path and expand route tests to cover alias workflows

## Testing
- pytest tests/test_routes_comprehensive.py -q

------
https://chatgpt.com/codex/tasks/task_b_68f7b74b57908331983ce7a91e74b466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now add multiple space-delimited aliases to content items.
  * Submit button automatically enables only when content text or aliases have changed from original values.

* **Improvements**
  * Form displays existing aliases for quick reference.
  * Enhanced validation prevents conflicting aliases across different content items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->