### PR TITLE
Serve raw content for bare CID requests

### DIFF
--- a/TEST_INDEX.md
+++ b/TEST_INDEX.md
@@ -2,10 +2,10 @@
 
 This index lists all tests in the project, organized by type.
 
-**Total Tests:** 1147
+**Total Tests:** 1149
 - Unit Tests: 1087
 - Integration Tests: 40
-- Property Tests: 4
+- Property Tests: 6
 - Gauge Tests: 16
 
 ## Unit Tests
@@ -137,24 +137,24 @@ Total: 1087 tests
 - [Test dashboard redirects users without access to profile.](tests/test_routes_comprehensive.py:603)
 - [Display a metadata inspector shortcut in the site navigation.](tests/test_routes_comprehensive.py:624)
 - [Test profile page.](tests/test_routes_comprehensive.py:618)
-- [Test that CID model only has the required fields](tests/test_cid_functionality.py:499)
+- [Test that CID model only has the required fields](tests/test_cid_functionality.py:493)
 - [Test creating CID record with all required fields](tests/test_cid_functionality.py:147)
 - [Test that CID generation produces expected hash](tests/test_cid_functionality.py:72)
 - [Test that CID generation only uses file data, not MIME type](tests/test_cid_functionality.py:51)
-- [The QR code helper should build PNG data using the qrcode library API.](tests/test_cid_functionality.py:384)
+- [The QR code helper should build PNG data using the qrcode library API.](tests/test_cid_functionality.py:378)
 - [Test MIME type detection from file extensions](tests/test_cid_functionality.py:87)
