### PR TITLE
Add explicit Gauge step definitions for literal spec phrases

### DIFF
--- a/step_impl/alias_steps.py
+++ b/step_impl/alias_steps.py
@@ -186,6 +186,13 @@ def given_alias_exists(alias_name: str, target_path: str) -> None:
     _scenario_state["alias_name"] = alias_name
 
 
+@step('Given there is an alias named <docs> pointing to /guides')
+def ypefci(docs: str) -> None:
+    """Specialised fixture for an alias pointing to /guides."""
+
+    given_alias_exists(docs, "/guides")
+
+
 @step("When I visit <path>")
 def when_i_visit_path(path: str) -> None:
     """Perform a GET request against the provided path."""
@@ -196,6 +203,13 @@ def when_i_visit_path(path: str) -> None:
     _scenario_state["last_path"] = path
     attach_response_snapshot(response)
     assert response.status_code == 200, f"Expected GET {path} to succeed."
+
+
+@step("When I visit /aliases/docs/edit")
+def ypdcaf() -> None:
+    """Load the edit page for the docs alias."""
+
+    when_i_visit_path("/aliases/docs/edit")
 
 
 @step("Then I can update the alias target and save the changes")
@@ -226,6 +240,13 @@ def then_update_alias_target() -> None:
         assert alias is not None, "Alias was not found after attempting to update it."
         expected_target = f"/{alias_name}/updated"
         assert alias.target_path == expected_target, "Alias target path did not update."
+
+
+@step("Path coverage: /aliases/ai")
+def aplfaz() -> None:
+    """Acknowledge the /aliases/ai route for documentation coverage."""
+
+    record_alias_path_coverage("ai")
 
 
 @step("Path coverage: /aliases")

--- a/step_impl/source_steps.py
+++ b/step_impl/source_steps.py
@@ -70,6 +70,13 @@ def then_response_contains(text: str) -> None:
     assert text in body, f"Expected to find {text!r} in the response body."
 
 
+@step("The response should contain Source Browser")
+def the_response_should_contain_source_browser() -> None:
+    """Verify the source browser page renders the expected heading."""
+
+    then_response_contains("Source Browser")
+
+
 @step("The page should contain <text>")
 def then_page_should_contain(text: str) -> None:
     response = get_scenario_state().get("response")

--- a/step_impl/web_steps.py
+++ b/step_impl/web_steps.py
@@ -49,6 +49,18 @@ def reset_scenario_store() -> None:
     clear_scenario_state()
 
 
+# Shared assertions
+@step("The response status should be 200")
+def the_response_status_should_be_200() -> None:
+    """Validate that the captured response completed successfully."""
+
+    response = get_scenario_state().get("response")
+    assert response is not None, "No response recorded. Call `When I request ...` first."
+    assert (
+        response.status_code == 200
+    ), f"Expected HTTP 200 but received {response.status_code} for {response.request.path!r}."
+
+
 # Page request steps
 @step("When I request the page /")
 def when_i_request_home_page() -> None:
@@ -430,6 +442,34 @@ def record_server_view_path_coverage(server_name: str) -> None:  # noqa: ARG001 
     """Acknowledge the server detail route for documentation coverage."""
 
     return None
+
+
+@step("Given there is a server named weather returning Weather forecast ready")
+def given_there_is_a_server_named_weather_returning_weather_forecast_ready() -> None:
+    """Create a weather server fixture returning the expected message."""
+
+    given_server_exists("weather", "Weather forecast ready")
+
+
+@step("When I request the page /servers/weather")
+def pvipha() -> None:
+    """Request the weather server detail page."""
+
+    when_i_request_server_detail_page("weather")
+
+
+@step("The page should contain Edit Server")
+def the_page_should_contain_edit_server() -> None:
+    """Assert that the response body lists the Edit Server action."""
+
+    then_page_should_contain("Edit Server")
+
+
+@step("The page should contain Server Definition")
+def the_page_should_contain_server_definition() -> None:
+    """Assert that the response body displays the server definition."""
+
+    then_page_should_contain("Server Definition")
 
 
 # Import/Export steps


### PR DESCRIPTION
## Summary
- add dedicated Gauge steps for shared HTTP status assertions and server detail checks
- wire alias management specs to explicit steps for fixture setup, edit navigation, and path coverage
- expose a convenience step to verify the Source Browser heading

## Testing
- pytest tests/test_source_spec_report.py -q

------
https://chatgpt.com/codex/tasks/task_b_68fe26d385cc8331913062fcb72b8679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for alias management functionality, including creating aliases and accessing alias edit pages.
  * Added verification for Source Browser presence in responses.
  * Expanded server management testing with response status assertions and server detail page validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->