### PR TITLE
Run Ruff as part of the local test script

### DIFF
--- a/test
+++ b/test
@@ -16,6 +16,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     env = build_test_environment()
 
+    ruff_command = [sys.executable, "-m", "ruff", "check"]
+    ruff_result = subprocess.call(ruff_command, cwd=str(ROOT_DIR), env=env)
+    if ruff_result != 0:
+        return ruff_result
+
     unit_command = [str(ROOT_DIR / "test-unit"), *argv]
     unit_result = subprocess.call(unit_command, cwd=str(ROOT_DIR), env=env)
     if unit_result != 0:


### PR DESCRIPTION
## Summary
- run Ruff linting before the unit and Gauge suites in the local test runner script

## Testing
- ./test-unit -- --maxfail=1

------
https://chatgpt.com/codex/tasks/task_b_68fba980da6083319d218e82aef5620f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented a pre-test lint validation step that runs before unit tests execute. Lint validation failures halt test execution immediately, ensuring code quality standards are met prior to test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->