### PR TITLE
Add reusable template support to entity forms

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -91,6 +91,14 @@ def get_user_servers(user_id: str) -> List[Server]:
     return Server.query.filter_by(user_id=user_id).order_by(Server.name).all()
 
 
+def get_user_template_servers(user_id: str) -> List[Server]:
+    return (
+        Server.query.filter_by(user_id=user_id, template=True)
+        .order_by(Server.name)
+        .all()
+    )
+
+
 def get_server_by_name(user_id: str, name: str) -> Optional[Server]:
     return Server.query.filter_by(user_id=user_id, name=name).first()
 
@@ -118,6 +126,14 @@ def get_first_server_name(user_id: str) -> Optional[str]:
 
 def get_user_aliases(user_id: str) -> List[Alias]:
     return Alias.query.filter_by(user_id=user_id).order_by(Alias.name).all()
+
+
+def get_user_template_aliases(user_id: str) -> List[Alias]:
+    return (
+        Alias.query.filter_by(user_id=user_id, template=True)
+        .order_by(Alias.name)
+        .all()
+    )
 
 
 def get_alias_by_name(user_id: str, name: str) -> Optional[Alias]:
@@ -190,6 +206,14 @@ def get_user_variables(user_id: str) -> List[Variable]:
     return Variable.query.filter_by(user_id=user_id).order_by(Variable.name).all()
 
 
+def get_user_template_variables(user_id: str) -> List[Variable]:
+    return (
+        Variable.query.filter_by(user_id=user_id, template=True)
+        .order_by(Variable.name)
+        .all()
+    )
+
+
 def get_variable_by_name(user_id: str, name: str) -> Optional[Variable]:
     return Variable.query.filter_by(user_id=user_id, name=name).first()
 
@@ -207,6 +231,14 @@ def get_first_variable_name(user_id: str) -> Optional[str]:
 
 def get_user_secrets(user_id: str) -> List[Secret]:
     return Secret.query.filter_by(user_id=user_id).order_by(Secret.name).all()
+
+
+def get_user_template_secrets(user_id: str) -> List[Secret]:
+    return (
+        Secret.query.filter_by(user_id=user_id, template=True)
+        .order_by(Secret.name)
+        .all()
+    )
 
 
 def get_secret_by_name(user_id: str, name: str) -> Optional[Secret]:

--- a/forms.py
+++ b/forms.py
@@ -75,6 +75,7 @@ class ServerForm(FlaskForm):
     ])
     definition = TextAreaField('Server Definition', validators=[DataRequired()], render_kw={'rows': 15})
     enabled = BooleanField('Enabled', default=True)
+    template = BooleanField('Template', default=False)
     submit = SubmitField('Save Server')
 
     def validate_name(self, field: Field) -> None:
@@ -89,6 +90,7 @@ class VariableForm(FlaskForm):
     ])
     definition = TextAreaField('Variable Definition', validators=[DataRequired()], render_kw={'rows': 15})
     enabled = BooleanField('Enabled', default=True)
+    template = BooleanField('Template', default=False)
     submit = SubmitField('Save Variable')
 
     def validate_name(self, field: Field) -> None:
@@ -136,6 +138,7 @@ class AliasForm(FlaskForm):
         },
     )
     enabled = BooleanField('Enabled', default=True)
+    template = BooleanField('Template', default=False)
     submit = SubmitField('Save Alias')
 
     def __init__(self, *args, **kwargs):
@@ -169,6 +172,7 @@ class SecretForm(FlaskForm):
     ])
     definition = TextAreaField('Secret Definition', validators=[DataRequired()], render_kw={'rows': 15})
     enabled = BooleanField('Enabled', default=True)
+    template = BooleanField('Template', default=False)
     submit = SubmitField('Save Secret')
 
     def validate_name(self, field: Field) -> None:

