### PR TITLE
Remove placeholder screenshot asset

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -70,9 +70,10 @@ def test_render_browser_screenshot_disables_signal_handlers(monkeypatch) -> None
     fake_module.launch = lambda **kwargs: _fake_launch(**kwargs)
     monkeypatch.setitem(sys.modules, "pyppeteer", fake_module)
 
-    result = artifacts._render_browser_screenshot("<html></html>")
+    result, error = artifacts._render_browser_screenshot("<html></html>")
 
     assert result == b"fake screenshot"
+    assert error is None
     assert captured["handleSIGINT"] is False
     assert captured["handleSIGTERM"] is False
     assert captured["handleSIGHUP"] is False
@@ -104,9 +105,10 @@ def test_render_browser_screenshot_supports_legacy_setcontent(monkeypatch) -> No
     fake_module.launch = lambda **kwargs: _fake_launch(**kwargs)
     monkeypatch.setitem(sys.modules, "pyppeteer", fake_module)
 
-    result = artifacts._render_browser_screenshot("<html></html>")
+    result, error = artifacts._render_browser_screenshot("<html></html>")
 
     assert result == b"fake screenshot"
+    assert error is None
     assert page.html_document == "<html></html>"
     assert page.wait_until is None
     assert page.wait_for_function == "document.readyState === 'complete'"
@@ -120,6 +122,8 @@ def test_render_browser_screenshot_falls_back_when_launch_fails(monkeypatch) -> 
     fake_module.launch = lambda **kwargs: _fake_launch(**kwargs)
     monkeypatch.setitem(sys.modules, "pyppeteer", fake_module)
 
-    result = artifacts._render_browser_screenshot("<html></html>")
+    result, error = artifacts._render_browser_screenshot("<html></html>")
 
     assert result is None
+    assert error is not None
+    assert "chromium download failed" in error

--- a/tests/test_build_report_site.py
+++ b/tests/test_build_report_site.py
@@ -1,0 +1,97 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_build_report_module():
+    module_name = "test_build_report_site"
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "build-report-site.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Unable to load build-report-site module for testing")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+build_report = _load_build_report_module()
+
+
+def test_collect_screenshot_issues_counts_placeholders(tmp_path) -> None:
+    gauge_dir = tmp_path / "gauge"
+    artifacts_dir = gauge_dir / "secureapp-artifacts"
+    artifacts_dir.mkdir(parents=True)
+
+    (artifacts_dir / "one.json").write_text(
+        json.dumps(
+            {
+                "screenshot": {
+                    "captured": False,
+                    "placeholder": True,
+                    "details": [
+                        "pyppeteer is not installed.",
+                        "Unable to read the shared placeholder image.",
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (artifacts_dir / "two.json").write_text(
+        json.dumps(
+            {
+                "screenshot": {
+                    "captured": False,
+                    "placeholder": True,
+                    "details": "Response body is not HTML; browser screenshot skipped.",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Captured screenshot should not be counted.
+    (artifacts_dir / "three.json").write_text(
+        json.dumps(
+            {
+                "screenshot": {
+                    "captured": True,
+                    "placeholder": False,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    count, reasons = build_report._collect_screenshot_issues(gauge_dir)
+
+    assert count == 2
+    assert reasons == [
+        "pyppeteer is not installed.",
+        "Unable to read the shared placeholder image.",
+        "Response body is not HTML; browser screenshot skipped.",
+    ]
+
+
+def test_format_screenshot_notice_builds_section() -> None:
+    notice = build_report._format_screenshot_notice(
+        2, ["First reason", "Second reason"]
+    )
+
+    assert notice is not None
+    assert "Gauge screenshot status" in notice
+    assert "<li>First reason</li>" in notice
+    assert "<li>Second reason</li>" in notice
+
+
+def test_write_landing_page_includes_notice(tmp_path) -> None:
+    notice = "<section class=\"screenshot-status\">Example</section>"
+    build_report._write_landing_page(tmp_path, screenshot_notice=notice)
+
+    index_path = tmp_path / "index.html"
+    content = index_path.read_text(encoding="utf-8")
+
+    assert notice in content


### PR DESCRIPTION
## Summary
- remove the placeholder screenshot asset that blocked the previous PR

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fee2a980f08331a3e9f9f4ff2c9299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screenshot status reporting to generated reports, displaying placeholder information when real screenshots are unavailable.
  * Implemented graceful error handling with detailed error messages for failed screenshot captures.
  * Enhanced metadata tracking to include screenshot provenance information.

* **Tests**
  * Added test coverage for screenshot collection, notice formatting, and landing page generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->