### PR TITLE
Add pylint linting to local and CI test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,17 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Ruff
+      - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install -r requirements.txt
+          pip install ruff pylint
 
       - name: Run Ruff
         run: ruff check .
+
+      - name: Run Pylint
+        run: pylint --errors-only .
 
   unit-tests:
     name: Unit Tests and Coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ sqlalchemy>=2.0.43
 werkzeug>=3.1.3
 python-dotenv>=1.0.0
 coverage>=7.0.0
+pylint>=3.3.1
 requests>=2.31.0
 Markdown>=3.6
 Pygments>=2.17.2

--- a/test
+++ b/test
@@ -21,6 +21,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if ruff_result != 0:
         return ruff_result
 
+    pylint_command = [sys.executable, "-m", "pylint", "--errors-only", "."]
+    pylint_result = subprocess.call(pylint_command, cwd=str(ROOT_DIR), env=env)
+    if pylint_result != 0:
+        return pylint_result
+
     unit_command = [str(ROOT_DIR / "test-unit"), *argv]
     unit_result = subprocess.call(unit_command, cwd=str(ROOT_DIR), env=env)
     if unit_result != 0:


### PR DESCRIPTION
## Summary
- add a pylint invocation to the combined test runner so local workflows catch error-level lint issues
- install pylint alongside other dependencies and wire it into the CI lint job

## Testing
- not run (pylint unavailable in container environment)

------
https://chatgpt.com/codex/tasks/task_b_68fbab91977c8331a0654926ef4e57d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with improved code linting verification.
  * Added advanced code analysis capabilities to the project toolchain.
  * Updated build process to include additional static code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->