### PR TITLE
Remove internal payment and terms management artifacts

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -1,12 +1,9 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any, Iterable, List, Tuple, Set
 
 import models
 from database import db
 from models import (
-    Payment,
-    TermsAcceptance,
-    CURRENT_TERMS_VERSION,
     User,
     Server,
     Alias,
@@ -23,57 +20,18 @@ from alias_definition import AliasDefinitionError, parse_alias_definition
 
 
 def get_user_profile_data(user_id: str) -> Dict[str, Any]:
-    """Gather payment and terms data for a user."""
-    payments = (
-        Payment.query.filter_by(user_id=user_id)
-        .order_by(Payment.payment_date.desc())
-        .all()
-    )
-    terms_history = (
-        TermsAcceptance.query.filter_by(user_id=user_id)
-        .order_by(TermsAcceptance.accepted_at.desc())
-        .all()
-    )
-    current_terms = TermsAcceptance.query.filter_by(
-        user_id=user_id, terms_version=CURRENT_TERMS_VERSION
-    ).first()
+    """Return placeholder profile metadata for externally managed accounts."""
+
+    # Payment and terms of service tracking now live in an external system. The
+    # application keeps this helper as a compatibility shim so callers receive a
+    # consistent shape without exposing internal payment details. The returned
+    # structure intentionally contains empty collections and neutral defaults.
     return {
-        "payments": payments,
-        "terms_history": terms_history,
-        "needs_terms_acceptance": current_terms is None,
-        "current_terms_version": CURRENT_TERMS_VERSION,
+        "payments": [],
+        "terms_history": [],
+        "needs_terms_acceptance": False,
+        "current_terms_version": None,
     }
-
-
-def create_payment_record(plan: str, amount: float, user: User) -> Payment:
-    """Create and persist a payment record, updating the user as needed."""
-    payment = Payment(user_id=user.id, amount=amount, plan_type=plan)
-    if plan == "annual":
-        payment.expires_at = datetime.now(timezone.utc) + timedelta(days=365)
-        user.is_paid = True
-        user.payment_expires_at = payment.expires_at
-    else:
-        user.is_paid = False
-        user.payment_expires_at = None
-    payment.transaction_id = f"mock_txn_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
-    db.session.add(payment)
-    db.session.commit()
-    return payment
-
-
-def create_terms_acceptance_record(user: User, ip_address: str) -> TermsAcceptance:
-    """Create and persist a terms acceptance record for the user."""
-    terms_acceptance = TermsAcceptance(
-        user_id=user.id,
-        terms_version=CURRENT_TERMS_VERSION,
-        ip_address=ip_address,
-    )
-    user.current_terms_accepted = True
-    db.session.add(terms_acceptance)
-    db.session.commit()
-    return terms_acceptance
-
-
 def get_user_servers(user_id: str):
     return Server.query.filter_by(user_id=user_id).order_by(Server.name).all()
 
@@ -850,9 +808,3 @@ def count_secrets() -> int:
     return Secret.query.count()
 
 
-def count_payments() -> int:
-    return Payment.query.count()
-
-
-def count_terms_acceptances() -> int:
-    return TermsAcceptance.query.count()

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
-from wtforms import BooleanField, SelectField, SubmitField, StringField, TextAreaField, RadioField
+from wtforms import BooleanField, SubmitField, StringField, TextAreaField, RadioField
 from wtforms.validators import DataRequired, Optional, Regexp, ValidationError
 import re
 
@@ -9,17 +9,6 @@ from alias_definition import AliasDefinitionError, parse_alias_definition
 
 def _strip_filter(value):
     return value.strip() if isinstance(value, str) else value
-
-class PaymentForm(FlaskForm):
-    plan = SelectField('Plan', choices=[
-        ('free', 'Free Plan - $0/year'),
-        ('annual', 'Annual Plan - $50/year')
-    ], validators=[DataRequired()])
-    submit = SubmitField('Subscribe')
-
-class TermsAcceptanceForm(FlaskForm):
-    accept_terms = BooleanField('I accept the current Terms and Conditions', validators=[DataRequired()])
-    submit = SubmitField('Accept Terms')
 
 class FileUploadForm(FlaskForm):
     upload_type = RadioField('Upload Method', choices=[

--- a/inspect_db.py
+++ b/inspect_db.py
@@ -13,10 +13,8 @@ from app import create_app
 from db_access import (
     count_cids,
     count_page_views,
-    count_payments,
     count_secrets,
     count_servers,
-    count_terms_acceptances,
     count_users,
     count_variables,
     get_all_users,
@@ -45,8 +43,6 @@ def inspect_database():
             ("Servers", count_servers),
             ("Variables", count_variables),
             ("Secrets", count_secrets),
-            ("Payments", count_payments),
-            ("Terms Acceptances", count_terms_acceptances),
         ]
 
         print("TABLE COUNTS:")

--- a/models.py
+++ b/models.py
@@ -20,10 +20,6 @@ class User(UserMixin, db.Model):
     payment_expires_at = db.Column(db.DateTime)
     current_terms_accepted = db.Column(db.Boolean, default=False)
 
-    # Relationships
-    payments = db.relationship('Payment', backref='user', lazy=True, cascade='all, delete-orphan')
-    terms_acceptances = db.relationship('TermsAcceptance', backref='user', lazy=True, cascade='all, delete-orphan')
-
     def has_access(self):
         """Check if user has full access (logged in, paid, terms accepted)"""
         return self.is_paid and self.current_terms_accepted and (
@@ -51,30 +47,6 @@ class OAuth(OAuthConsumerMixin, db.Model):
         'provider',
         name='uq_user_browser_session_key_provider',
     ),)
-
-class Payment(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False)
-    amount = db.Column(db.Float, nullable=False)
-    plan_type = db.Column(db.String(50), nullable=False)  # 'free' or 'annual'
-    payment_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    expires_at = db.Column(db.DateTime)
-    payment_method = db.Column(db.String(50), default='Mock Payment')
-    transaction_id = db.Column(db.String(100))
-    status = db.Column(db.String(20), default='completed')
-
-    def __repr__(self):
-        return f'<Payment {self.amount} for {self.plan_type}>'
-
-class TermsAcceptance(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False)
-    terms_version = db.Column(db.String(10), nullable=False)
-    accepted_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    ip_address = db.Column(db.String(45))  # Support IPv6
-
-    def __repr__(self):
-        return f'<TermsAcceptance {self.terms_version} by user {self.user_id}>'
 
 class CID(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -238,6 +210,3 @@ class ServerInvocation(db.Model):
 
     def __repr__(self):
         return f'<ServerInvocation {self.server_name} by {self.user_id} -> {self.result_cid}>'
-
-# Current terms version - update this when terms change
-CURRENT_TERMS_VERSION = "1.0"

--- a/replit.md
+++ b/replit.md
@@ -1,6 +1,6 @@
 # Overview
 
-Viewer is a Flask-based web application that demonstrates a multi-layered access control system. The application provides secure content access through user authentication, payment verification, and terms acceptance tracking. It features detailed HTTP request analysis as its core functionality, allowing authenticated and subscribed users to view comprehensive information about their web requests including headers, metadata, and network details.
+Viewer is a Flask-based web application focused on analysing HTTP requests and presenting rich diagnostics. User authentication, subscription management, and terms acceptance now live in external services; this application assumes an already-authenticated user context and concentrates on content tooling and observability features.
 
 # User Preferences
 
@@ -10,21 +10,17 @@ Preferred communication style: Simple, everyday language.
 
 ## Web Framework
 The application is built on Flask with SQLAlchemy ORM for database operations. The architecture follows a traditional MVC pattern with clear separation of concerns:
-- **Models**: User, Payment, and TermsAcceptance entities with relationships
+- **Models**: User plus supporting entities for aliases, servers, variables, secrets, and analytics
 - **Views**: Jinja2 templates with Bootstrap 5 for responsive UI
 - **Controllers**: Route handlers managing authentication, payments, and content access
 
 ## Authentication & Authorization
-Flask-Login provides session management with a multi-tier access control system:
-- **Authentication**: Username/password login with session persistence
-- **Payment Verification**: Subscription-based access with expiration tracking
-- **Terms Acceptance**: Version-controlled terms that users must accept
-- **Access Control**: Combined verification of all three factors before granting content access
+Flask-Login provides session management for the default application user. External identity and billing providers determine who may access the tool, allowing this service to focus on product functionality rather than subscription logic.
 
 ## Database Design
 SQLAlchemy with declarative base provides the ORM layer:
-- **User Model**: Core user data with password hashing and access control methods
-- **Payment Model**: Subscription tracking with plan types and expiration dates
+- **User Model**: Core user data plus helper methods for request analysis features
+- **Supporting Models**: Records for servers, aliases, variables, secrets, page views, and historical invocations
 - **Relationships**: One-to-many relationships with cascade delete for data integrity
 
 ## Form Handling

--- a/tests/test_db_access.py
+++ b/tests/test_db_access.py
@@ -23,11 +23,9 @@ from models import (
 from db_access import (
     count_cids,
     count_page_views,
-    count_payments,
     count_secrets,
     count_servers,
     count_variables,
-    count_terms_acceptances,
     count_unique_page_view_paths,
     count_user_servers,
     count_user_variables,
@@ -35,9 +33,7 @@ from db_access import (
     count_user_page_views,
     count_users,
     create_cid_record,
-    create_payment_record,
     create_server_invocation,
-    create_terms_acceptance_record,
     find_cids_by_prefix,
     find_entity_interaction,
     find_server_invocations_by_cid,
@@ -89,26 +85,12 @@ class TestDBAccess(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
 
-    def test_create_payment_record(self):
-        create_payment_record('annual', 50.0, self.user)
-        self.assertTrue(self.user.is_paid)
-        self.assertEqual(len(self.user.payments), 1)
-        self.assertEqual(self.user.payments[0].plan_type, 'annual')
-        self.assertEqual(count_payments(), 1)
-
-    def test_create_terms_acceptance_record(self):
-        create_terms_acceptance_record(self.user, '127.0.0.1')
-        self.assertTrue(self.user.current_terms_accepted)
-        self.assertEqual(len(self.user.terms_acceptances), 1)
-        self.assertEqual(self.user.terms_acceptances[0].ip_address, '127.0.0.1')
-        self.assertEqual(count_terms_acceptances(), 1)
-
     def test_get_user_profile_data(self):
-        create_payment_record('free', 0.0, self.user)
-        create_terms_acceptance_record(self.user, '127.0.0.1')
         data = get_user_profile_data(self.user.id)
-        self.assertEqual(len(data['payments']), 1)
+        self.assertEqual(data['payments'], [])
+        self.assertEqual(data['terms_history'], [])
         self.assertFalse(data['needs_terms_acceptance'])
+        self.assertIsNone(data['current_terms_version'])
 
     def test_entity_helpers(self):
         server = Server(name='srv', definition='print(1)', user_id=self.user.id)


### PR DESCRIPTION
## Summary
- drop the Payment and TermsAcceptance ORM models along with related helpers
- collapse profile and form helpers to simple placeholders now that billing and terms are external
- refresh documentation and tooling to reflect the externalized user management

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f8d27cd0e88331b079529dd473a553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal payment and terms acceptance record creation and management functions.
  * Removed Payment and TermsAcceptance models; delegated these functions to external providers.
  * Simplified user profile data structure; payment and terms history now return empty values.
  * Streamlined form validation by removing payment and terms acceptance forms.

* **Documentation**
  * Updated architecture documentation to reflect changes in application focus and data model organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->