### PR TITLE
Exclude Gauge specs and step definitions from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,8 @@ omit =
     .ruff_cache/*
     migrations/*
     */migrations/*
+    specs/*
+    step_impl/*
 
 # Include patterns
 include = 


### PR DESCRIPTION
## Summary
- omit Gauge spec files and step implementation modules from the coverage configuration so behavior-only assets are not counted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69055a38705c8331a95b7b6cc1218b5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage configuration to exclude additional test-related directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->