### PR TITLE
Align pyppeteer install guidance

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -53,13 +53,12 @@ RUN set -eux; \
 # Install Python dependencies used in CI
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --upgrade pip \
-    && pip install -r /tmp/requirements.txt \
-    && pip install hypothesis pytest "pyppeteer>=1.0.2,<2.0.0"
+    && python -m pip install -r /tmp/requirements.txt \
+    && python -m pip install hypothesis pytest
 
 # Pre-download Chromium so container users (and any jobs that retain /root as
 # $HOME) already have a browser binary before Gauge runs. GitHub Actions swaps
 # HOME to /github/home at runtime, so the workflow reruns the installer there.
-RUN pip install "pyppeteer>=1.0.2,<2.0.0"
-RUN python -m pyppeteer.install
+RUN python -m pyppeteer install
 
 WORKDIR /workspace

--- a/scripts/build-report-site.py
+++ b/scripts/build-report-site.py
@@ -321,7 +321,7 @@ def _format_screenshot_notice(count: int, reasons: Sequence[str]) -> str | None:
         "      <li>Install the project dependencies so <code>pyppeteer</code> is "
         "available (for example, <code>pip install -r requirements.txt</code>).</li>\n"
         "      <li>Download Chromium inside the environment that runs the Gauge "
-        "suite by executing <code>python -m pyppeteer.install</code> before "
+        "suite by executing <code>python -m pyppeteer install</code> before "
         "<code>./test-gauge</code>.</li>\n"
         "      <li>Ensure the runtime image provides the shared libraries that "
         "Chromium requires. On the Ubuntu-based CI container this means adding "

--- a/tests/test_build_report_site.py
+++ b/tests/test_build_report_site.py
@@ -86,7 +86,7 @@ def test_format_screenshot_notice_builds_section() -> None:
     assert "<li>First reason</li>" in notice
     assert "<li>Second reason</li>" in notice
     assert "gauge-specs/secureapp-artifacts" in notice
-    assert "python -m pyppeteer.install" in notice
+    assert "python -m pyppeteer install" in notice
     assert "libnss3" in notice
 
 


### PR DESCRIPTION
## Summary
- ensure the CI Dockerfile relies on python -m pip and drop the redundant pyppeteer reinstall step before the Chromium download
- update the build report guidance and tests to reference `python -m pyppeteer install`

## Testing
- pytest tests/test_build_report_site.py

------
https://chatgpt.com/codex/tasks/task_b_68ffe558c6b88331b3e323b3018ff019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined CI/CD dependency installation by consolidating separate steps and updating the invocation method.
  * Removed version constraints to allow flexible dependency management.

* **Tests**
  * Updated test expectations to reflect changes in the dependency installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->