### PR TITLE
Add settings page gauge coverage to cross reference

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,10 +2,10 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1113
+**Total Tests:** 1114
 - Unit Tests: 1061
 - Integration Tests: 40
-- Gauge Tests: 12
+- Gauge Tests: 13
 
 ## Unit Tests
 
@@ -1120,7 +1120,7 @@ Total: 40 tests
 
 ## Gauge Tests
 
-Total: 12 scenarios
+Total: 13 scenarios
 
 - [Aliases list shows available shortcuts](specs/alias_management.spec:21)
 - [Default workspace profile is accessible](specs/profile.spec:3)
@@ -1129,6 +1129,7 @@ Total: 12 scenarios
 - [Routes overview highlights available route types](specs/routes_overview.spec:3)
 - [Secrets list is accessible](specs/secrets.spec:3)
 - [Server events dashboard is accessible](specs/server_events.spec:3)
+- [Settings dashboard lists resource management links](specs/settings.spec:3)
 - [Source listing renders](specs/source_browser.spec:3)
 - [Users can create aliases through the form](specs/alias_management.spec:3)
 - [Users can edit existing aliases](specs/alias_management.spec:9)

--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -395,7 +395,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_settings_page.py::test_settings_page_displays_resource_counts_and_links`
 
 **Specs:**
-- _None_
+- settings.spec — Settings dashboard lists resource management links
 
 ## templates/source_browser.html
 

--- a/specs/settings.spec
+++ b/specs/settings.spec
@@ -1,0 +1,10 @@
+# Settings page
+
+## Settings dashboard lists resource management links
+* When I request the page /settings
+* The response status should be 200
+* The page should contain Settings
+* The page should contain View All Aliases
+* The page should contain View All Servers
+* The page should contain View All Variables
+* The page should contain View All Secrets

--- a/step_impl/web_steps.py
+++ b/step_impl/web_steps.py
@@ -74,6 +74,15 @@ def when_i_request_server_events_page() -> None:
     get_scenario_state()["response"] = response
 
 
+@step("When I request the page /settings")
+def when_i_request_settings_page() -> None:
+    """Request the settings dashboard page."""
+    if _client is None:
+        raise RuntimeError("Gauge test client is not initialized.")
+    response = _client.get("/settings")
+    get_scenario_state()["response"] = response
+
+
 @step("When I request the page /servers/new")
 def when_i_request_new_server_page() -> None:
     """Request the new server form page."""


### PR DESCRIPTION
## Summary
- add a Gauge spec that exercises the settings dashboard and its resource links
- expose a Gauge step for requesting `/settings` so the spec can capture the response
- regenerate the page/test cross reference and test index documentation

## Testing
- python generate_page_test_cross_reference.py
- python generate_test_index.py

------
https://chatgpt.com/codex/tasks/task_b_68fcc065e4a88331beab541c21db95ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test specification for Settings dashboard resource management links functionality, verifying the page displays Settings, View All Aliases, View All Servers, View All Variables, and View All Secrets sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->