### PR TITLE
Add database instance browsing to the source view

### DIFF
--- a/templates/source_browser.html
+++ b/templates/source_browser.html
@@ -6,6 +6,9 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2 class="mb-0"><i class="fas fa-code me-2"></i>Source Browser</h2>
+        <a class="btn btn-outline-primary" href="{{ url_for('main.source_instance_overview') }}">
+            <i class="fas fa-database me-2"></i>Database Tables
+        </a>
     </div>
 
     <nav aria-label="breadcrumb" class="mb-3">

--- a/templates/source_instance.html
+++ b/templates/source_instance.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Database Tables{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+        <div>
+            <h2 class="mb-1"><i class="fas fa-database me-2"></i>Database Tables</h2>
+            <p class="text-muted mb-0">Explore the schema and data available in this Viewer instance.</p>
+        </div>
+        <a class="btn btn-outline-secondary" href="{{ url_for('main.source_browser') }}">
+            <i class="fas fa-code me-2"></i>Back to Source
+        </a>
+    </div>
+
+    {% if tables %}
+        <div class="row g-3">
+            {% for table in tables %}
+                <div class="col-12">
+                    <div class="card h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">
+                                <a class="text-decoration-none" href="{{ url_for('main.source_instance_table', table_name=table.name) }}">
+                                    <i class="fas fa-table me-2 text-muted"></i>{{ table.name }}
+                                </a>
+                            </h5>
+                            <span class="badge bg-secondary">{{ table.columns|length }} fields</span>
+                        </div>
+                        <div class="card-body py-3">
+                            {% if table.columns %}
+                                <ul class="list-inline mb-0">
+                                    {% for column in table.columns %}
+                                        <li class="list-inline-item mb-2">
+                                            <span class="badge bg-light text-dark border"><code>{{ column }}</code></span>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                <p class="text-muted mb-0">No columns reported for this table.</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="alert alert-info mb-0" role="alert">
+            No database tables are available for this instance.
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/source_instance_table.html
+++ b/templates/source_instance_table.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}Table: {{ table_name }}{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+        <div>
+            <h2 class="mb-1"><i class="fas fa-table me-2"></i>Table: <code>{{ table_name }}</code></h2>
+            <p class="text-muted mb-0">Displaying {{ row_count }} {{ 'row' if row_count == 1 else 'rows' }}.</p>
+        </div>
+        <div class="d-flex gap-2">
+            <a class="btn btn-outline-secondary" href="{{ url_for('main.source_instance_overview') }}">
+                <i class="fas fa-database me-2"></i>All Tables
+            </a>
+            <a class="btn btn-outline-primary" href="{{ url_for('main.source_browser') }}">
+                <i class="fas fa-code me-2"></i>Source Browser
+            </a>
+        </div>
+    </div>
+
+    {% if columns %}
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered align-middle">
+                <thead class="table-light">
+                    <tr>
+                        {% for column in columns %}
+                            <th scope="col"><code>{{ column }}</code></th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% if rows %}
+                        {% for row in rows %}
+                            <tr>
+                                {% for column in columns %}
+                                    <td>{{ row[column] if column in row else '' }}</td>
+                                {% endfor %}
+                            </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr>
+                            <td colspan="{{ columns|length }}" class="text-center text-muted">No data available for this table.</td>
+                        </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <div class="alert alert-warning" role="alert">
+            No columns were found for this table.
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/integration/test_source_browser_page.py
+++ b/tests/integration/test_source_browser_page.py
@@ -1,7 +1,10 @@
-"""Integration tests for the source browser page."""
+"""Integration tests for the source browser and instance pages."""
 from __future__ import annotations
 
 import pytest
+
+from database import db
+from models import Variable
 
 pytestmark = pytest.mark.integration
 
@@ -38,3 +41,63 @@ def test_source_browser_displays_file_content(
     page = response.get_data(as_text=True)
     assert "Source Browser" in page
     assert "Viewer is a Flask based web application" in page
+
+
+def test_source_browser_links_to_instance_overview(
+    client,
+    login_default_user,
+):
+    """The source browser should link to the database instance overview."""
+
+    login_default_user()
+
+    response = client.get("/source")
+
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "/source/instance" in page
+    assert "Database Tables" in page
+
+
+def test_source_instance_lists_tables(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """The instance page should enumerate database tables and their columns."""
+
+    login_default_user()
+
+    response = client.get("/source/instance")
+
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "/source/instance/variable" in page
+    assert "name" in page
+
+
+def test_source_instance_table_view_displays_rows(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Viewing a specific table should render its rows in an HTML table."""
+
+    login_default_user()
+
+    with integration_app.app_context():
+        db.session.add(
+            Variable(name="example", definition="value", user_id="default-user")
+        )
+        db.session.commit()
+
+    response = client.get("/source/instance/variable")
+
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Table: <code>variable</code>" in page
+    assert "example" in page
+    assert "value" in page


### PR DESCRIPTION
## Summary
- add routes that expose a database table overview and per-table data views under /source/instance
- create templates to list tables, show their fields, and render raw table data with navigation back to the source browser
- link the source browser to the instance overview and extend integration coverage for the new pages

## Testing
- pytest -m integration tests/integration/test_source_browser_page.py

------
https://chatgpt.com/codex/tasks/task_b_68f904c0dbd083318eaf1b78b2c156d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Database Tables" view to the source browser—users can now browse available tables, examine column structures, and view row data directly.

* **Tests**
  * Expanded integration test coverage for database table browsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->