### PR TITLE
Remove legacy payment and terms integration

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
-from wtforms import BooleanField, SelectField, SubmitField, StringField, TextAreaField, RadioField
+from wtforms import BooleanField, SubmitField, StringField, TextAreaField, RadioField
 from wtforms.validators import DataRequired, Optional, Regexp, ValidationError
 import re
 
@@ -9,17 +9,6 @@ from alias_definition import AliasDefinitionError, parse_alias_definition
 
 def _strip_filter(value):
     return value.strip() if isinstance(value, str) else value
-
-class PaymentForm(FlaskForm):
-    plan = SelectField('Plan', choices=[
-        ('free', 'Free Plan - $0/year'),
-        ('annual', 'Annual Plan - $50/year')
-    ], validators=[DataRequired()])
-    submit = SubmitField('Subscribe')
-
-class TermsAcceptanceForm(FlaskForm):
-    accept_terms = BooleanField('I accept the current Terms and Conditions', validators=[DataRequired()])
-    submit = SubmitField('Accept Terms')
 
 class FileUploadForm(FlaskForm):
     upload_type = RadioField('Upload Method', choices=[

--- a/identity.py
+++ b/identity.py
@@ -34,23 +34,11 @@ def _ensure_default_user() -> User:
             email=_DEFAULT_EMAIL,
             first_name=_DEFAULT_FIRST_NAME,
             last_name=_DEFAULT_LAST_NAME,
-            is_paid=True,
-            current_terms_accepted=True,
         )
         save_entity(user)
         ensure_ai_stub_for_user(user.id)
         return user
 
-    # Ensure legacy flags remain enabled so existing UI behaves as expected.
-    updated = False
-    if not getattr(user, "is_paid", False):
-        user.is_paid = True
-        updated = True
-    if not getattr(user, "current_terms_accepted", False):
-        user.current_terms_accepted = True
-        updated = True
-    if updated:
-        save_entity(user)
     return user
 
 

--- a/inspect_db.py
+++ b/inspect_db.py
@@ -13,10 +13,8 @@ from app import create_app
 from db_access import (
     count_cids,
     count_page_views,
-    count_payments,
     count_secrets,
     count_servers,
-    count_terms_acceptances,
     count_users,
     count_variables,
     get_all_users,
@@ -45,8 +43,6 @@ def inspect_database():
             ("Servers", count_servers),
             ("Variables", count_variables),
             ("Secrets", count_secrets),
-            ("Payments", count_payments),
-            ("Terms Acceptances", count_terms_acceptances),
         ]
 
         print("TABLE COUNTS:")
@@ -81,8 +77,6 @@ def inspect_database():
                 print(f"ID: {user.id}")
                 print(f"  Email: {user.email}")
                 print(f"  Name: {user.first_name} {user.last_name}")
-                print(f"  Paid: {user.is_paid}")
-                print(f"  Terms Accepted: {user.current_terms_accepted}")
                 print(f"  Uploads: {len(user.uploads)}")
                 print()
         else:

--- a/models.py
+++ b/models.py
@@ -15,20 +15,9 @@ class User(UserMixin, db.Model):
     created_at = db.Column(db.DateTime, default=datetime.now)
     updated_at = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
 
-    # Payment and access control
-    is_paid = db.Column(db.Boolean, default=False)
-    payment_expires_at = db.Column(db.DateTime)
-    current_terms_accepted = db.Column(db.Boolean, default=False)
-
-    # Relationships
-    payments = db.relationship('Payment', backref='user', lazy=True, cascade='all, delete-orphan')
-    terms_acceptances = db.relationship('TermsAcceptance', backref='user', lazy=True, cascade='all, delete-orphan')
-
     def has_access(self):
-        """Check if user has full access (logged in, paid, terms accepted)"""
-        return self.is_paid and self.current_terms_accepted and (
-            self.payment_expires_at is None or self.payment_expires_at.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc)
-        )
+        """Compatibility shim now that access control is external."""
+        return True
 
     @property
     def username(self):
