### PR TITLE
Add unit coverage for source instance templates

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,14 +2,14 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1109
-- Unit Tests: 1057
+**Total Tests:** 1113
+- Unit Tests: 1061
 - Integration Tests: 40
 - Gauge Tests: 12
 
 ## Unit Tests
 
-Total: 1057 tests
+Total: 1061 tests
 
 - [AliasDefinitionTargetRenderingTests.test_describe_target_path_handles_aliases](tests/test_alias_view_definition_targets.py:40)
 - [AliasDefinitionTargetRenderingTests.test_describe_target_path_handles_cids](tests/test_alias_view_definition_targets.py:19)
@@ -456,6 +456,8 @@ Total: 1057 tests
 - [TestSettingsRoutes.test_settings_page_shows_direct_access_links](tests/test_routes_comprehensive.py:1802)
 - [TestSourceRoutes.test_source_htmlcov_serves_raw_content](tests/test_routes_comprehensive.py:1994)
 - [TestSourceRoutes.test_source_index_lists_tracked_files](tests/test_routes_comprehensive.py:1948)
+- [TestSourceRoutes.test_source_instance_overview_lists_database_tables](tests/test_routes_comprehensive.py:2017)
+- [TestSourceRoutes.test_source_instance_table_renders_existing_rows](tests/test_routes_comprehensive.py:2028)
 - [TestSourceRoutes.test_source_rejects_files_outside_project](tests/test_routes_comprehensive.py:1984)
 - [TestSourceRoutes.test_source_rejects_path_traversal](tests/test_routes_comprehensive.py:1989)
 - [TestSourceRoutes.test_source_serves_file_content](tests/test_routes_comprehensive.py:1957)
@@ -965,6 +967,8 @@ Total: 1057 tests
 - [test_source_browser_serves_comprehensive_files](tests/test_enhanced_error_pages.py:120)
 - [test_source_htmlcov_serves_raw_content](tests/test_routes_comprehensive.py:1994)
 - [test_source_index_lists_tracked_files](tests/test_routes_comprehensive.py:1948)
+- [test_source_instance_overview_lists_database_tables](tests/test_routes_comprehensive.py:2017)
+- [test_source_instance_table_renders_existing_rows](tests/test_routes_comprehensive.py:2028)
 - [test_source_link_generation_for_various_file_types](tests/test_error_page_source_links.py:172)
 - [test_source_links_open_in_new_tab](tests/test_error_page_source_links.py:312)
 - [test_source_links_use_clean_relative_paths](tests/test_error_page_path_formatting.py:72)

--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -428,7 +428,7 @@ This document maps site pages to the automated checks that exercise them.
 - `routes/source.py::source_instance_overview` (paths: `/source/instance`)
 
 **Unit tests:**
-- _None_
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_instance_overview_lists_database_tables`
 
 **Integration tests:**
 - `tests/integration/test_source_browser_page.py::test_source_instance_lists_tables`
@@ -442,7 +442,7 @@ This document maps site pages to the automated checks that exercise them.
 - `routes/source.py::source_instance_table` (paths: `/source/instance/<string:table_name>`)
 
 **Unit tests:**
-- _None_
+- `tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_instance_table_renders_existing_rows`
 
 **Integration tests:**
 - `tests/integration/test_source_browser_page.py::test_source_instance_table_view_displays_rows`

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -2014,6 +2014,32 @@ class TestSourceRoutes(BaseTestCase):
             if created_dir:
                 htmlcov_dir.rmdir()
 
+    def test_source_instance_overview_lists_database_tables(self):
+        """Instance overview should list available database tables and columns."""
+
+        response = self.client.get('/source/instance')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('Database Tables', page)
+        self.assertIn('href="/source/instance/alias"', page)
+        self.assertIn('<code>name</code>', page)
+
+    def test_source_instance_table_renders_existing_rows(self):
+        """Table detail view should render rows for a populated table."""
+
+        alias = Alias(name='overview-alias', definition='print("hi")', user_id=self.test_user_id)
+        db.session.add(alias)
+        db.session.commit()
+
+        response = self.client.get('/source/instance/alias')
+        self.assertEqual(response.status_code, 200)
+
+        page = response.get_data(as_text=True)
+        self.assertIn('<code>name</code>', page)
+        self.assertIn('overview-alias', page)
+        self.assertIn('Displaying', page)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests that exercise the source instance overview and table routes
- regenerate the page test cross reference to list the new coverage
- regenerate the consolidated test index

## Testing
- pytest tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_instance_overview_lists_database_tables tests/test_routes_comprehensive.py::TestSourceRoutes::test_source_instance_table_renders_existing_rows -q
- python generate_page_test_cross_reference.py
- python generate_test_index.py

------
https://chatgpt.com/codex/tasks/task_b_68fcb9f1e64c83319001fbae5e56edd4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for source instance overview and table rendering functionality.

* **Documentation**
  * Updated test cross-reference documentation with references to newly added tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->