### PR TITLE
Allow Pages deployment after failed test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,12 +249,7 @@ jobs:
       - unit-tests
       - integration-tests
       - gauge-specs
-    if: >-
-      ${{ github.event_name == 'push' &&
-          github.ref == 'refs/heads/main' &&
-          needs['unit-tests'].result == 'success' &&
-          needs['integration-tests'].result == 'success' &&
-          needs['gauge-specs'].result == 'success' }}
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
@@ -265,18 +260,21 @@ jobs:
     steps:
       - name: Download unit test report
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: unit-tests-html
           path: site/unit-tests
 
       - name: Download Gauge report
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: gauge-html
           path: site/gauge-specs
 
       - name: Download integration test results
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: integration-tests-results
           path: site/integration-tests


### PR DESCRIPTION
## Summary
- allow the GitHub Pages deployment job to run on pushes to main even when earlier test jobs fail
- make report artifact downloads tolerant of missing files so publishing still succeeds

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68fe44e057dc83319f633470eacdd17b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow robustness by improving deployment reliability and tolerating missing artifacts without workflow interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->