### PR TITLE
Ensure alias parser rejects invalid nested mappings

### DIFF
--- a/alias_definition.py
+++ b/alias_definition.py
@@ -72,6 +72,16 @@ def _normalize_target_path(raw: str) -> str:
     value = (raw or "").strip()
     if not value:
         raise AliasDefinitionError('Alias definition must include a target path after "->".')
+    brace_balance = 0
+    for character in value:
+        if character == "{":
+            brace_balance += 1
+        elif character == "}":
+            if brace_balance == 0:
+                raise AliasDefinitionError("Alias target path must reference a valid alias or URL.")
+            brace_balance -= 1
+    if brace_balance != 0:
+        raise AliasDefinitionError("Alias target path must reference a valid alias or URL.")
     if value.startswith("{") and value.endswith("}"):
         inner = value[1:-1].strip()
         if not inner:

--- a/tests/test_alias_definition.py
+++ b/tests/test_alias_definition.py
@@ -231,6 +231,7 @@ class ParseAliasDefinitionValidationTests(unittest.TestCase):
             "stuff -> {",
             "stuff -> {}",
             "stuff -> {thing}",
+            "xy -> {xdd",
         ]
 
         for definition in invalid_definitions:
@@ -242,7 +243,7 @@ class ParseAliasDefinitionValidationTests(unittest.TestCase):
                 self.assertIn("valid alias or url", message)
 
     def test_rejects_invalid_nested_target_paths(self):
-        invalid_targets = ["}", "{", "{}", "{thing}"]
+        invalid_targets = ["}", "{", "{}", "{thing}", "{xdd"]
 
         for target in invalid_targets:
             definition = textwrap.dedent(


### PR DESCRIPTION
## Summary
- ensure the alias parser checks every mapping line and reports the first parse error
- add regression tests covering invalid nested mappings and options in alias definitions

## Testing
- pytest tests/test_alias_definition.py

------
https://chatgpt.com/codex/tasks/task_b_6904ce1bf15c8331af16e0eb34ae9167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a dedicated parsing API and explicit validation error for alias definitions, reporting line-level failures as a single, actionable error.
* **Bug Fixes**
  * Tightens validation of alias target paths to reject malformed values.
  * Ensures each definition line is validated and non-mapping or malformed lines are flagged with clear line indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->