### PR TITLE
Add integration summary helper script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,23 +171,9 @@ jobs:
       - name: Publish integration summary
         if: always()
         run: |
-          if [ -f integration-tests.log ]; then
-            {
-              echo "### Integration tests"
-              echo
-              echo '```'
-              tail -n 50 integration-tests.log
-              echo '```'
-              echo
-              echo "JUnit XML: integration-tests-report.xml"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "### Integration tests"
-              echo
-              echo "No integration test log was produced."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          python scripts/publish_integration_summary.py \
+            --log integration-tests.log \
+            --junit integration-tests-report.xml
 
       - name: Upload integration test artifacts
         if: always()

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
 * `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
 * `scripts/check-test-index.sh` – verify `TEST_INDEX.md` matches the output of `python generate_test_index.py` so you can catch
   drift locally before pushing changes.
+* `scripts/publish_integration_summary.py` – reproduce the CI integration summary by tailing the most recent log output. After
+  running `python run_integration_tests.py -- --junitxml=integration-tests-report.xml | tee integration-tests.log`, invoke
+  `python scripts/publish_integration_summary.py --log integration-tests.log --junit integration-tests-report.xml` to preview
+  the summary locally. Omit `--summary` to print to the terminal or pass a path to write the output to a file for inspection.
 
 ### Gauge specs
 

--- a/scripts/publish_integration_summary.py
+++ b/scripts/publish_integration_summary.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Generate the integration test summary used in CI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_TAIL_LINES = 50
+
+
+def tail_lines(path: Path, limit: int) -> Iterable[str]:
+    """Return up to the last ``limit`` lines from ``path``."""
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        lines = handle.readlines()
+    return lines[-limit:]
+
+
+def build_summary(log_path: Path | None, junit_path: Path | None, tail_count: int) -> str:
+    lines: list[str] = ["### Integration tests", ""]
+
+    if log_path and log_path.is_file():
+        lines.append("```")
+        lines.extend(line.rstrip("\n") for line in tail_lines(log_path, tail_count))
+        lines.append("```")
+        lines.append("")
+        if junit_path:
+            lines.append(f"JUnit XML: {junit_path}")
+    else:
+        lines.append("No integration test log was produced.")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(content: str, summary_path: Path | None) -> None:
+    if summary_path:
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write(content)
+    else:
+        print(content, end="")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log",
+        type=Path,
+        help="Path to the integration test log file.",
+    )
+    parser.add_argument(
+        "--junit",
+        type=Path,
+        help="Path to the generated JUnit XML report.",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=os.environ.get("GITHUB_STEP_SUMMARY"),
+        help="File to append the summary to. Defaults to the GITHUB_STEP_SUMMARY output in CI.",
+    )
+    parser.add_argument(
+        "--tail-lines",
+        type=int,
+        default=DEFAULT_TAIL_LINES,
+        help=f"Number of log lines to include. Defaults to {DEFAULT_TAIL_LINES}.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    summary_content = build_summary(args.log, args.junit, args.tail_lines)
+    write_summary(summary_content, args.summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable script for generating the integration log summary used in CI
- update the workflow to call the helper so GitHub Step Summaries stay consistent
- document how to preview the integration summary locally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68fe65922220833194608649153c49a2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow by refactoring integration test summary handling into a dedicated external script for better maintainability

* **Documentation**
  * Added documentation for the integration test summary publication script, including usage instructions and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->