@@ -51,30 +40,6 @@ class OAuth(OAuthConsumerMixin, db.Model):
         'provider',
         name='uq_user_browser_session_key_provider',
     ),)
-
-class Payment(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False)
-    amount = db.Column(db.Float, nullable=False)
-    plan_type = db.Column(db.String(50), nullable=False)  # 'free' or 'annual'
-    payment_date = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    expires_at = db.Column(db.DateTime)
-    payment_method = db.Column(db.String(50), default='Mock Payment')
-    transaction_id = db.Column(db.String(100))
-    status = db.Column(db.String(20), default='completed')
-
-    def __repr__(self):
-        return f'<Payment {self.amount} for {self.plan_type}>'
-
-class TermsAcceptance(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.String, db.ForeignKey('users.id'), nullable=False)
-    terms_version = db.Column(db.String(10), nullable=False)
-    accepted_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
-    ip_address = db.Column(db.String(45))  # Support IPv6
-
-    def __repr__(self):
-        return f'<TermsAcceptance {self.terms_version} by user {self.user_id}>'
 
 class CID(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -238,6 +203,3 @@ class ServerInvocation(db.Model):
 
     def __repr__(self):
         return f'<ServerInvocation {self.server_name} by {self.user_id} -> {self.result_cid}>'
-
-# Current terms version - update this when terms change
-CURRENT_TERMS_VERSION = "1.0"

--- a/replit.md
+++ b/replit.md
@@ -1,6 +1,6 @@
 # Overview
 
-Viewer is a Flask-based web application that demonstrates a multi-layered access control system. The application provides secure content access through user authentication, payment verification, and terms acceptance tracking. It features detailed HTTP request analysis as its core functionality, allowing authenticated and subscribed users to view comprehensive information about their web requests including headers, metadata, and network details.
+Viewer is a Flask-based web application focused on analysing HTTP requests and presenting rich diagnostics. User authentication, subscription management, and terms acceptance now live in external services; this application assumes an already-authenticated user context and concentrates on content tooling and observability features.
 
 # User Preferences
 
@@ -10,21 +10,17 @@ Preferred communication style: Simple, everyday language.
 
 ## Web Framework
 The application is built on Flask with SQLAlchemy ORM for database operations. The architecture follows a traditional MVC pattern with clear separation of concerns:
-- **Models**: User, Payment, and TermsAcceptance entities with relationships
+- **Models**: User plus supporting entities for aliases, servers, variables, secrets, and analytics
 - **Views**: Jinja2 templates with Bootstrap 5 for responsive UI
-- **Controllers**: Route handlers managing authentication, payments, and content access
+- **Controllers**: Route handlers focusing on content tooling and workspace flows while external services handle authentication
 
 ## Authentication & Authorization
-Flask-Login provides session management with a multi-tier access control system:
-- **Authentication**: Username/password login with session persistence
-- **Payment Verification**: Subscription-based access with expiration tracking
-- **Terms Acceptance**: Version-controlled terms that users must accept
-- **Access Control**: Combined verification of all three factors before granting content access
+Flask-Login provides session management for the default application user. External identity and billing providers determine who may access the tool, allowing this service to focus on product functionality rather than subscription logic.
 
 ## Database Design
 SQLAlchemy with declarative base provides the ORM layer:
-- **User Model**: Core user data with password hashing and access control methods
-- **Payment Model**: Subscription tracking with plan types and expiration dates
+- **User Model**: Core user data plus helper methods for request analysis features
+- **Supporting Models**: Records for servers, aliases, variables, secrets, page views, and historical invocations
 - **Relationships**: One-to-many relationships with cascade delete for data integrity
 
 ## Form Handling
@@ -40,9 +36,8 @@ Bootstrap 5 with custom CSS provides a responsive, accessible interface:
 - **Responsive Design**: Mobile-first approach with grid system
 
 ## Security Features
-- **Password Security**: Werkzeug password hashing with salt
-- **Session Management**: Secure session handling with configurable secrets
-- **Access Guards**: Decorator-based route protection with redirect handling
+- **Session Management**: Flask-Login maintains a default workspace user with configurable secrets
+- **External Trust**: Upstream identity and billing providers gate access before requests reach the app
 - **CSRF Protection**: Form token validation on all POST requests
 
 # External Dependencies

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -38,8 +38,6 @@ class TestAnalytics(unittest.TestCase):
         self.user = User(
             id="analytics-user",
             email="analytics@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
         )
         db.session.add(self.user)
         db.session.commit()

--- a/tests/test_cid_functionality.py
+++ b/tests/test_cid_functionality.py
@@ -47,8 +47,6 @@ class TestCIDFunctionality(unittest.TestCase):
             email='test@example.com',
             first_name='Test',
             last_name='User',
-            is_paid=True,
-            current_terms_accepted=True
         )
         db.session.add(test_user)
         db.session.commit()