--- a/models.py
+++ b/models.py
@@ -36,6 +36,7 @@ class Server(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     enabled = db.Column(db.Boolean, nullable=False, default=True)
+    template = db.Column(db.Boolean, nullable=False, default=False)
 
     # Unique constraint: each user can only have one server with a given name
     __table_args__ = (db.UniqueConstraint('user_id', 'name', name='unique_user_server_name'),)
@@ -52,6 +53,7 @@ class Alias(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     enabled = db.Column(db.Boolean, nullable=False, default=True)
+    template = db.Column(db.Boolean, nullable=False, default=False)
 
     __table_args__ = (db.UniqueConstraint('user_id', 'name', name='unique_user_alias_name'),)
 
@@ -161,6 +163,7 @@ class Variable(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     enabled = db.Column(db.Boolean, nullable=False, default=True)
+    template = db.Column(db.Boolean, nullable=False, default=False)
 
     # Unique constraint: each user can only have one variable with a given name
     __table_args__ = (db.UniqueConstraint('user_id', 'name', name='unique_user_variable_name'),)
@@ -176,6 +179,7 @@ class Secret(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     enabled = db.Column(db.Boolean, nullable=False, default=True)
+    template = db.Column(db.Boolean, nullable=False, default=False)
 
     # Unique constraint: each user can only have one secret with a given name
     __table_args__ = (db.UniqueConstraint('user_id', 'name', name='unique_user_secret_name'),)

--- a/routes/entities.py
+++ b/routes/entities.py
@@ -57,6 +57,10 @@ def create_entity(
     if enabled_field is not None:
         entity_data['enabled'] = bool(enabled_field.data)
 
+    template_field = getattr(form, 'template', None)
+    if template_field is not None:
+        entity_data['template'] = bool(template_field.data)
+
     if model_class.__name__ == 'Server':
         definition_cid = save_server_definition_as_cid(form.definition.data, user_id)
         entity_data['definition_cid'] = definition_cid
@@ -125,6 +129,10 @@ def update_entity(
     enabled_field = getattr(form, 'enabled', None)
     if enabled_field is not None:
         entity.enabled = bool(enabled_field.data)
+
+    template_field = getattr(form, 'template', None)
+    if template_field is not None:
+        entity.template = bool(template_field.data)
 
     save_entity(entity)
 

--- a/routes/secrets.py
+++ b/routes/secrets.py
@@ -10,7 +10,13 @@ from cid_utils import (
     get_current_secret_definitions_cid,
     store_secret_definitions_cid,
 )
-from db_access import delete_entity, get_secret_by_name, get_user_secrets, save_entity
+from db_access import (
+    delete_entity,
+    get_secret_by_name,
+    get_user_secrets,
+    get_user_template_secrets,
+    save_entity,
+)
 from forms import BulkSecretsForm, SecretForm
 from identity import current_user
 from interaction_log import load_interaction_history
@@ -156,6 +162,16 @@ def new_secret():
     change_message = (request.form.get('change_message') or '').strip()
     definition_text = form.definition.data or ''
 
+    secret_templates = [
+        {
+            'id': secret.id,
+            'name': secret.name,
+            'definition': secret.definition or '',
+            'suggested_name': f"{secret.name}-copy" if secret.name else '',
+        }
+        for secret in get_user_template_secrets(current_user.id)
+    ]
+
     if form.validate_on_submit():
         if create_entity(
             Secret,
@@ -178,6 +194,7 @@ def new_secret():
         interaction_history=interaction_history,
         ai_entity_name=entity_name_hint,
         ai_entity_name_field=form.name.id,
+        secret_templates=secret_templates,
     )
 
 

--- a/routes/servers.py
+++ b/routes/servers.py
@@ -19,6 +19,7 @@ from db_access import (
     get_user_secrets,
     get_user_server_invocations_by_server,
     get_user_servers,
+    get_user_template_servers,
     get_user_uploads,
     get_user_variables,
 )
@@ -527,6 +528,16 @@ def new_server():
     change_message = (request.form.get('change_message') or '').strip()
     definition_text = form.definition.data or ''
 
+    user_server_templates = [
+        {
+            'id': f'user-{server.id}',
+            'name': server.name,
+            'definition': server.definition or '',
+            'suggested_name': f"{server.name}-copy" if server.name else '',
+        }
+        for server in get_user_template_servers(current_user.id)
+    ]
+
     if form.validate_on_submit():
         if create_entity(
             Server,
@@ -546,6 +557,7 @@ def new_server():
         form=form,
         title='Create New Server',
         server_templates=get_server_templates(),
+        user_server_templates=user_server_templates,
         server=None,
         interaction_history=interaction_history,
         ai_entity_name=entity_name_hint,

--- a/routes/variables.py
+++ b/routes/variables.py
@@ -11,7 +11,13 @@ from cid_utils import (
     get_current_variable_definitions_cid,
     store_variable_definitions_cid,
 )
-from db_access import delete_entity, get_user_variables, get_variable_by_name, save_entity
+from db_access import (
+    delete_entity,
+    get_user_template_variables,
+    get_user_variables,
+    get_variable_by_name,
+    save_entity,
+)
 from forms import BulkVariablesForm, VariableForm
 from identity import current_user
 from interaction_log import load_interaction_history
@@ -357,6 +363,16 @@ def new_variable():
     change_message = (request.form.get('change_message') or '').strip()
     definition_text = form.definition.data or ''
 
+    variable_templates = [
+        {
+            'id': variable.id,
+            'name': variable.name,
+            'definition': variable.definition or '',
+            'suggested_name': f"{variable.name}-copy" if variable.name else '',
+        }
+        for variable in get_user_template_variables(current_user.id)
+    ]
+
     if form.validate_on_submit():
         if create_entity(
             Variable,
@@ -380,6 +396,7 @@ def new_variable():
         ai_entity_name=entity_name_hint,
         ai_entity_name_field=form.name.id,
         matching_route=None,
+        variable_templates=variable_templates,
     )
 
 

--- a/templates/alias_form.html
+++ b/templates/alias_form.html
@@ -134,11 +134,36 @@
                             {% endif %}
                         </div>
 
+                        {% if alias_templates|default([]) %}
                         <div class="col-12">
-                            <div class="form-check form-switch">
-                                {{ form.enabled(class="form-check-input", role="switch") }}
-                                {{ form.enabled.label(class="form-check-label") }}
-                                <div class="form-text">Disabled aliases remain visible for editing and search but will not route requests.</div>
+                            <label class="form-label" for="alias-template-select">Start from an Alias Template</label>
+                            <div id="alias-template-select" class="d-flex flex-wrap gap-2" role="group" aria-label="Alias templates">
+                                {% for template in alias_templates %}
+                                <button type="button" class="btn btn-outline-secondary btn-sm px-2" data-alias-template-id="{{ template.id }}">
+                                    {{ template.name }}
+                                </button>
+                                {% endfor %}
+                            </div>
+                            <div class="form-text">Click a template to load its suggested name and definition. You can adjust the details before saving.</div>
+                        </div>
+                        {% endif %}
+
+                        <div class="col-12">
+                            <div class="row g-3">
+                                <div class="col-12 col-md-6">
+                                    <div class="form-check form-switch">
+                                        {{ form.enabled(class="form-check-input", role="switch") }}
+                                        {{ form.enabled.label(class="form-check-label") }}
+                                        <div class="form-text">Disabled aliases remain visible for editing and search but will not route requests.</div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    <div class="form-check form-switch">
+                                        {{ form.template(class="form-check-input", role="switch") }}
+                                        {{ form.template.label(class="form-check-label") }}
+                                        <div class="form-text">Mark this alias as a reusable template. Templates appear as starting points on the create page.</div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -231,6 +256,59 @@
     var parseMessage = parseIndicator ? parseIndicator.querySelector('[data-alias-parse-message]') : null;
     var parseDebounceTimer;
     var parseController;
+
+    var aliasTemplateButtons = document.querySelectorAll('[data-alias-template-id]');
+    var aliasTemplates = {{ alias_templates|default([])|tojson }};
+    if (aliasTemplateButtons.length && aliasTemplates.length) {
+        var aliasTemplateMap = {};
+        aliasTemplates.forEach(function (template) {
+            if (template && typeof template.id !== 'undefined') {
+                aliasTemplateMap[String(template.id)] = template;
+            }
+        });
+
+        aliasTemplateButtons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                var templateId = button.getAttribute('data-alias-template-id');
+                if (!templateId) {
+                    return;
+                }
+                var templateData = aliasTemplateMap[String(templateId)];
+                if (!templateData) {
+                    return;
+                }
+
+                var suggestedName = templateData.suggested_name || templateData.name || '';
+                if (nameField && suggestedName) {
+                    nameField.value = suggestedName;
+                    nameField.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+
+                var definitionValue = templateData.definition || '';
+                if (definitionField) {
+                    var editorController = window.codeEditors ? window.codeEditors[definitionField.id] : null;
+                    if (editorController && typeof editorController.setValue === 'function') {
+                        editorController.setValue(definitionValue);
+                        if (typeof editorController.focus === 'function') {
+                            editorController.focus();
+                        }
+                        if (typeof editorController.scrollIntoView === 'function') {
+                            editorController.scrollIntoView();
+                        }
+                    } else {
+                        definitionField.value = definitionValue;
+                        definitionField.dispatchEvent(new Event('input', { bubbles: true }));
+                        definitionField.focus();
+                    }
+                }
+
+                button.classList.add('active');
+                setTimeout(function () {
+                    button.classList.remove('active');
+                }, 1200);
+            });
+        });
+    }
 
     function escapeHtml(value) {
         return value.replace(/[&<>"']/g, function (character) {

--- a/templates/aliases.html
+++ b/templates/aliases.html
@@ -36,6 +36,9 @@
                                 {% if not alias.enabled %}
                                 <span class="badge text-bg-warning ms-2">Disabled</span>
                                 {% endif %}
+                                {% if alias.template %}
+                                <span class="badge text-bg-info ms-2">Template</span>
+                                {% endif %}
                             </td>
                             <td>
                                 <div><code>{{ alias.match_pattern }}</code></div>

--- a/templates/secret_form.html
+++ b/templates/secret_form.html
@@ -63,6 +63,21 @@
                                 </div>
                             {% endif %}
                         </div>
+
+                        {% if secret_templates|default([]) %}
+                        <div class="mb-3">
+                            <label class="form-label" for="secret-template-select">Start from a Secret Template</label>
+                            <div id="secret-template-select" class="d-flex flex-wrap gap-2" role="group" aria-label="Secret templates">
+                                {% for template in secret_templates %}
+                                <button type="button" class="btn btn-outline-secondary btn-sm px-2" data-secret-template-id="{{ template.id }}">
+                                    {{ template.name }}
+                                </button>
+                                {% endfor %}
+                            </div>
+                            <div class="form-text">Load a saved secret value into the form and make adjustments before saving.</div>
+                        </div>
+                        {% endif %}
+
                         {{ ai_text_controls(
                             form.definition.id,
                             'secret definition',
@@ -76,10 +91,21 @@
                             history_label='Recent edits and requests'
                         ) }}
 
-                        <div class="form-check form-switch mb-3">
-                            {{ form.enabled(class="form-check-input", role="switch") }}
-                            {{ form.enabled.label(class="form-check-label") }}
-                            <div class="form-text">Disable a secret to keep it out of execution contexts while retaining the value.</div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12 col-md-6">
+                                <div class="form-check form-switch">
+                                    {{ form.enabled(class="form-check-input", role="switch") }}
+                                    {{ form.enabled.label(class="form-check-label") }}
+                                    <div class="form-text">Disable a secret to keep it out of execution contexts while retaining the value.</div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-md-6">
+                                <div class="form-check form-switch">
+                                    {{ form.template(class="form-check-input", role="switch") }}
+                                    {{ form.template.label(class="form-check-label") }}
+                                    <div class="form-text">Mark this secret as a reusable template so it appears on the create page.</div>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
@@ -123,4 +149,65 @@
     {{ super() }}
     <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.6/src-min-noconflict/ace.js"></script>
     <script src="{{ url_for('static', filename='js/code_editor.js') }}"></script>
+    {% if secret_templates %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const templateButtons = document.querySelectorAll('[data-secret-template-id]');
+            if (!templateButtons.length) {
+                return;
+            }
+
+            const templates = {{ secret_templates|default([])|tojson }};
+            const templateMap = {};
+            templates.forEach(function (template) {
+                if (template && typeof template.id !== 'undefined') {
+                    templateMap[String(template.id)] = template;
+                }
+            });
+
+            const nameField = document.getElementById('{{ form.name.id }}');
+            const definitionField = document.getElementById('{{ form.definition.id }}');
+
+            templateButtons.forEach(function (button) {
+                button.addEventListener('click', function () {
+                    const templateId = button.getAttribute('data-secret-template-id');
+                    if (!templateId) {
+                        return;
+                    }
+
+                    const templateData = templateMap[String(templateId)];
+                    if (!templateData) {
+                        return;
+                    }
+
+                    const suggestedName = templateData.suggested_name || templateData.name || '';
+                    if (nameField && suggestedName) {
+                        nameField.value = suggestedName;
+                        nameField.dispatchEvent(new Event('input', { bubbles: true }));
+                    }
+
+                    const definitionValue = templateData.definition || '';
+                    if (definitionField) {
+                        const editorController = window.codeEditors ? window.codeEditors[definitionField.id] : null;
+                        if (editorController && typeof editorController.setValue === 'function') {
+                            editorController.setValue(definitionValue);
+                            if (typeof editorController.focus === 'function') {
+                                editorController.focus();
+                            }
+                        } else {
+                            definitionField.value = definitionValue;
+                            definitionField.dispatchEvent(new Event('input', { bubbles: true }));
+                            definitionField.focus();
+                        }
+                    }
+
+                    button.classList.add('active');
+                    setTimeout(function () {
+                        button.classList.remove('active');
+                    }, 1200);
+                });
+            });
+        });
+    </script>
+    {% endif %}
 {% endblock %}

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -32,6 +32,9 @@
                                 {% if not secret.enabled %}
                                 <span class="badge text-bg-warning ms-2">Disabled</span>
                                 {% endif %}
+                                {% if secret.template %}
+                                <span class="badge text-bg-info ms-2">Template</span>
+                                {% endif %}
                             </h5>
                             <div class="btn-group btn-group-sm">
                                 <a href="{{ url_for('main.view_secret', secret_name=secret.name) }}" class="btn btn-outline-primary btn-sm">

--- a/templates/server_form.html
+++ b/templates/server_form.html
@@ -131,6 +131,20 @@
                         </div>
                         {% endif %}
 
+                        {% if user_server_templates|default([]) %}
+                        <div class="col-12">
+                            <label class="form-label" for="user-server-template-select">Start from My Template</label>
+                            <div id="user-server-template-select" class="d-flex flex-wrap gap-2" role="group" aria-label="Saved server templates">
+                                {% for template in user_server_templates %}
+                                <button type="button" class="btn btn-outline-secondary btn-sm px-2" data-server-template-id="{{ template.id }}">
+                                    {{ template.name }}
+                                </button>
+                                {% endfor %}
+                            </div>
+                            <div class="form-text">Use one of your saved templates as the starting point for this server.</div>
+                        </div>
+                        {% endif %}
+
                         <div class="col-12">
                             {{ form.definition.label(class="form-label") }}
                             <div class="position-relative">
@@ -159,11 +173,22 @@
                             <div id="server-definition-errors" class="alert alert-danger mt-3 d-none" role="alert"></div>
                         </div>
 
-                        <div class="col-12 col-lg-6">
-                            <div class="form-check form-switch">
-                                {{ form.enabled(class="form-check-input", role="switch") }}
-                                {{ form.enabled.label(class="form-check-label") }}
-                                <div class="form-text">Disable a server to keep its definition without allowing execution.</div>
+                        <div class="col-12">
+                            <div class="row g-3">
+                                <div class="col-12 col-lg-6">
+                                    <div class="form-check form-switch">
+                                        {{ form.enabled(class="form-check-input", role="switch") }}
+                                        {{ form.enabled.label(class="form-check-label") }}
+                                        <div class="form-text">Disable a server to keep its definition without allowing execution.</div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-lg-6">
+                                    <div class="form-check form-switch">
+                                        {{ form.template(class="form-check-input", role="switch") }}
+                                        {{ form.template.label(class="form-check-label") }}
+                                        <div class="form-text">Mark this server as a reusable template so it appears on the create page.</div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
 
@@ -422,14 +447,16 @@ function loadHistoricalDefinition(index) {
     <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.6/src-min-noconflict/ace.js"></script>
     <script src="{{ url_for('static', filename='js/rename_controls.js') }}"></script>
     <script src="{{ url_for('static', filename='js/server_form.js') }}"></script>
-    {% if server_templates is defined and server_templates %}
+    {% if (server_templates is defined and server_templates) or user_server_templates|default([]) %}
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const templateButtons = document.querySelectorAll('[data-server-template-id]');
             const definitionField = document.getElementById('{{ form.definition.id }}');
             const nameField = document.getElementById('{{ form.name.id }}');
             const definitionEditor = window.serverDefinitionEditor;
-            const templates = {{ server_templates|tojson }};
+            const builtinTemplates = {{ server_templates|default([])|tojson }};
+            const savedTemplates = {{ user_server_templates|default([])|tojson }};
+            const templates = builtinTemplates.concat(savedTemplates);
 
             if (!templateButtons.length || !definitionField) {
                 return;
@@ -437,7 +464,10 @@ function loadHistoricalDefinition(index) {
 
             const templateMap = {};
             templates.forEach(function (template) {
-                templateMap[template.id] = template;
+                if (!template || typeof template.id === 'undefined') {
+                    return;
+                }
+                templateMap[String(template.id)] = template;
             });
 
             templateButtons.forEach(function (button) {
@@ -447,7 +477,7 @@ function loadHistoricalDefinition(index) {
                         return;
                     }
 
-                    const templateData = templateMap[templateId];
+                    const templateData = templateMap[String(templateId)];
                     if (!templateData) {
                         return;
                     }

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -42,6 +42,9 @@
                                     {% if not server.enabled %}
                                     <span class="badge text-bg-warning ms-2">Disabled</span>
                                     {% endif %}
+                                    {% if server.template %}
+                                    <span class="badge text-bg-info ms-2">Template</span>
+                                    {% endif %}
                                 </div>
                                 <div class="small text-muted">/servers/{{ server.name }}</div>
                             </td>

--- a/templates/variable_form.html
+++ b/templates/variable_form.html
@@ -63,6 +63,21 @@
                                 </div>
                             {% endif %}
                         </div>
+
+                        {% if variable_templates|default([]) %}
+                        <div class="mb-3">
+                            <label class="form-label" for="variable-template-select">Start from a Variable Template</label>
+                            <div id="variable-template-select" class="d-flex flex-wrap gap-2" role="group" aria-label="Variable templates">
+                                {% for template in variable_templates %}
+                                <button type="button" class="btn btn-outline-secondary btn-sm px-2" data-variable-template-id="{{ template.id }}">
+                                    {{ template.name }}
+                                </button>
+                                {% endfor %}
+                            </div>
+                            <div class="form-text">Load the saved value from a template and adjust it before saving.</div>
+                        </div>
+                        {% endif %}
+
                         {{ ai_text_controls(
                             form.definition.id,
                             'variable definition',
@@ -76,10 +91,21 @@
                             history_label='Recent edits and requests'
                         ) }}
 
-                        <div class="form-check form-switch mb-3">
-                            {{ form.enabled(class="form-check-input", role="switch") }}
-                            {{ form.enabled.label(class="form-check-label") }}
-                            <div class="form-text">Disable a variable to keep its value out of request contexts.</div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12 col-md-6">
+                                <div class="form-check form-switch">
+                                    {{ form.enabled(class="form-check-input", role="switch") }}
+                                    {{ form.enabled.label(class="form-check-label") }}
+                                    <div class="form-text">Disable a variable to keep its value out of request contexts.</div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-md-6">
+                                <div class="form-check form-switch">
+                                    {{ form.template(class="form-check-input", role="switch") }}
+                                    {{ form.template.label(class="form-check-label") }}
+                                    <div class="form-text">Mark this variable as a template so it appears on the create page.</div>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
@@ -144,4 +170,65 @@
     {{ super() }}
     <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.6/src-min-noconflict/ace.js"></script>
     <script src="{{ url_for('static', filename='js/code_editor.js') }}"></script>
+    {% if variable_templates %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const templateButtons = document.querySelectorAll('[data-variable-template-id]');
+            if (!templateButtons.length) {
+                return;
+            }
+
+            const templates = {{ variable_templates|default([])|tojson }};
+            const templateMap = {};
+            templates.forEach(function (template) {
+                if (template && typeof template.id !== 'undefined') {
+                    templateMap[String(template.id)] = template;
+                }
+            });
+
+            const nameField = document.getElementById('{{ form.name.id }}');
+            const definitionField = document.getElementById('{{ form.definition.id }}');
+
+            templateButtons.forEach(function (button) {
+                button.addEventListener('click', function () {
+                    const templateId = button.getAttribute('data-variable-template-id');
+                    if (!templateId) {
+                        return;
+                    }
+
+                    const templateData = templateMap[String(templateId)];
+                    if (!templateData) {
+                        return;
+                    }
+
+                    const suggestedName = templateData.suggested_name || templateData.name || '';
+                    if (nameField && suggestedName) {
+                        nameField.value = suggestedName;
+                        nameField.dispatchEvent(new Event('input', { bubbles: true }));
+                    }
+
+                    const definitionValue = templateData.definition || '';
+                    if (definitionField) {
+                        const editorController = window.codeEditors ? window.codeEditors[definitionField.id] : null;
+                        if (editorController && typeof editorController.setValue === 'function') {
+                            editorController.setValue(definitionValue);
+                            if (typeof editorController.focus === 'function') {
+                                editorController.focus();
+                            }
+                        } else {
+                            definitionField.value = definitionValue;
+                            definitionField.dispatchEvent(new Event('input', { bubbles: true }));
+                            definitionField.focus();
+                        }
+                    }
+
+                    button.classList.add('active');
+                    setTimeout(function () {
+                        button.classList.remove('active');
+                    }, 1200);
+                });
+            });
+        });
+    </script>
+    {% endif %}
 {% endblock %}

--- a/templates/variables.html
+++ b/templates/variables.html
@@ -32,6 +32,9 @@
                                 {% if not variable.enabled %}
                                 <span class="badge text-bg-warning ms-2">Disabled</span>
                                 {% endif %}
+                                {% if variable.template %}
+                                <span class="badge text-bg-info ms-2">Template</span>
+                                {% endif %}
                             </h5>
                             <div class="btn-group btn-group-sm">
                                 <a href="{{ url_for('main.view_variable', variable_name=variable.name) }}" class="btn btn-outline-primary btn-sm">

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -89,3 +89,36 @@ def test_alias_detail_page_displays_alias_information(
     assert "Alias Details" in page
     assert "<code>docs</code>" in page
     assert "<code>/docs</code>" in page
+
+
+def test_new_alias_form_includes_template_options(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Template aliases should surface as reusable buttons on the new form."""
+
+    with integration_app.app_context():
+        alias = Alias(
+            name="template-source",
+            user_id="default-user",
+            definition=format_primary_alias_line(
+                'literal',
+                '/template-source',
+                '/target',
+                alias_name='template-source',
+            ),
+            template=True,
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/aliases/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "data-alias-template-id" in page
+    assert "template-source" in page
+    assert "name=\"template\"" in page

--- a/tests/integration/test_secret_pages.py
+++ b/tests/integration/test_secret_pages.py
@@ -35,6 +35,34 @@ def test_new_secret_form_renders_for_authenticated_user(
     assert "name=\"definition\"" in page
 
 
+def test_new_secret_form_includes_templates(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Secrets flagged as templates should appear on the new form."""
+
+    with integration_app.app_context():
+        secret = Secret(
+            name="templated-secret",
+            definition="return 'secret'",
+            user_id="default-user",
+            template=True,
+        )
+        db.session.add(secret)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/secrets/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "data-secret-template-id" in page
+    assert "templated-secret" in page
+    assert "name=\"template\"" in page
+
+
 def test_edit_secret_form_displays_existing_secret(
     client,
     integration_app,

--- a/tests/integration/test_server_pages.py
+++ b/tests/integration/test_server_pages.py
@@ -148,6 +148,34 @@ def test_new_server_form_renders_for_authenticated_user(
     assert "name=\"definition\"" in page
 
 
+def test_new_server_form_includes_saved_templates(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """User-marked server templates should appear as reusable buttons."""
+
+    with integration_app.app_context():
+        server = Server(
+            name="templated-server",
+            definition="def main():\n    return {'output': 'ok'}\n",
+            user_id="default-user",
+            template=True,
+        )
+        db.session.add(server)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/servers/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "data-server-template-id" in page
+    assert "templated-server" in page
+    assert "name=\"template\"" in page
+
+
 def test_server_detail_page_displays_server_information(
     client,
     integration_app,

--- a/tests/integration/test_variable_pages.py
+++ b/tests/integration/test_variable_pages.py
@@ -89,6 +89,34 @@ def test_new_variable_form_renders_for_authenticated_user(
     assert 'name="definition"' in page
 
 
+def test_new_variable_form_includes_templates(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Variables marked as templates should appear on the creation form."""
+
+    with integration_app.app_context():
+        variable = Variable(
+            name="TEMPLATE_VAR",
+            definition="sample-value",
+            user_id="default-user",
+            template=True,
+        )
+        db.session.add(variable)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/variables/new")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert "data-variable-template-id" in page
+    assert "TEMPLATE_VAR" in page
+    assert "name=\"template\"" in page
+
+
 def test_edit_variable_form_displays_existing_variable_details(
     client,
     integration_app,

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -186,6 +186,8 @@ class ImportExportRoutesTestCase(unittest.TestCase):
         self.assertNotIn('definition', aliases[0])
         self.assertIn('enabled', aliases[0])
         self.assertTrue(aliases[0]['enabled'])
+        self.assertIn('template', aliases[0])
+        self.assertFalse(aliases[0]['template'])
         alias_definition_cid = aliases[0]['definition_cid']
 
         servers = self._load_section(payload, 'servers')
@@ -194,6 +196,8 @@ class ImportExportRoutesTestCase(unittest.TestCase):
         self.assertNotIn('definition', servers[0])
         self.assertIn('enabled', servers[0])
         self.assertTrue(servers[0]['enabled'])
+        self.assertIn('template', servers[0])
+        self.assertFalse(servers[0]['template'])
 
         cid_values = payload.get('cid_values', {})
         self.assertIn(alias_definition_cid, cid_values)
@@ -213,11 +217,15 @@ class ImportExportRoutesTestCase(unittest.TestCase):
         self.assertEqual(variables[0]['definition'], 'value')
         self.assertIn('enabled', variables[0])
         self.assertTrue(variables[0]['enabled'])
+        self.assertIn('template', variables[0])
+        self.assertFalse(variables[0]['template'])
 
         secrets_section = self._load_section(payload, 'secrets')
         self.assertEqual(secrets_section.get('encryption'), SECRET_ENCRYPTION_SCHEME)
         self.assertIn('enabled', secrets_section['items'][0])
         self.assertTrue(secrets_section['items'][0]['enabled'])
+        self.assertIn('template', secrets_section['items'][0])
+        self.assertFalse(secrets_section['items'][0]['template'])
         ciphertext = secrets_section['items'][0]['ciphertext']
         self.assertEqual(decrypt_secret_value(ciphertext, 'passphrase'), 'super-secret')
 
@@ -290,9 +298,17 @@ class ImportExportRoutesTestCase(unittest.TestCase):
         secrets_section = self._load_section(payload, 'secrets')
 
         self.assertFalse(alias_entries[0]['enabled'])
+        self.assertIn('template', alias_entries[0])
+        self.assertFalse(alias_entries[0]['template'])
         self.assertFalse(server_entries[0]['enabled'])
+        self.assertIn('template', server_entries[0])
+        self.assertFalse(server_entries[0]['template'])
         self.assertFalse(variable_entries[0]['enabled'])
+        self.assertIn('template', variable_entries[0])
+        self.assertFalse(variable_entries[0]['template'])
         self.assertFalse(secrets_section['items'][0]['enabled'])
+        self.assertIn('template', secrets_section['items'][0])
+        self.assertFalse(secrets_section['items'][0]['template'])
 
         with self.app.app_context():
             Alias.query.delete()

--- a/tests/test_routes_comprehensive.py
+++ b/tests/test_routes_comprehensive.py
@@ -1483,6 +1483,7 @@ class TestServerRoutes(BaseTestCase):
         response = self.client.post('/servers/new', data={
             'name': 'test-server',
             'definition': 'Test server definition',
+            'template': 'y',
             'submit': 'Save Server'
         }, follow_redirects=True)
 
@@ -1492,6 +1493,7 @@ class TestServerRoutes(BaseTestCase):
         server = Server.query.filter_by(user_id=self.test_user_id, name='test-server').first()
         self.assertIsNotNone(server)
         self.assertEqual(server.definition, 'Test server definition')
+        self.assertTrue(server.template)
 
     def test_new_server_duplicate_name(self):
         """Test creating server with duplicate name."""
@@ -1817,6 +1819,7 @@ class TestVariableRoutes(BaseTestCase):
         response = self.client.post('/variables/new', data={
             'name': 'test-variable',
             'definition': 'Test variable definition',
+            'template': 'y',
             'submit': 'Save Variable'
         }, follow_redirects=True)
 
@@ -1826,6 +1829,7 @@ class TestVariableRoutes(BaseTestCase):
         variable = Variable.query.filter_by(user_id=self.test_user_id, name='test-variable').first()
         self.assertIsNotNone(variable)
         self.assertEqual(variable.definition, 'Test variable definition')
+        self.assertTrue(variable.template)
 
     def test_new_variable_form_includes_ai_controls(self):
         """Variable form should expose AI helper controls."""
@@ -1926,6 +1930,7 @@ class TestSecretRoutes(BaseTestCase):
         response = self.client.post('/secrets/new', data={
             'name': 'test-secret',
             'definition': 'Test secret definition',
+            'template': 'y',
             'submit': 'Save Secret'
         }, follow_redirects=True)
 
@@ -1935,6 +1940,7 @@ class TestSecretRoutes(BaseTestCase):
         secret = Secret.query.filter_by(user_id=self.test_user_id, name='test-secret').first()
         self.assertIsNotNone(secret)
         self.assertEqual(secret.definition, 'Test secret definition')
+        self.assertTrue(secret.template)
 
     def test_new_secret_form_includes_ai_controls(self):
         """Secret form should expose AI helper controls."""


### PR DESCRIPTION
## Summary
- add template flags to alias, server, variable, and secret models and expose matching fields on their forms
- allow users to reuse their template entries when creating new records and surface template state in list views
- ensure import/export workflows and tests account for template metadata and new UI behaviors

## Testing
- pytest tests/integration/test_alias_pages.py tests/integration/test_server_pages.py tests/integration/test_variable_pages.py tests/integration/test_secret_pages.py tests/test_import_export.py tests/test_routes_comprehensive.py

------
https://chatgpt.com/codex/tasks/task_b_69067745b2648331a47d7259d11bff0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now mark servers, aliases, variables, and secrets as reusable templates for future creation
  * New template selection UI in entity creation forms allows users to quickly populate configurations from saved templates
  * Template entities are identified with badges throughout list views
  * Import/export functionality now preserves template settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->