### PR TITLE
Add integration test for search page filters

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,9 +2,9 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1108
+**Total Tests:** 1109
 - Unit Tests: 1057
-- Integration Tests: 39
+- Integration Tests: 40
 - Gauge Tests: 12
 
 ## Unit Tests
@@ -1071,7 +1071,7 @@ Total: 1057 tests
 
 ## Integration Tests
 
-Total: 39 tests
+Total: 40 tests
 
 - [test_alias_detail_page_displays_alias_information](tests/integration/test_alias_pages.py:62)
 - [test_aliases_page_lists_user_aliases](tests/integration/test_alias_pages.py:13)
@@ -1091,6 +1091,7 @@ Total: 39 tests
 - [test_new_variable_form_renders_for_authenticated_user](tests/integration/test_variable_pages.py:72)
 - [test_profile_page_links_to_workspace](tests/integration/test_profile_page.py:9)
 - [test_routes_overview_lists_user_routes](tests/integration/test_routes_overview_page.py:14)
+- [test_search_page_displays_filters_and_status](tests/integration/test_search_page.py:18)
 - [test_secret_detail_page_displays_secret_information](tests/integration/test_secret_pages.py:65)
 - [test_secrets_list_page_displays_user_secrets](tests/integration/test_secret_pages.py:94)
 - [test_server_detail_page_displays_server_information](tests/integration/test_server_pages.py:151)

--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -256,7 +256,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/test_routes_comprehensive.py::TestPublicRoutes::test_search_page_renders_with_filters`
 
 **Integration tests:**
-- _None_
+- `tests/integration/test_search_page.py::test_search_page_displays_filters_and_status`
 
 **Specs:**
 - _None_

--- a/tests/integration/test_search_page.py
+++ b/tests/integration/test_search_page.py
@@ -1,0 +1,37 @@
+"""Integration tests for the workspace search page."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+_DEFAULT_CATEGORIES = (
+    "aliases",
+    "servers",
+    "cids",
+    "variables",
+    "secrets",
+)
+
+
+def test_search_page_displays_filters_and_status(client, login_default_user):
+    """The search page should render with all filters enabled and helpful copy."""
+
+    login_default_user()
+
+    response = client.get("/search")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "Workspace Search" in page
+    assert "Start typing to search your workspace." in page
+    assert "id=\"search-query\"" in page
+    assert "id=\"search-endpoint\"" in page
+
+    for category in _DEFAULT_CATEGORIES:
+        assert f"id=\"filter-{category}\"" in page
+        assert f"data-search-category=\"{category}\"" in page
+        assert f"data-search-count=\"{category}\"" in page
+
+    assert "static/js/search.js" in page


### PR DESCRIPTION
## Summary
- add an integration test that verifies the workspace search page renders its filters and guidance copy
- regenerate the page-to-test cross reference to include the new coverage
- refresh the global test index to reflect the additional integration test

## Testing
- pytest tests/integration/test_search_page.py -m integration
- python generate_page_test_cross_reference.py
- python generate_test_index.py

------
https://chatgpt.com/codex/tasks/task_b_68fc413e7d748331a054653a942cfdcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for the workspace search page to validate filters, UI elements, and page functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->