### PR TITLE
Split lint workflow into dedicated Ruff and Pylint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ permissions:
   id-token: write
 
 jobs:
-  lint:
-    name: Ruff Lint
+  ruff:
+    name: Ruff
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +26,32 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install lint dependencies
+      - name: Install Ruff
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install ruff pylint
+          pip install ruff
 
       - name: Run Ruff
         run: ruff check .
+
+  pylint:
+    name: Pylint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Pylint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pylint
 
       - name: Run Pylint
         run: pylint --errors-only .


### PR DESCRIPTION
## Summary
- split the combined lint workflow into a dedicated Ruff job
- add a separate Pylint job that installs project dependencies before running

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fbe1b018288331b681d698cb4d3d6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration pipeline with restructured code quality checks across separate linting jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->