### PR TITLE
Add UI link and button design guidelines to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ both the pytest suite and the Gauge specs succeed.
 After changing the configuration or dependencies re‑run `./doctor` to ensure your setup is healthy.  Use `Ctrl+C` to stop
  the development server started with `./run`.
 
+### UI design principles
+
+* If a UI element with text could be a link to something useful it should be, especially when there is a single obvious target. Make links look like links so people recognise them immediately.
+* Reserve buttons for actions that make changes. If interacting with a control simply navigates to another location without side effects, use a link instead of a button.
+
 Run `pytest` (or the `./test` wrapper) before opening a pull request so you catch regressions locally.  Integration scenarios
 live under `tests/integration` and are skipped by default; run `scripts/run-integration.sh` when you need to validate
 end-to-end behaviour with the same logging CI captures.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,8 @@
+# Template guidelines
+
+These UI design principles keep the interface consistent and intuitive:
+
+* If a UI element with text could be a link to something useful it should be, particularly when there is a single obvious destination. Make sure links are styled so they are clearly identifiable as links.
+* Reserve buttons for actions that trigger changes. When the action only changes the current location without side effects, prefer a link over a button.
+
+Refer back to the main project README for additional development guidance.


### PR DESCRIPTION
## Summary
- document link and button usage principles in the main README
- add a templates README that repeats the UI guidance for designers working on Jinja templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690287b8f2ac833189081a94ba1fabb9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added UI design principles sections with guidance on using links and buttons in user interfaces.
  * Created template documentation with design guidelines for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->