### PR TITLE
Add search page spec coverage

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,10 +2,10 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1114
+**Total Tests:** 1115
 - Unit Tests: 1061
 - Integration Tests: 40
-- Gauge Tests: 13
+- Gauge Tests: 14
 
 ## Unit Tests
 
@@ -1120,13 +1120,14 @@ Total: 40 tests
 
 ## Gauge Tests
 
-Total: 13 scenarios
+Total: 14 scenarios
 
 - [Aliases list shows available shortcuts](specs/alias_management.spec:21)
 - [Default workspace profile is accessible](specs/profile.spec:3)
 - [Info icon links to metadata](specs/meta_navigation.spec:3)
 - [New server form is accessible](specs/server_form.spec:3)
 - [Routes overview highlights available route types](specs/routes_overview.spec:3)
+- [Search page is accessible with filters](specs/search.spec:3)
 - [Secrets list is accessible](specs/secrets.spec:3)
 - [Server events dashboard is accessible](specs/server_events.spec:3)
 - [Settings dashboard lists resource management links](specs/settings.spec:3)

--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -259,7 +259,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_search_page.py::test_search_page_displays_filters_and_status`
 
 **Specs:**
-- _None_
+- search.spec — Search page is accessible with filters
 
 ## templates/secret_form.html
 

--- a/specs/search.spec
+++ b/specs/search.spec
@@ -1,0 +1,12 @@
+# Search page
+
+## Search page is accessible with filters
+* When I request the page /search
+* The response status should be 200
+* The page should contain Workspace Search
+* The page should contain Search query
+* The page should contain Aliases
+* The page should contain Servers
+* The page should contain CIDs
+* The page should contain Variables
+* The page should contain Secrets


### PR DESCRIPTION
## Summary
- add a Gauge scenario that verifies the search page renders its filters
- regenerate the page test cross reference so the search template lists the new spec
- update the test index to include the additional Gauge scenario

## Testing
- python generate_page_test_cross_reference.py
- python generate_test_index.py

------
https://chatgpt.com/codex/tasks/task_b_68fcc904a46c83319ffd24aaee50195b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test for search page accessibility with filters, verifying the /search page loads successfully.
  * Test confirms the page contains expected search-related interface elements ("Workspace Search", "Search query", "Aliases", "Servers", "CIDs", "Variables", "Secrets").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->