### PR TITLE
Ensure Hypothesis dependencies are installed in CI image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -41,6 +41,7 @@ RUN set -eux; \
 # Install Python dependencies used in CI
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --upgrade pip \
-    && pip install -r /tmp/requirements.txt
+    && pip install -r /tmp/requirements.txt \
+    && pip install hypothesis pytest
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- ensure the CI Docker image installs Hypothesis and pytest so property tests are available

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68fea44ab5148331846540e3d9afbbdd