### PR TITLE
Add Gauge step for aliases index page

### DIFF
--- a/step_impl/web_steps.py
+++ b/step_impl/web_steps.py
@@ -119,6 +119,15 @@ def when_i_request_aliases_ai_page() -> None:
     get_scenario_state()["response"] = response
 
 
+@step("When I request the page /aliases")
+def when_i_request_aliases_index_page() -> None:
+    """Request the aliases index page."""
+    if _client is None:
+        raise RuntimeError("Gauge test client is not initialized.")
+    response = _client.get("/aliases")
+    get_scenario_state()["response"] = response
+
+
 # Content verification steps
 @step("The page should contain <text>")
 def then_page_should_contain(text: str) -> None:


### PR DESCRIPTION
## Summary
- add a dedicated Gauge step for the aliases index route so specs can call it directly

## Testing
- ./test-gauge

------
https://chatgpt.com/codex/tasks/task_b_68fcd73e5d38833188e96925be0a22c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include request scenarios for the /aliases endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->