### PR TITLE
Add PurgeCSS warning check to local scripts and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,25 @@ jobs:
       - name: Run Stylelint
         run: npm run lint:css
 
+  purgecss:
+    name: PurgeCSS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run PurgeCSS check
+        run: npm run purgecss:check
+
   test-index:
     name: Test Index Validation
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "type": "commonjs",
   "scripts": {
     "lint": "eslint \"static/js/**/*.js\" --max-warnings=0 --no-error-on-unmatched-pattern",
-    "lint:css": "stylelint \"static/**/*.css\" --max-warnings=0"
+    "lint:css": "stylelint \"static/**/*.css\" --max-warnings=0",
+    "purgecss:check": "node scripts/purgecss-check.mjs"
   },
   "devDependencies": {
     "eslint": "^8.56.0",
+    "purgecss": "^6.0.0",
     "stylelint": "^16.8.0",
     "stylelint-config-standard": "^36.0.0"
   }

--- a/scripts/purgecss-check.mjs
+++ b/scripts/purgecss-check.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { PurgeCSS } from 'purgecss';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+async function main() {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = path.dirname(currentFile);
+  const projectRoot = path.resolve(currentDir, '..');
+
+  const purgeCSS = new PurgeCSS();
+  const results = await purgeCSS.purge({
+    css: [path.join(projectRoot, 'static/**/*.css')],
+    content: [
+      path.join(projectRoot, 'templates/**/*.html'),
+      path.join(projectRoot, 'templates/**/*.j2'),
+      path.join(projectRoot, 'static/js/**/*.js'),
+    ],
+  });
+
+  const warnings = results.flatMap((entry) => entry.warnings ?? []);
+
+  if (warnings.length > 0) {
+    console.error('PurgeCSS warnings detected:');
+    for (const warning of warnings) {
+      console.error(`- ${warning}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('PurgeCSS completed without warnings.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a PurgeCSS-driven warning check script for the static assets
- expose the check through an npm script and ensure PurgeCSS is available locally
- run the PurgeCSS check as its own CI job so failures are reported independently

## Testing
- `npm install` *(fails in container: 403 Forbidden when contacting registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_6906bc9821588331a41840b1c906ff83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated CSS analysis to the CI pipeline.
  * Introduced a new npm script for local CSS checking.
  * Integrated PurgeCSS tooling into the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->