### PR TITLE
Add alias enablement toggles

### DIFF
--- a/routes/openapi.py
+++ b/routes/openapi.py
@@ -517,6 +517,22 @@ def _alias_form_schema() -> Dict[str, Any]:
     }
 
 
+def _alias_enabled_update_schema() -> Dict[str, Any]:
+    """Schema describing alias enabled state updates."""
+
+    return {
+        "type": "object",
+        "required": ["enabled"],
+        "properties": {
+            "enabled": {
+                "type": "boolean",
+                "description": "Whether the alias should be active after the update.",
+            }
+        },
+        "additionalProperties": False,
+    }
+
+
 def _server_form_schema() -> Dict[str, Any]:
     """Schema for server create/edit submissions."""
 
@@ -979,6 +995,57 @@ def _build_openapi_spec() -> Dict[str, Any]:
                 },
             },
         },
+        "/aliases/{alias_name}/enabled": {
+            "parameters": [_path_parameter("alias_name", "Alias name to toggle.")],
+            "post": {
+                "tags": ["Aliases"],
+                "summary": "Update alias enabled state",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {"$ref": "#/components/schemas/AliasEnabledUpdate"}
+                        },
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/AliasEnabledUpdate"}
+                        },
+                    },
+                },
+                "responses": {
+                    "302": _redirect_response("Alias enabled state updated and browser redirected."),
+                    "200": {
+                        "description": "Alias enabled state updated.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["alias", "enabled"],
+                                    "properties": {
+                                        "alias": {
+                                            "type": "string",
+                                            "description": "Alias name.",
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Whether the alias is enabled after the update.",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                    },
+                    "400": {
+                        "description": "Invalid enabled value supplied.",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                    "404": _html_response("Alias not found."),
+                },
+            },
+        },
         "/aliases/{alias_name}/delete": {
             "parameters": [_path_parameter("alias_name", "Alias name to delete.")],
             "post": {
@@ -1414,6 +1481,7 @@ def _build_openapi_spec() -> Dict[str, Any]:
                 "VariableRecord": _variable_record_schema(),
                 "SecretRecord": _secret_record_schema(),
                 "AliasFormSubmission": _alias_form_schema(),
+                "AliasEnabledUpdate": _alias_enabled_update_schema(),
                 "ServerFormSubmission": _server_form_schema(),
                 "VariableFormSubmission": _variable_form_schema(),
                 "VariablesBulkEditFormSubmission": _variables_bulk_edit_form_schema(),

--- a/templates/aliases.html
+++ b/templates/aliases.html
@@ -21,6 +21,7 @@
                             <th scope="col">Name</th>
                             <th scope="col">Match</th>
                             <th scope="col">Target</th>
+                            <th scope="col" class="text-center">Status</th>
                             <th scope="col" class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -56,6 +57,32 @@
                                         <code>{{ alias.target_path }}</code>
                                     {% endif %}
                                 {% endif %}
+                            </td>
+                            <td class="text-center">
+                                {% set toggle_id = 'alias-enabled-toggle-' ~ alias.name %}
+                                <form
+                                    method="post"
+                                    action="{{ url_for('main.update_alias_enabled', alias_name=alias.name) }}"
+                                    class="d-inline-block"
+                                >
+                                    <input type="hidden" name="enabled" value="0">
+                                    <div class="form-check form-switch d-inline-flex align-items-center gap-2 mb-0 justify-content-center">
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"
+                                            role="switch"
+                                            id="{{ toggle_id }}"
+                                            name="enabled"
+                                            value="1"
+                                            {% if alias.enabled %}checked{% endif %}
+                                            aria-label="Toggle {{ alias.name }} alias"
+                                            onchange="this.form.submit()"
+                                        >
+                                        <label class="form-check-label small text-muted fw-semibold alias-enabled-label" for="{{ toggle_id }}">
+                                            {% if alias.enabled %}Enabled{% else %}Disabled{% endif %}
+                                        </label>
+                                    </div>
+                                </form>
                             </td>
                             <td class="text-end">
                                 <a href="{{ url_for('main.view_alias', alias_name=alias.name) }}" class="btn btn-outline-primary btn-sm">

--- a/tests/integration/test_alias_pages.py
+++ b/tests/integration/test_alias_pages.py
@@ -1,6 +1,8 @@
 """Integration coverage for alias management pages."""
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from alias_definition import format_primary_alias_line
@@ -39,6 +41,88 @@ def test_aliases_page_lists_user_aliases(
     page = response.get_data(as_text=True)
     assert "docs" in page
     assert "/docs" in page
+
+
+def test_aliases_page_includes_enabled_toggle(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Each alias entry should expose a toggle reflecting its enabled state."""
+
+    with integration_app.app_context():
+        alias = Alias(
+            name="docs",
+            user_id="default-user",
+            enabled=False,
+            definition=format_primary_alias_line(
+                "literal",
+                None,
+                "/docs",
+                alias_name="docs",
+            ),
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.get("/aliases")
+    assert response.status_code == 200
+
+    page = response.get_data(as_text=True)
+    assert 'action="/aliases/docs/enabled"' in page
+    toggle_match = re.search(r'id="alias-enabled-toggle-docs"[^>]*>', page)
+    assert toggle_match is not None
+    assert 'checked' not in toggle_match.group(0)
+    assert 'alias-enabled-label' in page
+
+
+def test_alias_enable_toggle_updates_state(
+    client,
+    integration_app,
+    login_default_user,
+):
+    """Submitting the toggle form should persist the new enabled state."""
+
+    with integration_app.app_context():
+        alias = Alias(
+            name="docs",
+            user_id="default-user",
+            enabled=False,
+            definition=format_primary_alias_line(
+                "literal",
+                None,
+                "/docs",
+                alias_name="docs",
+            ),
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    login_default_user()
+
+    response = client.post(
+        "/aliases/docs/enabled",
+        data={"enabled": ["0", "1"]},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with integration_app.app_context():
+        alias = Alias.query.filter_by(user_id="default-user", name="docs").one()
+        assert alias.enabled is True
+
+    response = client.post(
+        "/aliases/docs/enabled",
+        data={"enabled": "0"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with integration_app.app_context():
+        alias = Alias.query.filter_by(user_id="default-user", name="docs").one()
+        assert alias.enabled is False
 
 
 def test_new_alias_form_renders_for_authenticated_user(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -66,6 +66,7 @@ class TestOpenAPI(unittest.TestCase):
             '/aliases/new': ['get', 'post'],
             '/aliases/{alias_name}': ['get'],
             '/aliases/{alias_name}/edit': ['get', 'post'],
+            '/aliases/{alias_name}/enabled': ['post'],
             '/aliases/{alias_name}/delete': ['post'],
             '/aliases/match-preview': ['post'],
             '/servers': ['get'],


### PR DESCRIPTION
## Summary
- add a status column with enable/disable toggles on the aliases listing page
- add a POST endpoint that persists alias enabled state changes and document it in the OpenAPI spec
- extend integration and OpenAPI tests to cover the new controls

## Testing
- pytest -m integration tests/integration/test_alias_pages.py
- pytest tests/test_openapi.py
- pytest tests/test_routes_comprehensive.py

------
https://chatgpt.com/codex/tasks/task_b_69075f4bb22c83318d80521698b8c887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Status column to the aliases table displaying the current enabled or disabled state for each alias
  * New interactive toggle switch enables quick enable/disable control for individual aliases
  * All status changes are automatically saved to the database

<!-- end of auto-generated comment: release notes by coderabbit.ai -->