--- a/tests/test_db_access.py
+++ b/tests/test_db_access.py
@@ -23,11 +23,9 @@ from models import (
 from db_access import (
     count_cids,
     count_page_views,
-    count_payments,
     count_secrets,
     count_servers,
     count_variables,
-    count_terms_acceptances,
     count_unique_page_view_paths,
     count_user_servers,
     count_user_variables,
@@ -35,9 +33,7 @@ from db_access import (
     count_user_page_views,
     count_users,
     create_cid_record,
-    create_payment_record,
     create_server_invocation,
-    create_terms_acceptance_record,
     find_cids_by_prefix,
     find_entity_interaction,
     find_server_invocations_by_cid,
@@ -89,26 +85,11 @@ class TestDBAccess(unittest.TestCase):
         db.drop_all()
         self.app_context.pop()
 
-    def test_create_payment_record(self):
-        create_payment_record('annual', 50.0, self.user)
-        self.assertTrue(self.user.is_paid)
-        self.assertEqual(len(self.user.payments), 1)
-        self.assertEqual(self.user.payments[0].plan_type, 'annual')
-        self.assertEqual(count_payments(), 1)
-
-    def test_create_terms_acceptance_record(self):
-        create_terms_acceptance_record(self.user, '127.0.0.1')
-        self.assertTrue(self.user.current_terms_accepted)
-        self.assertEqual(len(self.user.terms_acceptances), 1)
-        self.assertEqual(self.user.terms_acceptances[0].ip_address, '127.0.0.1')
-        self.assertEqual(count_terms_acceptances(), 1)
-
     def test_get_user_profile_data(self):
-        create_payment_record('free', 0.0, self.user)
-        create_terms_acceptance_record(self.user, '127.0.0.1')
         data = get_user_profile_data(self.user.id)
-        self.assertEqual(len(data['payments']), 1)
-        self.assertFalse(data['needs_terms_acceptance'])
+        self.assertEqual(data['user_id'], self.user.id)
+        self.assertEqual(data['profile'], {})
+        self.assertTrue(data['managed_externally'])
 
     def test_entity_helpers(self):
         server = Server(name='srv', definition='print(1)', user_id=self.user.id)

--- a/tests/test_echo_functionality.py
+++ b/tests/test_echo_functionality.py
@@ -33,8 +33,6 @@ class TestEchoFunctionality(unittest.TestCase):
             email='test@example.com',
             first_name='Test',
             last_name='User',
-            is_paid=True,
-            current_terms_accepted=True
         )
         db.session.add(self.test_user)
         db.session.commit()

--- a/tests/test_entity_references.py
+++ b/tests/test_entity_references.py
@@ -37,8 +37,6 @@ class TestEntityReferences(unittest.TestCase):
                 email=f'{user_id}@example.com',
                 first_name='User',
                 last_name='One',
-                is_paid=True,
-                current_terms_accepted=True,
             )
             db.session.add(user)
             db.session.commit()

--- a/tests/test_glom_server_template.py
+++ b/tests/test_glom_server_template.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import unittest
 
@@ -26,9 +25,6 @@ class TestGlomServerTemplate(unittest.TestCase):
         self.user = User(
             id="user-1",
             email="user@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
 

--- a/tests/test_meta_route.py
+++ b/tests/test_meta_route.py
@@ -33,8 +33,6 @@ class TestMetaRoute(unittest.TestCase):
             email='test@example.com',
             first_name='Test',
             last_name='User',
-            is_paid=True,
-            current_terms_accepted=True,
         )
         db.session.add(user)
         db.session.commit()

--- a/tests/test_pygments_server_template.py
+++ b/tests/test_pygments_server_template.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import unittest
 
@@ -25,9 +24,6 @@ class TestPygmentsServerTemplate(unittest.TestCase):
         self.user = User(
             id="user-1",
             email="user@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
 

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -58,9 +58,6 @@ class BaseTestCase(unittest.TestCase):
             email='test@example.com',
             first_name='Test',
             last_name='User',
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=365)
         )
         db.session.add(self.test_user)
         db.session.commit()
