### PR TITLE
Add variable assignment flow to upload success page

### DIFF
--- a/templates/upload_success.html
+++ b/templates/upload_success.html
@@ -24,7 +24,9 @@
                         <div class="col-md-6">
                             <h6>File Details:</h6>
                             <ul class="list-unstyled">
+                                {% if filename %}
                                 <li><strong>Filename:</strong> {{ filename }}</li>
+                                {% endif %}
                                 <li><strong>Size:</strong> {{ file_size }} bytes</li>
                                 {% if title %}
                                 <li><strong>Title:</strong> {{ title }}</li>
@@ -72,7 +74,63 @@
                             </small>
                         </div>
                     </div>
-                    
+
+                    <div class="mt-4">
+                        <h6 class="mb-3">
+                            <i class="fas fa-code me-2"></i>Assign this CID to a Variable
+                        </h6>
+                        <p class="text-muted small">Select an existing variable or enter a new one to reuse this CID in aliases and servers.</p>
+                        {% if assigned_variable and assigned_variable.name %}
+                            <div class="alert alert-success" role="alert">
+                                <i class="fas fa-link me-2"></i>
+                                This CID is currently assigned to
+                                <a href="{{ url_for('main.view_variable', variable_name=assigned_variable.name) }}" class="alert-link">
+                                    {{ assigned_variable.name }}
+                                </a>.
+                            </div>
+                        {% endif %}
+                        <form method="post" action="{{ url_for('main.assign_cid_variable') }}" class="row g-3 align-items-end">
+                            <input type="hidden" name="cid" value="{{ cid }}">
+                            <input type="hidden" name="view_url_extension" value="{{ view_url_extension or '' }}">
+                            <input type="hidden" name="filename" value="{{ filename or '' }}">
+                            <input type="hidden" name="detected_mime_type" value="{{ detected_mime_type or '' }}">
+                            <div class="col-lg-8">
+                                <label for="assign-variable-name" class="form-label fw-semibold">Variable name</label>
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="assign-variable-name"
+                                    name="variable_name"
+                                    list="upload-variable-options"
+                                    value="{{ assignment_variable_name or '' }}"
+                                    placeholder="e.g. latest-report-cid"
+                                    pattern="[A-Za-z0-9._-]+"
+                                    required
+                                >
+                                <datalist id="upload-variable-options">
+                                    {% for variable in variables %}
+                                        {% if variable.name %}
+                                            <option value="{{ variable.name }}"></option>
+                                        {% endif %}
+                                    {% endfor %}
+                                </datalist>
+                                <div class="form-text">
+                                    {% if variables %}
+                                        Start typing to choose an existing variable or enter a new name to create it.
+                                    {% else %}
+                                        Enter a new variable name to create it with this CID.
+                                    {% endif %}
+                                    Allowed characters: letters, numbers, dots, hyphens, and underscores.
+                                </div>
+                            </div>
+                            <div class="col-lg-4">
+                                <button type="submit" class="btn btn-outline-success w-100">
+                                    <i class="fas fa-code-branch me-2"></i>Assign to Variable
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+
                     <div class="d-flex gap-2 mt-4">
                         <a href="{{ url_for('main.upload') }}" class="btn btn-success">
                             <i class="fas fa-upload me-2"></i>Upload Another File

--- a/tests/test_upload_extensions.py
+++ b/tests/test_upload_extensions.py
@@ -3,7 +3,9 @@ import unittest
 from unittest.mock import Mock, patch
 
 from app import create_app, db
-from cid_utils import CID_LENGTH, process_file_upload
+from cid_presenter import format_cid
+from cid_utils import CID_LENGTH, generate_cid, process_file_upload
+from models import Variable
 
 
 class TestUploadExtensions(unittest.TestCase):
@@ -29,7 +31,6 @@ class TestUploadExtensions(unittest.TestCase):
 
     def test_process_file_upload_returns_filename(self):
         """Test that process_file_upload returns both content and filename"""
