### PR TITLE
Remove inaccurate IPFS references from upload pages

### DIFF
--- a/routes/uploads.py
+++ b/routes/uploads.py
@@ -137,7 +137,7 @@ def _persist_alias_from_upload(alias: Alias) -> Alias:
 
 @main_bp.route('/upload', methods=['GET', 'POST'])
 def upload():
-    """File upload page with IPFS CID storage."""
+    """File upload page with CID storage."""
     form = FileUploadForm()
     upload_templates = get_upload_templates()
 

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -15,7 +15,7 @@
                 </div>
                 <div class="card-body">
                     <p class="card-text text-muted mb-4">
-                        Upload a file or paste text content to store it in the database with an IPFS CID as the lookup key.
+                        Upload a file or paste text content to store it in the database with a CID as the lookup key.
                         The content will be accessible at a unique path based on its content hash.
                     </p>
 
@@ -58,7 +58,7 @@
                                     </div>
                                 {% endif %}
                                 <small class="form-text text-muted">
-                                    Select any file to upload. A unique IPFS CID will be generated based on the file content.
+                                    Select any file to upload. A unique CID will be generated based on the file content.
                                 </small>
                             </div>
                         </div>
@@ -102,7 +102,7 @@
                                     </div>
                                 {% endif %}
                                 <small class="form-text text-muted">
-                                    Paste or type your text content here. A unique IPFS CID will be generated based on the content.
+                                    Paste or type your text content here. A unique CID will be generated based on the content.
                                 </small>
                             </div>
                         </div>
@@ -120,7 +120,7 @@
                                     </div>
                                 {% endif %}
                                 <small class="form-text text-muted">
-                                    Enter the URL of the file you want to download and store. The file will be fetched and a unique IPFS CID will be generated.
+                                    Enter the URL of the file you want to download and store. The file will be fetched and a unique CID will be generated.
                                 </small>
                             </div>
                         </div>
@@ -149,7 +149,7 @@
                 <div class="card-footer">
                     <small class="text-muted">
                         <i class="fas fa-info-circle me-1"></i>
-                        Content is stored securely and assigned a unique IPFS-compatible CID for easy retrieval.
+                        Content is stored securely and assigned a unique CID for easy retrieval.
                     </small>
                 </div>
             </div>

--- a/templates/upload_success.html
+++ b/templates/upload_success.html
@@ -17,7 +17,7 @@
                         <h5 class="alert-heading">
                             <i class="fas fa-thumbs-up me-2"></i>File uploaded successfully!
                         </h5>
-                        <p class="mb-0">Your file has been stored in the database and assigned a unique IPFS CID.</p>
+                        <p class="mb-0">Your file has been stored in the database and assigned a unique CID.</p>
                     </div>
                     
                     <div class="row">
@@ -37,9 +37,9 @@
                             </ul>
                         </div>
                         <div class="col-md-6">
-                            <h6>IPFS Information:</h6>
+                            <h6>CID Information:</h6>
                             <div class="bg-light p-3 rounded">
-                                <label class="form-label fw-bold">IPFS CID:</label>
+                                <label class="form-label fw-bold">CID:</label>
                                 <div class="d-flex flex-column gap-2">
                                     {{ render_cid_link(cid) }}
                                     <div class="input-group">


### PR DESCRIPTION
## Summary
- update upload route docstring and related templates to stop referring to IPFS CIDs
- clarify that uploads are associated with generic CIDs throughout the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69053e2421f08331a5475afc4c4d15d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing text throughout the upload flow to reference "CID" instead of "IPFS CID", including page descriptions, success messages, and informational labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->