### PR TITLE
Handle new Gauge archive layout in CI Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -22,15 +22,21 @@ RUN apt-get update \
 # Install Gauge CLI and required plugins
 ARG GAUGE_VERSION=1.5.6
 ARG GAUGE_DIST_URL="https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip"
-RUN curl -fsSL "${GAUGE_DIST_URL}" -o /tmp/gauge.zip \
-    && unzip /tmp/gauge.zip -d /tmp/gauge-dist \
-    && GAUGE_DIR="$(find /tmp/gauge-dist -maxdepth 1 -mindepth 1 -type d -name 'gauge-*' | head -n 1)" \
-    && [ -n "${GAUGE_DIR}" ] \
-    && mv "${GAUGE_DIR}" /opt/gauge \
-    && ln -s /opt/gauge/bin/gauge /usr/local/bin/gauge \
-    && rm -rf /tmp/gauge.zip /tmp/gauge-dist \
-    && gauge install python \
-    && gauge install html-report
+RUN set -eux; \
+    curl -fsSL "${GAUGE_DIST_URL}" -o /tmp/gauge.zip; \
+    unzip /tmp/gauge.zip -d /tmp/gauge-dist; \
+    if GAUGE_DIR="$(find /tmp/gauge-dist -maxdepth 1 -mindepth 1 -type d -name 'gauge-*' | head -n 1)" && [ -n "${GAUGE_DIR}" ]; then \
+        mv "${GAUGE_DIR}" /opt/gauge; \
+    elif [ -f /tmp/gauge-dist/gauge ]; then \
+        install -Dm755 /tmp/gauge-dist/gauge /opt/gauge/bin/gauge; \
+    else \
+        echo "Unexpected Gauge archive layout" >&2; \
+        exit 1; \
+    fi; \
+    ln -s /opt/gauge/bin/gauge /usr/local/bin/gauge; \
+    rm -rf /tmp/gauge.zip /tmp/gauge-dist; \
+    gauge install python; \
+    gauge install html-report
 
 # Install Python dependencies used in CI
 COPY requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
## Summary
- handle both directory-based and single-binary Gauge release archives when installing the CLI in the CI Docker image

## Testing
- docker build -f docker/ci/Dockerfile . *(fails: Docker not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68fd951815548331be228d28ec05b58d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI Docker image installation process with improved error handling and detection mechanisms, resulting in more resilient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->