### PR TITLE
Update CI image usage to rely on preinstalled dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
 
     steps:
       - name: Checkout repository
@@ -45,7 +45,7 @@ jobs:
     name: Pylint
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
 
     steps:
       - name: Checkout repository
@@ -58,7 +58,7 @@ jobs:
     name: Mypy
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
 
     steps:
       - name: Checkout repository
@@ -90,7 +90,7 @@ jobs:
     name: Unit Tests and Coverage
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
     env:
       DATABASE_URL: sqlite:////tmp/secureapp-ci.db
       SESSION_SECRET: test-secret-key
@@ -138,16 +138,13 @@ jobs:
     name: Property Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
     env:
       HYPOTHESIS_PROFILE: ci
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
 
       - name: Run property tests
         run: pytest property_tests
@@ -156,7 +153,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
     env:
       DATABASE_URL: sqlite:////tmp/secureapp-ci.db
       SESSION_SECRET: test-secret-key
@@ -197,7 +194,7 @@ jobs:
     name: Gauge Specs
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
     env:
       DATABASE_URL: sqlite:////tmp/secureapp-ci.db
       SESSION_SECRET: test-secret-key
@@ -237,7 +234,7 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
+      image: ${{ env.CI_IMAGE }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eux; \
 
 # Install Python dependencies used in CI
 COPY requirements.txt /tmp/requirements.txt
-RUN python -m pip install --upgrade pip \
-    && pip install -r /tmp/requirements.txt
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- ensure all CI jobs reference the shared container image via the CI_IMAGE environment variable
- remove the per-run dependency installation from the property test job now that the image includes requirements
- bake pip, setuptools, wheel, and project requirements into the Docker image for CI

## Testing
- Not run (proxy prevents installing test dependencies locally)


------
https://chatgpt.com/codex/tasks/task_b_68fe9bf11b6c8331a5a85246ec8b265b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI infrastructure by centralizing container image references to use environment-based configuration, enhancing runtime flexibility across all test and deployment workflows.
  * Enhanced CI dependency installation with package version upgrades and cache optimization to accelerate build times.
  * Streamlined CI workflow by removing unnecessary duplicate dependency installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->