### PR TITLE
Add mypy checks to local and CI test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,27 @@ jobs:
       - name: Run Pylint
         run: pylint --errors-only .
 
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install mypy dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run mypy
+        run: mypy
+
   unit-tests:
     name: Unit Tests and Coverage
     runs-on: ubuntu-latest

--- a/formdown_renderer.py
+++ b/formdown_renderer.py
@@ -38,7 +38,8 @@ class FormField:
     attributes: Dict[str, str] = field(default_factory=dict)
 
 
-FormElement = Union[Heading, Paragraph, HorizontalRule, FormField]
+TextNode = Union[Heading, Paragraph, HorizontalRule]
+FormElement = Union[TextNode, FormField]
 
 
 @dataclass
@@ -47,7 +48,7 @@ class FormBlock:
     elements: List[FormElement] = field(default_factory=list)
 
 
-DocumentNode = Union[Heading, Paragraph, HorizontalRule, FormBlock]
+DocumentNode = Union[TextNode, FormBlock]
 
 
 BOOLEAN_ATTRIBUTES = {
@@ -120,7 +121,7 @@ def _parse_field_line(line: str) -> FormField:
     )
 
 
-def _parse_line_as_node(line: str) -> Optional[DocumentNode]:
+def _parse_line_as_node(line: str) -> Optional[TextNode]:
     stripped = line.strip()
     if not stripped:
         return None

--- a/glom/__init__.py
+++ b/glom/__init__.py
@@ -1,7 +1,7 @@
 """Minimal glom-compatible helpers for template execution tests."""
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 
@@ -56,7 +56,7 @@ def glom(target: Any, spec: Any) -> Any:
     current = target
 
     for step in steps:
-        if isinstance(step, Callable):
+        if callable(step):
             current = step(current)
             continue
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.12
+ignore_missing_imports = True
+show_error_codes = True
+pretty = True
+files = formdown_renderer.py, glom/__init__.py, server_templates/definitions/auto_main_shell.py
+
+[mypy-tests.*]
+disable_error_code = empty-body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ dependencies = [
     "qrcode[pil]>=7.4.2",
     "glom>=23.3.0",
     "ruff>=0.1.0",
+    "mypy>=1.13.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ werkzeug>=3.1.3
 python-dotenv>=1.0.0
 coverage>=7.0.0
 pylint>=3.3.1
+mypy>=1.13.0
 requests>=2.31.0
 Markdown>=3.6
 Pygments>=2.17.2

--- a/server_templates/definitions/auto_main_shell.py
+++ b/server_templates/definitions/auto_main_shell.py
@@ -33,7 +33,7 @@ def main(
 ):
     """Render a minimal HTML shell runner and execute submitted commands."""
 
-    shell_endpoint = endpoint or os.environ.get("SHELL_ENDPOINT", "/shell")
+    shell_endpoint: str = endpoint or os.environ.get("SHELL_ENDPOINT") or "/shell"
     command_text = command.strip() if isinstance(command, str) else ""
 
     executed = None

--- a/test
+++ b/test
@@ -21,6 +21,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if ruff_result != 0:
         return ruff_result
 
+    mypy_command = [sys.executable, "-m", "mypy"]
+    mypy_result = subprocess.call(mypy_command, cwd=str(ROOT_DIR), env=env)
+    if mypy_result != 0:
+        return mypy_result
+
     pylint_command = [sys.executable, "-m", "pylint", "--errors-only", "--ignore-patterns=^$", "*.py"]
     pylint_result = subprocess.call(pylint_command, cwd=str(ROOT_DIR), env=env)
     if pylint_result != 0:


### PR DESCRIPTION
## Summary
- add a dedicated mypy job to the CI workflow and create a shared configuration
- include mypy in the local ./test runner and fix type issues in typed modules
- record mypy as a dependency for both pip requirements and pyproject metadata

## Testing
- mypy

------
https://chatgpt.com/codex/tasks/task_b_68fbe390c3dc8331b3e0e4d4e66b3521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated static type checking into the continuous integration pipeline.
  * Updated project dependencies to support enhanced code quality assurance.

* **Bug Fixes**
  * Improved shell endpoint resolution for more robust fallback handling when environment variables are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->