### PR TITLE
Add missing path coverage step for weather server spec

### DIFF
--- a/step_impl/web_steps.py
+++ b/step_impl/web_steps.py
@@ -444,6 +444,13 @@ def record_server_view_path_coverage(server_name: str) -> None:  # noqa: ARG001 
     return None
 
 
+@step("Path coverage: /servers/weather")
+def record_weather_server_path_coverage() -> None:
+    """Acknowledge the weather server detail route for documentation coverage."""
+
+    record_server_view_path_coverage("weather")
+
+
 @step("Given there is a server named weather returning Weather forecast ready")
 def given_there_is_a_server_named_weather_returning_weather_forecast_ready() -> None:
     """Create a weather server fixture returning the expected message."""


### PR DESCRIPTION
## Summary
- add a gauge step to record path coverage for the weather server route
- reuse the existing generic server path coverage helper for this specific path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68fe6587819883318664e40fa573bb12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added path coverage tracking for weather service endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->