-- [TestCIDFunctionality.test_markdown_heuristic_balances_inline_and_structural_cues](tests/test_cid_functionality.py:567)
-- [TestCIDFunctionality.test_markdown_heuristic_ignores_plain_python_text](tests/test_cid_functionality.py:571)
-- [Test that proper caching headers are set for CID content](tests/test_cid_functionality.py:436)
-- [Test ETag-based caching returns 304 when content hasn't changed](tests/test_cid_functionality.py:468)
-- [Requests with a .qr extension should render a QR code landing page.](tests/test_cid_functionality.py:341)
+- [TestCIDFunctionality.test_markdown_heuristic_balances_inline_and_structural_cues](tests/test_cid_functionality.py:561)
+- [TestCIDFunctionality.test_markdown_heuristic_ignores_plain_python_text](tests/test_cid_functionality.py:565)
+- [Test that proper caching headers are set for CID content](tests/test_cid_functionality.py:430)
+- [Test ETag-based caching returns 304 when content hasn't changed](tests/test_cid_functionality.py:462)
+- [Requests with a .qr extension should render a QR code landing page.](tests/test_cid_functionality.py:335)
 - [Test serving CID content with file extension for MIME type detection](tests/test_cid_functionality.py:173)
-- [Test that serving None CID record returns None](tests/test_cid_functionality.py:560)
-- [Test that serving CID content with None file_data returns None (fixed behavior)](tests/test_cid_functionality.py:537)
+- [Test that serving None CID record returns None](tests/test_cid_functionality.py:554)
+- [Test that serving CID content with None file_data returns None (fixed behavior)](tests/test_cid_functionality.py:531)
 - [CID content requested with .txt extension should render as UTF-8 text when possible.](tests/test_cid_functionality.py:243)
 - [Test serving CID content without extension defaults to UTF-8 text when possible.](tests/test_cid_functionality.py:210)
 - [Plain source files without Markdown cues should not be rendered.](tests/test_cid_functionality.py:270)
-- [Markdown content without an extension should render to HTML.](tests/test_cid_functionality.py:299)
+- [Markdown content without an extension should be served without rendering.](tests/test_cid_functionality.py:299)
 - [Test CID generation with binary content](tests/test_cid_generation.py:110)
 - [Test that generated CIDs have the correct format](tests/test_cid_generation.py:66)
 - [Test helper functions that validate and parse CID values.](tests/test_cid_generation.py:218)
@@ -417,9 +417,9 @@ Total: 1087 tests
 - [TestServeCidContent.test_conditional_requests_with_filename](tests/test_serve_cid_content.py:126)
 - [TestServeCidContent.test_content_with_none_file_data_returns_none](tests/test_serve_cid_content.py:112)
 - [TestServeCidContent.test_edge_cases](tests/test_serve_cid_content.py:77)
-- [TestServeCidContent.test_explicit_markdown_html_extension_renders_markdown](tests/test_serve_cid_content.py:157)
+- [TestServeCidContent.test_explicit_markdown_html_extension_renders_markdown](tests/test_serve_cid_content.py:156)
 - [TestServeCidContent.test_filename_with_special_characters](tests/test_serve_cid_content.py:94)
-- [TestServeCidContent.test_markdown_without_extension_renders_html_document](tests/test_serve_cid_content.py:143)
+- [TestServeCidContent.test_markdown_without_extension_serves_raw_content](tests/test_serve_cid_content.py:143)
 - [TestServeCidContent.test_none_content_returns_none](tests/test_serve_cid_content.py:108)
 - [Definition validation remains accessible in the default workspace.](tests/test_server_definition_validation_route.py:104)
 - [Unsupported auto main signatures should include helpful reasons.](tests/test_server_definition_validation_route.py:82)
@@ -566,7 +566,7 @@ Total: 1087 tests
 - [Test helper functions that validate and parse CID values.](tests/test_cid_generation.py:218)
 - [test_cid_lookup_helpers](tests/test_db_access.py:301)
 - [Simulate the CID lookup with the fix](tests/test_fix_validation.py:33)
-- [Test that CID model only has the required fields](tests/test_cid_functionality.py:499)
+- [Test that CID model only has the required fields](tests/test_cid_functionality.py:493)
 - [test_cid_only_no_content_disposition](tests/test_serve_cid_content.py:28)
 - [Test /{CID} - should return None (no content disposition)](tests/test_content_disposition.py:46)
 - [Test /{CID} - should return None](tests/test_serve_cid_integration.py:20)
@@ -709,7 +709,7 @@ Total: 1087 tests
 - [test_execute_functions_share_error_flow](tests/test_server_execution_output_encoding.py:162)
 - [test_execute_functions_share_success_flow](tests/test_server_execution_output_encoding.py:141)
 - [Test what should happen with variables and secrets](tests/test_variables_secrets_simple.py:74)
-- [test_explicit_markdown_html_extension_renders_markdown](tests/test_serve_cid_content.py:157)
+- [test_explicit_markdown_html_extension_renders_markdown](tests/test_serve_cid_content.py:156)
 - [test_export_allows_runtime_only](tests/test_import_export.py:249)
 - [test_export_excludes_unreferenced_cids_by_default](tests/test_import_export.py:306)
 - [test_export_excludes_virtualenv_python_files](tests/test_import_export.py:444)
@@ -754,7 +754,7 @@ Total: 1087 tests
 - [Test CID generation function.](tests/test_routes_comprehensive.py:97)
 - [Test that CID generation produces expected hash](tests/test_cid_functionality.py:72)
 - [Test that CID generation only uses file data, not MIME type](tests/test_cid_functionality.py:51)
-- [The QR code helper should build PNG data using the qrcode library API.](tests/test_cid_functionality.py:384)
+- [The QR code helper should build PNG data using the qrcode library API.](tests/test_cid_functionality.py:378)
 - [Test with complex definition including options.](tests/test_db_access_alias_integration.py:149)
 - [Test when alias has empty definition.](tests/test_db_access_alias_integration.py:112)
 - [Test with multi-line definition (should use primary rule).](tests/test_db_access_alias_integration.py:128)
@@ -839,9 +839,9 @@ Total: 1087 tests
 - [load() should return raw bytes when encoding is disabled.](tests/test_text_function_runner.py:283)
 - [test_make_session_permanent_marks_session](tests/test_analytics.py:44)
 - [Test that the CID matches expected hash calculation](tests/test_cid_generation.py:154)
-- [test_markdown_heuristic_balances_inline_and_structural_cues](tests/test_cid_functionality.py:567)
-- [test_markdown_heuristic_ignores_plain_python_text](tests/test_cid_functionality.py:571)
-- [test_markdown_without_extension_renders_html_document](tests/test_serve_cid_content.py:143)
+- [test_markdown_heuristic_balances_inline_and_structural_cues](tests/test_cid_functionality.py:561)
+- [test_markdown_heuristic_ignores_plain_python_text](tests/test_cid_functionality.py:565)
+- [test_markdown_without_extension_serves_raw_content](tests/test_serve_cid_content.py:143)
 - [test_mermaid_fenced_block_renders_to_svg_image](tests/test_markdown_rendering.py:133)
 - [test_mermaid_renderer_falls_back_to_remote_svg_on_error](tests/test_markdown_rendering.py:154)
 - [test_meta_route_handles_versioned_server_multiple_matches](tests/test_meta_route.py:267)
@@ -960,17 +960,17 @@ Total: 1087 tests
 - [Search results should highlight matches across every enabled category.](tests/test_routes_comprehensive.py:382)
 - [Test secrets list page.](tests/test_routes_comprehensive.py:1661)
 - [Test the serialize_model_objects function](tests/test_serialization_fix.py:55)
-- [Test that proper caching headers are set for CID content](tests/test_cid_functionality.py:436)
-- [Test ETag-based caching returns 304 when content hasn't changed](tests/test_cid_functionality.py:468)
+- [Test that proper caching headers are set for CID content](tests/test_cid_functionality.py:430)
+- [Test ETag-based caching returns 304 when content hasn't changed](tests/test_cid_functionality.py:462)
 - [Analyze the serve_cid_content function logic](tests/test_cid_serving_issue.py:69)
-- [Requests with a .qr extension should render a QR code landing page.](tests/test_cid_functionality.py:341)
+- [Requests with a .qr extension should render a QR code landing page.](tests/test_cid_functionality.py:335)
 - [Test serving CID content with file extension for MIME type detection](tests/test_cid_functionality.py:173)
-- [Test that serving None CID record returns None](tests/test_cid_functionality.py:560)
-- [Test that serving CID content with None file_data returns None (fixed behavior)](tests/test_cid_functionality.py:537)
+- [Test that serving None CID record returns None](tests/test_cid_functionality.py:554)
+- [Test that serving CID content with None file_data returns None (fixed behavior)](tests/test_cid_functionality.py:531)
 - [CID content requested with .txt extension should render as UTF-8 text when possible.](tests/test_cid_functionality.py:243)
 - [Test serving CID content without extension defaults to UTF-8 text when possible.](tests/test_cid_functionality.py:210)
 - [Plain source files without Markdown cues should not be rendered.](tests/test_cid_functionality.py:270)
-- [Markdown content without an extension should render to HTML.](tests/test_cid_functionality.py:299)
+- [Markdown content without an extension should be served without rendering.](tests/test_cid_functionality.py:299)
 - [Test that server definitions are saved as CIDs when created/updated](tests/test_server_cid_functionality.py:13)
 - [Server events page should list invocation details and required links.](tests/test_routes_comprehensive.py:854)
 - [Test what's required for server execution to work](tests/test_echo_simple.py:42)
@@ -1147,8 +1147,10 @@ Total: 40 tests
 
 ## Property Tests
 
-Total: 4 tests
+Total: 6 tests
 
+- [When an extension is provided, the MIME type matches the extension.](tests/property/test_serve_cid_content_properties.py:33)
+- [A /CID request returns exactly the stored content.](tests/property/test_serve_cid_content_properties.py:15)
 - [test_decrypt_rejects_modified_payload](tests/property/test_encryption_properties.py:32)
 - [Round-tripping the CID components preserves the values.](tests/property/test_cid_properties.py:27)
 - [test_encrypt_decrypt_round_trip](tests/property/test_encryption_properties.py:10)

--- a/cid_utils.py
+++ b/cid_utils.py
@@ -997,21 +997,6 @@ def _render_markdown_document(text):
         "</html>\n"
     )
 
-def _maybe_render_markdown(data, *, path_has_extension):
-    if path_has_extension:
-        return data, False
-
-    text = _decode_text_safely(data)
-    if text is None:
-        return data, False
-
-    if not _looks_like_markdown(text):
-        return data, False
-
-    html_document = _render_markdown_document(text)
-    return html_document.encode('utf-8'), True
-
-
 def get_mime_type_from_extension(path):
     """Determine MIME type from file extension in URL path"""
     if '.' in path:
@@ -1103,10 +1088,7 @@ def serve_cid_content(cid_content, path):
             response_body = _render_markdown_document(text).encode('utf-8')
             content_type = 'text/html'
     elif content_type == 'application/octet-stream':
-        response_body, rendered = _maybe_render_markdown(response_body, path_has_extension=has_extension)
-        if rendered:
-            content_type = 'text/html'
-        elif not has_extension:
+        if not has_extension:
             text = _decode_text_safely(response_body)
             if text is not None:
                 response_body = text.encode('utf-8')
@@ -1115,9 +1097,7 @@ def serve_cid_content(cid_content, path):
         text = _decode_text_safely(response_body)
         if text is not None:
             response_body = text.encode('utf-8')
-            content_type = 'text/plain; charset=utf-8'
-        else:
-            content_type = 'application/octet-stream'
+        content_type = 'text/plain; charset=utf-8'
     elif content_type == 'text/plain':
         text = _decode_text_safely(response_body)
         if text is not None:

--- a/tests/property/test_serve_cid_content_properties.py
+++ b/tests/property/test_serve_cid_content_properties.py
@@ -1,0 +1,47 @@
+"""Property tests for serving CID content."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from flask import Flask
+from hypothesis import given, strategies as st
+
+from cid_utils import EXTENSION_TO_MIME, serve_cid_content
+
+_app = Flask(__name__)
+
+
+@given(content_bytes=st.binary())
+def test_cid_page_returns_exact_content(content_bytes):
+    """A /CID request returns exactly the stored content."""
+
+    path = "/propertytestcid"
+    created_at = datetime.now(timezone.utc)
+
+    with _app.test_request_context(path):
+        cid_content = SimpleNamespace(file_data=content_bytes, created_at=created_at)
+        response = serve_cid_content(cid_content, path)
+
+    assert response is not None
+    assert response.get_data() == content_bytes
+
+
+_extension_strategy = st.sampled_from(sorted(EXTENSION_TO_MIME.items()))
+
+
+@given(extension_entry=_extension_strategy, content_bytes=st.binary())
+def test_cid_page_mime_matches_extension(extension_entry, content_bytes):
+    """When an extension is provided, the MIME type matches the extension."""
+
+    extension, base_mime = extension_entry
+    path = f"/propertytestcid.{extension}"
+    created_at = datetime.now(timezone.utc)
+
+    with _app.test_request_context(path):
+        cid_content = SimpleNamespace(file_data=content_bytes, created_at=created_at)
+        response = serve_cid_content(cid_content, path)
+
+    assert response is not None
+
+    expected_mime = "text/plain; charset=utf-8" if base_mime == "text/plain" else base_mime
+    assert response.headers.get("Content-Type") == expected_mime

--- a/tests/test_cid_functionality.py
+++ b/tests/test_cid_functionality.py
@@ -296,8 +296,8 @@ class TestCIDFunctionality(unittest.TestCase):
                 mock_response.headers.__setitem__.assert_any_call('Content-Type', 'text/plain; charset=utf-8')
 
     @patch('cid_utils.make_response')
-    def test_serve_cid_content_without_extension_renders_markdown(self, mock_make_response):
-        """Markdown content without an extension should render to HTML."""
+    def test_serve_cid_content_without_extension_serves_raw_markdown(self, mock_make_response):
+        """Markdown content without an extension should be served without rendering."""
         with self.app.app_context():
             test_user = self._create_test_user()
             with self.app.test_request_context():
@@ -325,16 +325,10 @@ class TestCIDFunctionality(unittest.TestCase):
                 path_without_extension = f"/{cid}"
                 serve_cid_content(cid_record, path_without_extension)
 
-                mock_make_response.assert_called_once()
-                rendered_bytes = mock_make_response.call_args[0][0]
-                self.assertIsInstance(rendered_bytes, bytes)
-                rendered_html = rendered_bytes.decode('utf-8')
-                self.assertIn('<h1', rendered_html)
-                self.assertIn('<ul>', rendered_html)
-                self.assertIn('class="language-python"', rendered_html)
+                mock_make_response.assert_called_once_with(markdown_body)
 
-                mock_response.headers.__setitem__.assert_any_call('Content-Type', 'text/html')
-                mock_response.headers.__setitem__.assert_any_call('Content-Length', len(rendered_bytes))
+                mock_response.headers.__setitem__.assert_any_call('Content-Type', 'text/plain; charset=utf-8')
+                mock_response.headers.__setitem__.assert_any_call('Content-Length', len(markdown_body))
 
     @patch('cid_utils._generate_qr_data_url')
     @patch('cid_utils.make_response')

--- a/tests/test_serve_cid_content.py
+++ b/tests/test_serve_cid_content.py
@@ -140,7 +140,7 @@ class TestServeCidContent(unittest.TestCase):
         self.assertIn('Last-Modified', response.headers)
         self.assertIn('ETag', response.headers)
 
-    def test_markdown_without_extension_renders_html_document(self):
+    def test_markdown_without_extension_serves_raw_content(self):
         path = "/bafybeihelloworld123456789012345678901234567890123456"
         markdown_content = SimpleNamespace(
             file_data=b"# Heading\n\n- item one\n- item two\n",
@@ -149,10 +149,9 @@ class TestServeCidContent(unittest.TestCase):
 
         response = self._serve(path, content=markdown_content)
         self.assertIsNotNone(response)
-        self.assertEqual(response.headers.get('Content-Type'), 'text/html')
+        self.assertEqual(response.headers.get('Content-Type'), 'text/plain; charset=utf-8')
         body = response.get_data(as_text=True)
-        self.assertIn('<h1>Heading</h1>', body)
-        self.assertIn('<li>item one</li>', body)
+        self.assertEqual(body, "# Heading\n\n- item one\n- item two\n")
 
     def test_explicit_markdown_html_extension_renders_markdown(self):
         path = "/bafybeihelloworld123456789012345678901234567890123456.notes.md.html"


### PR DESCRIPTION
## Summary
- remove the markdown auto-rendering branch for bare /CID requests and ensure .txt responses keep their declared MIME type
- update CID serving tests to expect raw content and add property coverage for raw bytes and extension-driven MIME handling
- regenerate the test index after introducing the new property suite

## Testing
- pytest tests/test_serve_cid_content.py tests/test_cid_functionality.py tests/property/test_serve_cid_content_properties.py


------
https://chatgpt.com/codex/tasks/task_b_68fec7d438808331aa210b5d9b347a1b