### PR TITLE
Add Gauge coverage for secret form page

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,10 +2,10 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1115
+**Total Tests:** 1116
 - Unit Tests: 1061
 - Integration Tests: 40
-- Gauge Tests: 14
+- Gauge Tests: 15
 
 ## Unit Tests
 
@@ -1120,7 +1120,7 @@ Total: 40 tests
 
 ## Gauge Tests
 
-Total: 14 scenarios
+Total: 15 scenarios
 
 - [Aliases list shows available shortcuts](specs/alias_management.spec:21)
 - [Default workspace profile is accessible](specs/profile.spec:3)
@@ -1128,6 +1128,7 @@ Total: 14 scenarios
 - [New server form is accessible](specs/server_form.spec:3)
 - [Routes overview highlights available route types](specs/routes_overview.spec:3)
 - [Search page is accessible with filters](specs/search.spec:3)
+- [Secret form is accessible](specs/secret_form.spec:3)
 - [Secrets list is accessible](specs/secrets.spec:3)
 - [Server events dashboard is accessible](specs/server_events.spec:3)
 - [Settings dashboard lists resource management links](specs/settings.spec:3)

--- a/docs/page_test_cross_reference.md
+++ b/docs/page_test_cross_reference.md
@@ -277,7 +277,7 @@ This document maps site pages to the automated checks that exercise them.
 - `tests/integration/test_secret_pages.py::test_new_secret_form_renders_for_authenticated_user`
 
 **Specs:**
-- _None_
+- secret_form.spec — Secret form is accessible
 
 ## templates/secret_view.html
 

--- a/specs/secret_form.spec
+++ b/specs/secret_form.spec
@@ -1,0 +1,9 @@
+# Secret form page
+
+## Secret form is accessible
+* When I request the page /secrets/new
+* Path coverage: /secrets/new
+* The response status should be 200
+* The page should contain Create New Secret
+* The page should contain Secret Configuration
+* The page should contain Back to Secrets

--- a/step_impl/web_steps.py
+++ b/step_impl/web_steps.py
@@ -282,6 +282,13 @@ def then_page_should_contain_back_to_servers() -> None:
     assert "Back to Servers" in body, "Expected to find Back to Servers in the response body."
 
 
+@step("Path coverage: /secrets/new")
+def record_secret_form_path_coverage() -> None:
+    """Acknowledge the new secret form route for documentation coverage."""
+
+    return None
+
+
 # Import/Export steps
 @step("Given an origin site with a server named <shared-tool> returning <Hello from origin>")
 def given_an_origin_site_with_a_server_named_returning(server_name: str, server_message: str) -> None:


### PR DESCRIPTION
## Summary
- add a Gauge spec that verifies the new secret form renders with expected content
- register a path coverage step for the /secrets/new route so documentation includes the scenario
- regenerate the page test cross reference and test index to reflect the new coverage

## Testing
- python generate_page_test_cross_reference.py
- python generate_test_index.py

------
https://chatgpt.com/codex/tasks/task_b_68fccaeccec0833183af0c2b1a52f273