### PR TITLE
Pin pyppeteer <2.0 to restore CI build

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -54,12 +54,12 @@ RUN set -eux; \
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --upgrade pip \
     && pip install -r /tmp/requirements.txt \
-    && pip install hypothesis pytest pyppeteer
+    && pip install hypothesis pytest "pyppeteer>=1.0.2,<2.0.0"
 
 # Pre-download Chromium so container users (and any jobs that retain /root as
 # $HOME) already have a browser binary before Gauge runs. GitHub Actions swaps
 # HOME to /github/home at runtime, so the workflow reruns the installer there.
-RUN pip install pyppeteer
+RUN pip install "pyppeteer>=1.0.2,<2.0.0"
 RUN python -m pyppeteer.install
 
 WORKDIR /workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
     "hypothesis>=6.124.1",
     "ruff>=0.1.0",
     "mypy>=1.13.0",
-    "pyppeteer>=1.0.2",
+    "pyppeteer>=1.0.2,<2.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ glom>=23.3.0
 hypothesis>=6.124.1
 pytest>=8.2.0
 ruff>=0.1.0
-pyppeteer>=1.0.2
+pyppeteer>=1.0.2,<2.0.0
 logfire[all]
 logfire[aiohttp-client]
 opentelemetry-instrumentation-flask>=0.48b0


### PR DESCRIPTION
## Summary
- pin the pyppeteer dependency below 2.0 so the legacy installer module remains available
- align the CI Docker image with the pinned dependency when installing tools

## Testing
- pytest tests/test_build_report_site.py

------
https://chatgpt.com/codex/tasks/task_b_68ffe363722083319627546cc7e01116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency constraints to ensure stability and maintain compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->