### PR TITLE
Add script to publish coverage summary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,25 +109,7 @@ jobs:
       - name: Publish coverage summary
         id: coverage
         if: always()
-        run: |
-          if [ -f "coverage-report.txt" ]; then
-            cat coverage-report.txt
-            {
-              echo "### Coverage summary"
-              echo '```'
-              cat coverage-report.txt
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "generated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No coverage data found. Tests may not have run." | tee coverage-report.txt
-            {
-              echo "### Coverage summary"
-              echo
-              echo "No coverage data was generated."
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "generated=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: ./scripts/publish-coverage-summary.sh coverage-report.txt
 
       - name: Upload coverage XML
         if: always() && steps.coverage.outputs.generated == 'true'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
 * `run_coverage.py` – execute the test suite with coverage analysis and optional HTML/XML reports.
 * `scripts/check-test-index.sh` – verify `TEST_INDEX.md` matches the output of `python generate_test_index.py` so you can catch
   drift locally before pushing changes.
+* `scripts/publish-coverage-summary.sh` – format the most recent coverage report from `test-unit/coverage.txt` (falling back to
+  `coverage-report.txt`) and append the result to the GitHub Actions step summary when invoked in CI.
+
+To replicate the CI coverage summary locally, run the unit tests with coverage output and then feed the resulting report to the
+script::
+
+    ./test-unit --coverage --summary-file coverage-report.txt
+    ./scripts/publish-coverage-summary.sh coverage-report.txt
 
 ### Gauge specs
 

--- a/scripts/publish-coverage-summary.sh
+++ b/scripts/publish-coverage-summary.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUMMARY_FILE="${1:-test-unit/coverage.txt}"
+
+if [[ ! -f "${SUMMARY_FILE}" && "${SUMMARY_FILE}" == "test-unit/coverage.txt" && -f "coverage-report.txt" ]]; then
+  SUMMARY_FILE="coverage-report.txt"
+fi
+
+if [[ -f "${SUMMARY_FILE}" ]]; then
+  cat "${SUMMARY_FILE}"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Coverage summary"
+      echo '```'
+      cat "${SUMMARY_FILE}"
+      echo '```'
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "generated=true" >> "${GITHUB_OUTPUT}"
+  fi
+else
+  message="No coverage data found. Tests may not have run."
+  echo "${message}"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### Coverage summary"
+      echo
+      echo "No coverage data was generated."
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "generated=false" >> "${GITHUB_OUTPUT}"
+  fi
+fi


### PR DESCRIPTION
## Summary
- add a reusable `scripts/publish-coverage-summary.sh` helper that prints the coverage summary and updates GitHub step metadata
- update the unit-test workflow to invoke the helper and document local usage in the README

## Testing
- ./scripts/publish-coverage-summary.sh

------
https://chatgpt.com/codex/tasks/task_b_68fe639890d88331981f3df2ff2525db