-        # Create a mock form with file data
         form = Mock()
         mock_file = Mock()
         mock_file.filename = 'test_document.pdf'
@@ -43,7 +44,6 @@ class TestUploadExtensions(unittest.TestCase):
 
     def test_process_file_upload_handles_no_filename(self):
         """Test that process_file_upload handles files without filename"""
-        # Create a mock form with file data but no filename
         form = Mock()
         mock_file = Mock()
         mock_file.filename = None
@@ -59,72 +59,166 @@ class TestUploadExtensions(unittest.TestCase):
     def test_upload_text_gets_txt_extension(self, mock_current_user):
         """Test that pasted text uploads get .txt extension in view URL"""
         mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
 
         with self.app.app_context():
-            # Simulate text upload
             response = self.client.post('/upload', data={
                 'upload_type': 'text',
                 'text_content': 'This is some test text content',
                 'submit': 'Upload'
             }, follow_redirects=False)
 
-            # Should render upload_success.html template
-            self.assertEqual(response.status_code, 200)
-            self.assertIn(b'Upload Successful', response.data)
-
-            # Check that the response contains .txt extension in the view URL
-            self.assertIn(b'.txt', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Upload Successful', response.data)
+        self.assertIn(b'.txt', response.data)
 
     @patch('routes.uploads.current_user')
     def test_upload_file_preserves_original_extension(self, mock_current_user):
         """Test that file uploads preserve their original extension"""
         mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
 
         with self.app.app_context():
-            # Create a mock file with .pdf extension
             file_data = io.BytesIO(b'PDF file content')
             file_data.name = 'document.pdf'
 
-            # Simulate file upload
             response = self.client.post('/upload', data={
                 'upload_type': 'file',
                 'file': (file_data, 'document.pdf'),
                 'submit': 'Upload'
             }, follow_redirects=False)
 
-            # Should render upload_success.html template
-            self.assertEqual(response.status_code, 200)
-            self.assertIn(b'Upload Successful', response.data)
-
-            # Check that the response contains .pdf extension in the view URL
-            self.assertIn(b'.pdf', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Upload Successful', response.data)
+        self.assertIn(b'.pdf', response.data)
 
     @patch('routes.uploads.current_user')
     def test_upload_file_handles_no_extension(self, mock_current_user):
         """Test that file uploads without extension don't break"""
         mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
 
         with self.app.app_context():
-            # Create a mock file without extension
             file_data = io.BytesIO(b'File content without extension')
             file_data.name = 'document'
 
-            # Simulate file upload
             response = self.client.post('/upload', data={
                 'upload_type': 'file',
                 'file': (file_data, 'document'),
                 'submit': 'Upload'
             }, follow_redirects=False)
 
-            # Should render upload_success.html template
-            self.assertEqual(response.status_code, 200)
-            self.assertIn(b'Upload Successful', response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Upload Successful', response.data)
 
-            # Should not have any extension in the view URL (no .txt, .pdf, etc.)
-            response_text = response.data.decode('utf-8')
-            # The CID should appear without any extension and match the canonical length
-            cid_pattern = rf'/[A-Za-z0-9_-]{{{CID_LENGTH}}}(?!\.)'
-            self.assertRegex(response_text, cid_pattern)  # CID without extension
+        response_text = response.data.decode('utf-8')
+        cid_pattern = rf'/[A-Za-z0-9_-]{{{CID_LENGTH}}}(?!\.)'
+        self.assertRegex(response_text, cid_pattern)
+
+    @patch('routes.uploads.current_user')
+    def test_upload_success_includes_variable_assignment_form(self, mock_current_user):
+        """Upload success page should render variable assignment controls."""
+
+        mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
+
+        with self.app.app_context():
+            db.session.add(
+                Variable(name='existing-var', definition='/old-cid', user_id=self.test_user_id)
+            )
+            db.session.commit()
+
+            response = self.client.post('/upload', data={
+                'upload_type': 'text',
+                'text_content': 'variable assignment preview',
+                'submit': 'Upload'
+            }, follow_redirects=False)
+
+        self.assertEqual(response.status_code, 200)
+        page = response.get_data(as_text=True)
+        self.assertIn('Assign this CID to a Variable', page)
+        self.assertIn('existing-var', page)
+        self.assertIn('name="cid"', page)
+
+    @patch('routes.uploads.current_user')
+    def test_assign_cid_creates_new_variable(self, mock_current_user):
+        """Assigning a CID should create a new variable."""
+
+        mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
+
+        content_text = 'new variable content'
+
+        with self.app.app_context():
+            upload_response = self.client.post('/upload', data={
+                'upload_type': 'text',
+                'text_content': content_text,
+                'submit': 'Upload'
+            }, follow_redirects=False)
+
+        self.assertEqual(upload_response.status_code, 200)
+
+        cid_value = format_cid(generate_cid(content_text.encode('utf-8')))
+
+        assign_response = self.client.post('/upload/assign-variable', data={
+            'cid': cid_value,
+            'variable_name': 'NEW_ASSIGN',
+            'view_url_extension': 'txt',
+            'filename': '',
+            'detected_mime_type': 'text/plain',
+        })
+
+        self.assertEqual(assign_response.status_code, 200)
+        assign_page = assign_response.get_data(as_text=True)
+        self.assertIn('NEW_ASSIGN', assign_page)
+        self.assertIn('currently assigned', assign_page)
+
+        with self.app.app_context():
+            created = Variable.query.filter_by(user_id=self.test_user_id, name='NEW_ASSIGN').first()
+            self.assertIsNotNone(created)
+            self.assertEqual(created.definition, f'/{cid_value}')
+
+    @patch('routes.uploads.current_user')
+    def test_assign_cid_updates_existing_variable(self, mock_current_user):
+        """Assigning a CID should update an existing variable definition."""
+
+        mock_current_user.id = self.test_user_id
+        mock_current_user.username = 'test-user'
+
+        with self.app.app_context():
+            db.session.add(
+                Variable(name='STATUS_PAGE', definition='/old-definition', user_id=self.test_user_id)
+            )
+            db.session.commit()
+
+        updated_text = 'updated variable definition via cid'
+
+        with self.app.app_context():
+            upload_response = self.client.post('/upload', data={
+                'upload_type': 'text',
+                'text_content': updated_text,
+                'submit': 'Upload'
+            }, follow_redirects=False)
+
+        self.assertEqual(upload_response.status_code, 200)
+
+        cid_value = format_cid(generate_cid(updated_text.encode('utf-8')))
+
+        assign_response = self.client.post('/upload/assign-variable', data={
+            'cid': cid_value,
+            'variable_name': 'STATUS_PAGE',
+            'view_url_extension': 'txt',
+            'filename': '',
+            'detected_mime_type': 'text/plain',
+        })
+
+        self.assertEqual(assign_response.status_code, 200)
+        page = assign_response.get_data(as_text=True)
+        self.assertIn('STATUS_PAGE', page)
+
+        with self.app.app_context():
+            refreshed = Variable.query.filter_by(user_id=self.test_user_id, name='STATUS_PAGE').one()
+            self.assertEqual(refreshed.definition, f'/{cid_value}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add helpers in the uploads route to render the success page with variable assignment context and handle POSTs that assign a CID to a variable
- extend the upload success template with a variable assignment form and current-assignment messaging
- cover the new behaviour with upload extension tests for the form rendering and assignment flows

## Testing
- pytest tests/test_upload_extensions.py

------
https://chatgpt.com/codex/tasks/task_b_6905392026b0833189e2110b4c851534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added variable assignment functionality on the upload success page, allowing users to create new variables or update existing ones with their uploaded content.
  * Introduced autocomplete suggestions when assigning variables, populated from existing user variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->