### PR TITLE
Ensure deploy job can import gauge helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download unit test report
         uses: actions/download-artifact@v4
         continue-on-error: true


### PR DESCRIPTION
## Summary
- check out the repository in the publish job so helper modules are available while building the report site

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68fe5d71512c8331891895f17fe16fb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to enhance deployment process reliability by adding a repository checkout step before artifact download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->