### PR TITLE
Add reusable test index check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,7 @@ jobs:
         run: python generate_test_index.py
 
       - name: Check if test index is up to date
-        run: |
-          if ! git diff --exit-code TEST_INDEX.md; then
-            echo "Error: TEST_INDEX.md is out of date!"
-            echo "Please run 'python generate_test_index.py' and commit the changes."
-            exit 1
-          fi
-          echo "Test index is up to date."
+        run: bash scripts/check-test-index.sh
 
   unit-tests:
     name: Unit Tests and Coverage

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
 * `test` – invoke both `test-unit` and `test-gauge` sequentially.
 * `run_integration_tests.py` – execute only the integration tests under `tests/integration`.
 * `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
+* `scripts/check-test-index.sh` – verify `TEST_INDEX.md` matches the output of `python generate_test_index.py` so you can catch
+  drift locally before pushing changes.
 
 ### Gauge specs
 

--- a/scripts/check-test-index.sh
+++ b/scripts/check-test-index.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git diff --exit-code TEST_INDEX.md; then
+  echo "Error: TEST_INDEX.md is out of date!"
+  echo "Please run 'python generate_test_index.py' and commit the changes."
+  exit 1
+fi
+
+echo "Test index is up to date."


### PR DESCRIPTION
## Summary
- move the test index validation into scripts/check-test-index.sh for reuse
- update the CI workflow to call the shared script
- document the script so contributors can run the check locally

## Testing
- not run (not needed for this change)


------
https://chatgpt.com/codex/tasks/task_b_68fe62b3c5848331bd197cf0ef0f625f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new test index validation script.

* **Chores**
  * Updated CI workflow to use an external validation script for test index checks.
  * Added a new script to validate test index consistency locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->