### PR TITLE
Add reusable coverage summary publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,24 +110,10 @@ jobs:
         id: coverage
         if: always()
         run: |
-          if [ -f "coverage-report.txt" ]; then
-            cat coverage-report.txt
-            {
-              echo "### Coverage summary"
-              echo '```'
-              cat coverage-report.txt
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "generated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No coverage data found. Tests may not have run." | tee coverage-report.txt
-            {
-              echo "### Coverage summary"
-              echo
-              echo "No coverage data was generated."
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "generated=false" >> "$GITHUB_OUTPUT"
-          fi
+          scripts/publish-coverage-summary.sh \
+            coverage-report.txt \
+            "${GITHUB_STEP_SUMMARY:-}" \
+            "${GITHUB_OUTPUT:-}"
 
       - name: Upload coverage XML
         if: always() && steps.coverage.outputs.generated == 'true'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ python run_coverage.py --xml --html  # run tests with coverage reports (optional
   running `python run_integration_tests.py -- --junitxml=integration-tests-report.xml | tee integration-tests.log`, invoke
   `python scripts/publish_integration_summary.py --log integration-tests.log --junit integration-tests-report.xml` to preview
   the summary locally. Omit `--summary` to print to the terminal or pass a path to write the output to a file for inspection.
+* `scripts/publish-coverage-summary.sh` – mirror the CI coverage summary step. After producing a report with
+  `./test-unit --coverage --summary-file coverage-report.txt`, run
+  `scripts/publish-coverage-summary.sh coverage-report.txt coverage-summary.md coverage-output.txt` to print the summary,
+  append the Markdown block to `coverage-summary.md`, and capture the generated flag. Omit the extra arguments to fall back to
+  `GITHUB_STEP_SUMMARY` and `GITHUB_OUTPUT` when running inside GitHub Actions.
 
 ### Gauge specs
 

--- a/scripts/publish-coverage-summary.sh
+++ b/scripts/publish-coverage-summary.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "Usage: $0 <report-path> [summary-path] [outputs-path]" >&2
+  exit 1
+fi
+
+report_path="$1"
+summary_target="${2:-${GITHUB_STEP_SUMMARY:-}}"
+outputs_target="${3:-${GITHUB_OUTPUT:-}}"
+
+gh_summary_available=false
+if command -v gh >/dev/null 2>&1 && gh summary --help >/dev/null 2>&1; then
+  gh_summary_available=true
+fi
+
+append_summary() {
+  if [[ -n "${summary_target:-}" ]]; then
+    cat >>"$summary_target"
+  elif [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat >>"$GITHUB_STEP_SUMMARY"
+  elif [[ "$gh_summary_available" == "true" ]]; then
+    local tmp
+    tmp=$(mktemp)
+    cat >"$tmp"
+    gh summary --append "$tmp" >/dev/null
+    rm -f "$tmp"
+  else
+    cat
+  fi
+}
+
+set_output() {
+  local value="$1"
+  if [[ -n "${outputs_target:-}" ]]; then
+    printf '%s\n' "$value" >>"$outputs_target"
+  elif [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s\n' "$value" >>"$GITHUB_OUTPUT"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+if [[ -f "$report_path" ]]; then
+  cat "$report_path"
+  {
+    echo "### Coverage summary"
+    echo '```'
+    cat "$report_path"
+    echo '```'
+  } | append_summary
+  set_output "generated=true"
+else
+  message="No coverage data found. Tests may not have run."
+  echo "$message" | tee "$report_path"
+  {
+    echo "### Coverage summary"
+    echo
+    echo "No coverage data was generated."
+  } | append_summary
+  set_output "generated=false"
+fi


### PR DESCRIPTION
## Summary
- add a scripts/publish-coverage-summary.sh helper that mirrors the CI coverage summary logic and works locally
- call the new helper from the GitHub Actions workflow so the step can be shared between environments
- document how to preview the coverage summary locally in the project README

## Testing
- scripts/publish-coverage-summary.sh /tmp/coverage-report.txt /tmp/summary.md /tmp/output.txt

------
https://chatgpt.com/codex/tasks/task_b_68fe68ac844c8331a0dca2a3ea45786b