@@ -566,14 +563,11 @@ class TestAuthenticatedRoutes(BaseTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn('/profile', response.location)
 
-    def test_dashboard_without_access_redirects_to_profile(self):
-        """Test dashboard redirects users without access to profile."""
-        # Create user without access
+    def test_dashboard_redirects_new_users_to_profile(self):
+        """Dashboard should lead any signed-in user to their profile."""
         user_no_access = User(
             id='no_access_user',
             email='noaccess@example.com',
-            is_paid=False,
-            current_terms_accepted=False
         )
         db.session.add(user_no_access)
         db.session.commit()

--- a/tests/test_routes_overview.py
+++ b/tests/test_routes_overview.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from datetime import datetime, timedelta, timezone
 
 os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
 os.environ.setdefault('SESSION_SECRET', 'test-secret-key')
@@ -32,9 +31,6 @@ class RoutesOverviewTestCase(unittest.TestCase):
             id='user-1',
             email='user@example.com',
             first_name='Test',
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
         db.session.commit()

--- a/tests/test_server_cid_functionality.py
+++ b/tests/test_server_cid_functionality.py
@@ -32,8 +32,6 @@ def test_server_cid_functionality():
             email='test@example.com',
             first_name='Test',
             last_name='User',
-            is_paid=True,
-            current_terms_accepted=True
         )
         db.session.add(test_user)
         db.session.commit()

--- a/tests/test_server_definition_validation_route.py
+++ b/tests/test_server_definition_validation_route.py
@@ -1,6 +1,5 @@
 """Tests for the server definition validation endpoint."""
 
-from datetime import datetime, timedelta, timezone
 import textwrap
 import unittest
 
@@ -27,9 +26,6 @@ class TestServerDefinitionValidationRoute(unittest.TestCase):
         self.user = User(
             id="user-1",
             email="user@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
         db.session.commit()

--- a/tests/test_server_execution_error_pages.py
+++ b/tests/test_server_execution_error_pages.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from html.parser import HTMLParser
 from pathlib import Path
-from datetime import datetime, timedelta, timezone
 import unittest
 
 from app import create_app
@@ -62,9 +61,6 @@ class TestServerExecutionErrorPages(unittest.TestCase):
         self.user = User(
             id="user-1",
             email="user@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
 

--- a/tests/test_server_test_page_upload.py
+++ b/tests/test_server_test_page_upload.py
@@ -26,9 +26,6 @@ class TestServerTestPageUpload(unittest.TestCase):
         self.user = User(
             id="user-1",
             email="user@example.com",
-            is_paid=True,
-            current_terms_accepted=True,
-            payment_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.session.add(self.user)
         db.session.commit()


### PR DESCRIPTION
## Summary
- drop the User payment and terms columns and keep a compatibility shim for `has_access`
- update the identity helper, profile accessor, and tooling to stop surfacing payment metadata
- refresh tests and docs to reflect that access control now lives in external services

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f8d27cd0e88331b079529dd473a553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Externalized payment and subscription management to external services; the application no longer tracks payments or terms acceptance internally.
  * Simplified user profiles to reflect externalized identity and billing providers; access control is now assumed to be pre-authorized.
  * Reframed application purpose from access control demo to diagnostics-focused request analysis tool.

* **Chores**
  * Removed unused payment and terms acceptance models and related database functions.
  * Cleaned up imports and test fixtures across test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->