### PR TITLE
Move edit history sections to page bottom

### DIFF
--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -126,21 +126,6 @@
                         </div>
 
                         <div class="col-12">
-                            {{ ai_text_controls(
-                                form.definition.id,
-                                'alias definition',
-                                request_label='Ask AI to edit the alias definition',
-                                helper_text='Describe how the AI should adjust the alias definition before saving.',
-                                context={'form': 'alias_form'},
-                                entity_type='alias',
-                                entity_name=ai_entity_name|default(''),
-                                entity_name_field=ai_entity_name_field|default(''),
-                                interactions=interaction_history|default([]),
-                                history_label='Recent alias edits and requests'
-                            ) }}
-                        </div>
-
-                        <div class="col-12">
                             <div class="form-check form-switch">
                                 {{ form.enabled(class="form-check-input", role="switch") }}
                                 {{ form.enabled.label(class="form-check-label") }}
@@ -201,6 +186,21 @@
             <div class="d-flex gap-2 flex-wrap align-items-center">
                 {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
             </div>
+        </div>
+
+        <div class="card-body border-top bg-body-tertiary">
+            {{ ai_text_controls(
+                form.definition.id,
+                'alias definition',
+                request_label='Ask AI to edit the alias definition',
+                helper_text='Describe how the AI should adjust the alias definition before saving.',
+                context={'form': 'alias_form'},
+                entity_type='alias',
+                entity_name=ai_entity_name|default(''),
+                entity_name_field=ai_entity_name_field|default(''),
+                interactions=interaction_history|default([]),
+                history_label='Recent alias edits and requests'
+            ) }}
         </div>
     </form>
 </div>

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -159,21 +159,6 @@
                             <div id="server-definition-errors" class="alert alert-danger mt-3 d-none" role="alert"></div>
                         </div>
 
-                        <div class="col-12">
-                            {{ ai_text_controls(
-                                form.definition.id,
-                                'server definition',
-                                request_label='Ask AI to edit the server definition',
-                                helper_text='Describe how the AI should adjust the server definition before saving.',
-                                context={'form': 'server_form'},
-                                entity_type='server',
-                                entity_name=ai_entity_name|default(''),
-                                entity_name_field=ai_entity_name_field|default(''),
-                                interactions=interaction_history|default([]),
-                                history_label='Recent edits and requests'
-                            ) }}
-                        </div>
-
                         <div class="col-12 col-lg-6">
                             <div class="form-check form-switch">
                                 {{ form.enabled(class="form-check-input", role="switch") }}
@@ -189,6 +174,21 @@
                             <div class="d-flex gap-2 flex-wrap">
                                 {{ ai_action_button(form.definition.id, button_label='AI', extra_classes='btn-outline-primary') }}
                             </div>
+                        </div>
+
+                        <div class="col-12 mt-3">
+                            {{ ai_text_controls(
+                                form.definition.id,
+                                'server definition',
+                                request_label='Ask AI to edit the server definition',
+                                helper_text='Describe how the AI should adjust the server definition before saving.',
+                                context={'form': 'server_form'},
+                                entity_type='server',
+                                entity_name=ai_entity_name|default(''),
+                                entity_name_field=ai_entity_name_field|default(''),
+                                interactions=interaction_history|default([]),
+                                history_label='Recent edits and requests'
+                            ) }}
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- reposition the server edit history panel below the primary form actions so save controls remain prominent
- relocate the alias edit history panel into a dedicated footer section after the cancel/action buttons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6904c207623083318d18aaa3486ec86e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the placement of AI text controls in the alias configuration form, moving them to a dedicated bottom section.
  * Reorganized the placement of AI text controls in the server definition form, relocating them after the action controls.
  * All functionality remains available with improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->