### PR TITLE
Enhance test runner and share gauge report tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,10 +335,10 @@ jobs:
             rm -rf site/gauge-specs/reports
           fi
           python3 <<'PY'
-          import json
           from html import escape
           from pathlib import Path
-          from textwrap import dedent
+
+          from tests.gauge_report import enhance_gauge_report
           
           base = Path("site/integration-tests")
           base.mkdir(parents=True, exist_ok=True)
@@ -377,77 +377,7 @@ jobs:
           </html>
           """.format(xml_link=xml_link, log_content=log_content)
           )
-          gauge_base = Path("site/gauge-specs")
-          artifacts_dir = gauge_base / "secureapp-artifacts"
-          gauge_index = gauge_base / "index.html"
-
-          if artifacts_dir.exists() and gauge_index.exists():
-              png_files = sorted(artifacts_dir.glob("*.png"))
-              if png_files:
-                  gallery_items: list[str] = []
-                  for png_path in png_files:
-                      stem = png_path.stem
-                      json_path = artifacts_dir / f"{stem}.json"
-                      label = stem
-                      if json_path.exists():
-                          try:
-                              metadata = json.loads(json_path.read_text(encoding="utf-8"))
-                              label = metadata.get("label", stem)
-                          except json.JSONDecodeError:
-                              label = stem
-                      rel_png = png_path.relative_to(gauge_base).as_posix()
-                      rel_json = None
-                      if json_path.exists():
-                          rel_json = json_path.relative_to(gauge_base).as_posix()
-                      caption = escape(label)
-                      json_link = ""
-                      if rel_json:
-                          json_link = f' (<a href="{rel_json}">request/response</a>)'
-
-                      item_html = (
-                          "<figure class=\"gauge-screenshot\">"
-                          f'<a href="{rel_png}" target="_blank" rel="noopener">'
-                          f'<img src="{rel_png}" alt="{caption}" loading="lazy" />'
-                          "</a>"
-                          f"<figcaption>{caption}{json_link}</figcaption>"
-                          "</figure>"
-                      )
-                      gallery_items.append(item_html)
-
-                  if gallery_items:
-                      index_html = gauge_index.read_text(encoding="utf-8")
-                      if "gauge-screenshot-gallery" not in index_html:
-                          gallery_block = dedent(
-                              """
-                              <section class=\"gauge-screenshot-gallery\">
-                                <h2>Captured page screenshots</h2>
-                                <div class=\"gallery-grid\">
-                              {items}
-                                </div>
-                              </section>
-                              """
-                          ).format(items="\n".join(f"            {item}" for item in gallery_items))
-
-                          style_block = dedent(
-                              """
-                              <style>
-                              .gauge-screenshot-gallery { margin-top: 2rem; }
-                              .gauge-screenshot-gallery h2 { font-size: 1.5rem; margin-bottom: 1rem; }
-                              .gauge-screenshot-gallery .gallery-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
-                              .gauge-screenshot-gallery figure { margin: 0; }
-                              .gauge-screenshot-gallery img { width: 100%; height: auto; border: 1px solid #d0d7de; border-radius: 6px; box-shadow: 0 1px 3px rgba(27, 31, 36, 0.12); }
-                              .gauge-screenshot-gallery figcaption { margin-top: 0.5rem; font-size: 0.95rem; }
-                              .gauge-screenshot-gallery a { color: #0366d6; text-decoration: none; }
-                              .gauge-screenshot-gallery a:hover { text-decoration: underline; }
-                              </style>
-                              """
-                          )
-
-                          if "</head>" in index_html:
-                              index_html = index_html.replace("</head>", style_block + "</head>")
-                          if "</body>" in index_html:
-                              index_html = index_html.replace("</body>", gallery_block + "</body>")
-                          gauge_index.write_text(index_html, encoding="utf-8")
+          enhance_gauge_report(Path("site/gauge-specs"))
           PY
           cat <<'HTML' > site/index.html
           <!DOCTYPE html>

--- a/test
+++ b/test
@@ -1,43 +1,114 @@
 #!/usr/bin/env python3
-"""Run both the pytest suite and Gauge specifications."""
+"""Run lint checks, unit tests, integration tests, and Gauge specifications."""
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from collections.abc import Sequence
 
+from tests.gauge_report import enhance_gauge_report
 from tests.test_support import ROOT_DIR, build_test_environment
+
+_ALL_TARGETS = ("unit", "integration", "spec")
+
+
+def parse_arguments(argv: Sequence[str]) -> tuple[list[str], list[str]]:
+    parser = argparse.ArgumentParser(
+        description="Run repository checks and test suites.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        choices=_ALL_TARGETS,
+        help="Specific test suites to run. Defaults to all suites when omitted.",
+    )
+
+    if "--" in argv:
+        separator = argv.index("--")
+        passthrough = list(argv[separator + 1 :])
+        filtered = list(argv[:separator])
+    else:
+        passthrough = []
+        filtered = list(argv)
+
+    args = parser.parse_args(filtered)
+
+    selected = list(dict.fromkeys(args.targets)) or list(_ALL_TARGETS)
+
+    if passthrough and "unit" not in selected:
+        parser.error("Additional pytest arguments require running the unit tests.")
+
+    return selected, passthrough
+
+
+def run_command(command: Sequence[str], env: dict[str, str]) -> int:
+    return subprocess.call(command, cwd=str(ROOT_DIR), env=env)
+
+
+def run_lint_checks(env: dict[str, str]) -> int:
+    for command in (
+        [sys.executable, "-m", "ruff", "check"],
+        [sys.executable, "-m", "mypy"],
+        [sys.executable, "-m", "pylint", "--errors-only", "--ignore-patterns=^$", "*.py"],
+    ):
+        result = run_command(command, env)
+        if result != 0:
+            return result
+    return 0
+
+
+def run_unit_tests(env: dict[str, str], extra_args: Sequence[str]) -> int:
+    command = [str(ROOT_DIR / "test-unit")]
+    if extra_args:
+        command.append("--")
+        command.extend(extra_args)
+    return run_command(command, env)
+
+
+def run_integration_tests(env: dict[str, str]) -> int:
+    command = [str(ROOT_DIR / "run_integration_tests.py")]
+    return run_command(command, env)
+
+
+def run_spec_tests(env: dict[str, str]) -> int:
+    command = [str(ROOT_DIR / "test-gauge")]
+    result = run_command(command, env)
+    if result == 0:
+        try:
+            enhance_gauge_report(ROOT_DIR / "reports" / "html-report")
+        except Exception:  # noqa: BLE001 - best effort augmentation
+            pass
+    return result
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
+    targets, passthrough = parse_arguments(list(argv))
     env = build_test_environment()
 
-    ruff_command = [sys.executable, "-m", "ruff", "check"]
-    ruff_result = subprocess.call(ruff_command, cwd=str(ROOT_DIR), env=env)
-    if ruff_result != 0:
-        return ruff_result
+    lint_result = run_lint_checks(env)
+    if lint_result != 0:
+        return lint_result
 
-    mypy_command = [sys.executable, "-m", "mypy"]
-    mypy_result = subprocess.call(mypy_command, cwd=str(ROOT_DIR), env=env)
-    if mypy_result != 0:
-        return mypy_result
+    for target in targets:
+        if target == "unit":
+            result = run_unit_tests(env, passthrough)
+        elif target == "integration":
+            result = run_integration_tests(env)
+        elif target == "spec":
+            result = run_spec_tests(env)
+        else:  # pragma: no cover - defensive safeguard
+            raise ValueError(f"Unknown test target: {target}")
 
-    pylint_command = [sys.executable, "-m", "pylint", "--errors-only", "--ignore-patterns=^$", "*.py"]
-    pylint_result = subprocess.call(pylint_command, cwd=str(ROOT_DIR), env=env)
-    if pylint_result != 0:
-        return pylint_result
+        if result != 0:
+            return result
 
-    unit_command = [str(ROOT_DIR / "test-unit"), *argv]
-    unit_result = subprocess.call(unit_command, cwd=str(ROOT_DIR), env=env)
-    if unit_result != 0:
-        return unit_result
-
-    gauge_command = [str(ROOT_DIR / "test-gauge")]
-    return subprocess.call(gauge_command, cwd=str(ROOT_DIR), env=env)
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/gauge_report.py
+++ b/tests/gauge_report.py
@@ -1,0 +1,165 @@
+"""Utilities for enhancing Gauge HTML reports with captured artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from html import escape
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterable, Sequence
+
+_STYLE_START = "<!-- secureapp-gauge-gallery-style:start -->"
+_STYLE_END = "<!-- secureapp-gauge-gallery-style:end -->"
+_GALLERY_START = "<!-- secureapp-gauge-gallery:start -->"
+_GALLERY_END = "<!-- secureapp-gauge-gallery:end -->"
+
+
+def enhance_gauge_report(gauge_base: Path, *, artifacts_subdir: str = "secureapp-artifacts") -> bool:
+    """Inject a screenshot gallery into the Gauge report if artifacts exist.
+
+    Parameters
+    ----------
+    gauge_base:
+        Path to the directory that contains ``index.html`` for the Gauge report.
+    artifacts_subdir:
+        Name of the directory underneath ``gauge_base`` that contains the
+        captured PNG and JSON artifacts.
+
+    Returns
+    -------
+    bool
+        ``True`` if the report was updated, otherwise ``False``.
+    """
+
+    gauge_base = gauge_base.resolve()
+    index_path = gauge_base / "index.html"
+    artifacts_dir = gauge_base / artifacts_subdir
+
+    if not index_path.exists() or not artifacts_dir.exists():
+        return False
+
+    png_files = sorted(artifacts_dir.glob("*.png"))
+    if not png_files:
+        return False
+
+    gallery_items = list(_build_gallery_items(png_files, gauge_base))
+    if not gallery_items:
+        return False
+
+    index_html = index_path.read_text(encoding="utf-8")
+    index_html = _strip_marked_block(index_html, _STYLE_START, _STYLE_END)
+    index_html = _strip_marked_block(index_html, _GALLERY_START, _GALLERY_END)
+
+    style_block = dedent(
+        """
+        {start}
+        <style>
+        .gauge-screenshot-gallery {{ margin-top: 2rem; }}
+        .gauge-screenshot-gallery h2 {{ font-size: 1.5rem; margin-bottom: 1rem; }}
+        .gauge-screenshot-gallery .gallery-grid {{ display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }}
+        .gauge-screenshot-gallery figure {{ margin: 0; }}
+        .gauge-screenshot-gallery img {{ width: 100%; height: auto; border: 1px solid #d0d7de; border-radius: 6px; box-shadow: 0 1px 3px rgba(27, 31, 36, 0.12); }}
+        .gauge-screenshot-gallery figcaption {{ margin-top: 0.5rem; font-size: 0.95rem; }}
+        .gauge-screenshot-gallery a {{ color: #0366d6; text-decoration: none; }}
+        .gauge-screenshot-gallery a:hover {{ text-decoration: underline; }}
+        </style>
+        {end}
+        """
+    ).format(start=_STYLE_START, end=_STYLE_END)
+
+    gallery_block = dedent(
+        """
+        {start}
+        <section class="gauge-screenshot-gallery">
+          <h2>Captured page screenshots</h2>
+          <div class="gallery-grid">
+        {items}
+          </div>
+        </section>
+        {end}
+        """
+    ).format(
+        start=_GALLERY_START,
+        end=_GALLERY_END,
+        items="\n".join(f"            {item}" for item in gallery_items),
+    )
+
+    if "</head>" in index_html:
+        index_html = index_html.replace("</head>", style_block + "</head>")
+    else:
+        index_html = style_block + index_html
+
+    if "</body>" in index_html:
+        index_html = index_html.replace("</body>", gallery_block + "</body>")
+    else:
+        index_html += gallery_block
+
+    index_path.write_text(index_html, encoding="utf-8")
+    return True
+
+
+def _build_gallery_items(png_files: Iterable[Path], gauge_base: Path) -> Iterable[str]:
+    for png_path in png_files:
+        stem = png_path.stem
+        json_path = png_path.with_suffix(".json")
+        label = stem
+
+        if json_path.exists():
+            try:
+                metadata = json.loads(json_path.read_text(encoding="utf-8"))
+                label = str(metadata.get("label", label))
+            except json.JSONDecodeError:
+                label = stem
+
+        rel_png = png_path.relative_to(gauge_base).as_posix()
+        rel_json = json_path.relative_to(gauge_base).as_posix() if json_path.exists() else None
+
+        caption = escape(label)
+        json_link = ""
+        if rel_json:
+            json_link = f' (<a href="{rel_json}">request/response</a>)'
+
+        item_html = (
+            "<figure class=\"gauge-screenshot\">"
+            f'<a href="{rel_png}" target="_blank" rel="noopener">'
+            f'<img src="{rel_png}" alt="{caption}" loading="lazy" />'
+            "</a>"
+            f"<figcaption>{caption}{json_link}</figcaption>"
+            "</figure>"
+        )
+        yield item_html
+
+
+def _strip_marked_block(html: str, start_marker: str, end_marker: str) -> str:
+    start = html.find(start_marker)
+    while start != -1:
+        end = html.find(end_marker, start)
+        if end == -1:
+            break
+        end += len(end_marker)
+        # Remove any trailing newline to avoid accumulating blank lines.
+        slice_end = end
+        while slice_end < len(html) and html[slice_end] in "\r\n":
+            slice_end += 1
+        html = html[:start].rstrip("\r\n") + html[slice_end:]
+        start = html.find(start_marker)
+    return html
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Enhance Gauge HTML reports with screenshots.")
+    parser.add_argument("gauge_base", type=Path, help="Directory containing the Gauge index.html file.")
+    parser.add_argument(
+        "--artifacts-subdir",
+        default="secureapp-artifacts",
+        help="Relative path containing PNG and JSON artifacts.",
+    )
+    parsed = parser.parse_args(argv)
+
+    enhance_gauge_report(parsed.gauge_base, artifacts_subdir=parsed.artifacts_subdir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- allow the `./test` runner to select unit, integration, or spec suites while still running all by default
- add integration coverage to the default run and reuse a new Gauge report enhancer to embed screenshots locally and in CI

## Testing
- ./test unit -- --maxfail=1 -k doesnotexist


------
https://chatgpt.com/codex/tasks/task_b_68fd0537ec1c8331b185e691f6d7e530