### PR TITLE
Fix gauge report artifact links for GitHub Pages

### DIFF
--- a/tests/test_gauge_report_enhancements.py
+++ b/tests/test_gauge_report_enhancements.py
@@ -30,8 +30,8 @@ def test_enhance_gauge_report_converts_artifact_paths(tmp_path):
         """<!DOCTYPE html>
 <html><head><title>Gauge</title></head>
 <body>
-  <p>Screenshot path: secureapp-artifacts/example.png</p>
-  <p>Metadata path: secureapp-artifacts/example.json</p>
+  <p>Screenshot path: /__w/Viewer/Viewer/gauge/reports/html-report/secureapp-artifacts/example.png</p>
+  <p>Metadata path: /__w/Viewer/Viewer/gauge/reports/html-report/secureapp-artifacts/example.json</p>
 </body></html>
 """,
         encoding="utf-8",
@@ -39,21 +39,29 @@ def test_enhance_gauge_report_converts_artifact_paths(tmp_path):
 
     detail_html = gauge_dir / "detail.html"
     detail_html.write_text(
-        "See secureapp-artifacts/example.png and secureapp-artifacts/example.json for more details.",
+        "See /__w/Viewer/Viewer/gauge/reports/html-report/secureapp-artifacts/example.png and /__w/Viewer/Viewer/gauge/reports/html-report/secureapp-artifacts/example.json for more details.",
         encoding="utf-8",
     )
 
-    updated = enhance_gauge_report(gauge_dir)
+    public_base_url = "https://example.test/reports/gauge-specs"
+    updated = enhance_gauge_report(gauge_dir, public_base_url=public_base_url)
     assert updated is True
 
     updated_index = index_html.read_text(encoding="utf-8")
-    assert '<img src="secureapp-artifacts/example.png"' in updated_index
+    png_href = "https://example.test/reports/gauge-specs/secureapp-artifacts/example.png"
+    json_href = "https://example.test/reports/gauge-specs/secureapp-artifacts/example.json"
+    assert f'<img src="{png_href}"' in updated_index
+    assert f'href="{png_href}"' in updated_index
     assert 'class="secureapp-inline-snapshot"' in updated_index
-    assert 'Metadata for GET /demo' in updated_index or 'JSON metadata' in updated_index
     assert '<a class="secureapp-inline-metadata"' in updated_index
+    assert '>info<' in updated_index
+    assert '/__w/' not in updated_index
 
     updated_detail = detail_html.read_text(encoding="utf-8")
-    assert '<img src="secureapp-artifacts/example.png"' in updated_detail
-    assert '<a class="secureapp-inline-metadata"' in updated_detail
+    assert f'<img src="{png_href}"' in updated_detail
+    assert f'href="{json_href}"' in updated_detail
+    assert '>info<' in updated_detail
+    assert '/__w/' not in updated_detail
 
     assert '<section class="gauge-screenshot-gallery">' in updated_index
+    assert f'href="{json_href}"' in updated_index


### PR DESCRIPTION
## Summary
- update the gauge report enhancer to normalize artifact paths, emit GitHub Pages URLs, and label JSON links as "info"
- teach the report-site builder about a public base URL so published reports link to hosted artifacts
- expand the gauge report enhancement test to cover absolute CI paths and verify cleaned output

## Testing
- pytest tests/test_gauge_report_enhancements.py

------
https://chatgpt.com/codex/tasks/task_b_68fecdf4fa1c833180fe28d1ab4844df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--public-base-url` command-line option to specify the base URL for published gauge report assets.

* **Enhancements**
  * Report asset references now use absolute URLs when a public base URL is configured, improving compatibility for externally published reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->