### PR TITLE
Publish property test results in CI reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,27 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Run property tests
-        run: pytest tests/property
+        id: run_property_tests
+        run: |
+          set -o pipefail
+          pytest tests/property \
+            --junitxml=property-tests-report.xml \
+            | tee property-tests.log
+        continue-on-error: true
+
+      - name: Upload property test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: property-tests-results
+          path: |
+            property-tests-report.xml
+            property-tests.log
+          if-no-files-found: warn
+
+      - name: Fail if property tests failed
+        if: steps.run_property_tests.outcome == 'failure'
+        run: exit 1
 
   integration-tests:
     name: Integration Tests
@@ -234,6 +254,7 @@ jobs:
       - unit-tests
       - integration-tests
       - gauge-specs
+      - property-tests
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     container:
@@ -267,12 +288,20 @@ jobs:
           name: integration-tests-results
           path: site/integration-tests
 
+      - name: Download property test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: property-tests-results
+          path: site/property-tests
+
       - name: Prepare site content
         run: |
           python scripts/build-report-site.py \
             --unit-tests-artifacts site/unit-tests \
             --gauge-artifacts site/gauge-specs \
             --integration-artifacts site/integration-tests \
+            --property-artifacts site/property-tests \
             --output site
 
       - name: Upload artifact for GitHub Pages


### PR DESCRIPTION
## Summary
- capture JUnit XML and log output for the property tests during CI
- include the property test artifacts when publishing the GitHub Pages reports
- extend the report site generator to render a property test summary and log

## Testing
- python -m compileall scripts/build-report-site.py

------
https://chatgpt.com/codex/tasks/task_b_68feac8e8ca88331bc7f7706fde221b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Property tests are now integrated into the CI workflow with automated artifact collection and reporting.
  * Property test results are published and accessible via the project report site alongside other test metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->