### PR TITLE
Support variables in alias definitions

### DIFF
--- a/templates/_alias_definition_help.html
+++ b/templates/_alias_definition_help.html
@@ -4,7 +4,9 @@
         Use the alias definition field to capture multi-line context for related shortcuts, nested routes,
         and pattern behaviour. Start each alias with <code>pattern -> /target [options]</code>—even a single-line
         alias follows this format. The text you enter here travels with workspace exports and returns on import,
-        keeping documentation and routing intent in sync.
+        keeping documentation and routing intent in sync. Embed saved variables inside braces
+        (for example <code>{status-page}</code>) to reuse workspace configuration when generating targets or
+        patterns.
     </p>
     <p class="mb-3">
         Automated coverage for these examples lives in
@@ -22,6 +24,10 @@ docs -> /documentation                         # redirects /docs to /documentati
 # Pair literal roots with glob aliases for deeper paths
 status -> /status-page                         # /status stays on the overview
 status/* -> /status/sections/* [glob]          # nested paths reuse the captured suffix
+
+# Reuse saved variables in aliases
+status -> {status-page}                        # redirect /status using a saved variable value
+status/* -> {status-page}/sections/* [glob]    # combine variables with captured segments
 
 # Declaration order controls overlapping matches
 docs/* -> /preferred [glob]                    # first matching declaration wins for /docs/topic/guide

--- a/tests/test_alias_model.py
+++ b/tests/test_alias_model.py
@@ -15,6 +15,17 @@ class AliasModelTests(unittest.TestCase):
         )
         self.assertEqual(alias.get_primary_target_path(), "/target")
 
+    def test_get_primary_target_path_with_variable_reference(self):
+        """Test that variable placeholders resolve before accessing the target path."""
+        alias = Alias(
+            name="status",
+            definition="status -> {status-page}",
+            user_id="user1",
+        )
+        alias._resolved_variables = {"status-page": "/beageghugragegar"}
+
+        self.assertEqual(alias.get_primary_target_path(), "/beageghugragegar")
+
     def test_get_primary_target_path_fallback(self):
         """Test fallback when definition parsing fails."""
         alias = Alias(


### PR DESCRIPTION
## Summary
- allow alias definitions to substitute saved variable placeholders before generating routes
- reuse resolved variable maps when collecting alias routes and when resolving aliases by target path
- document the new placeholder support and cover it with focused unit tests

## Testing
- pytest tests/test_alias_model.py tests/test_alias_routes_integration.py
- pytest tests/test_alias_definition.py

------
https://chatgpt.com/codex/tasks/task_b_6904b33f454c8331853e45baf89982bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alias definitions now support variable substitution using placeholder syntax (e.g., {variable-name}), allowing reuse of saved variables across routes.
  * User-specific variables are automatically resolved during alias routing.

* **Documentation**
  * Updated help documentation with examples demonstrating variable embedding in alias definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->