### PR TITLE
Add toggles to manage server, variable, and secret enablement

### DIFF
--- a/routes/enabled.py
+++ b/routes/enabled.py
@@ -1,0 +1,64 @@
+"""Shared helpers for handling enabled/disabled toggles across routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import request
+
+_TRUE_ENABLED_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_ENABLED_VALUES = {"0", "false", "f", "no", "n", "off", ""}
+
+
+def coerce_enabled_value(raw_value: Any) -> bool:
+    """Interpret an enabled value from form or JSON submissions."""
+
+    if isinstance(raw_value, bool):
+        return raw_value
+    if raw_value is None:
+        raise ValueError("Missing enabled value")
+
+    text = str(raw_value).strip().lower()
+    if text in _TRUE_ENABLED_VALUES:
+        return True
+    if text in _FALSE_ENABLED_VALUES:
+        return False
+    raise ValueError(f"Unrecognized enabled value: {raw_value}")
+
+
+def extract_enabled_value_from_request() -> bool:
+    """Return the desired enabled value from the current request payload."""
+
+    if request.is_json:
+        payload = request.get_json(silent=True) or {}
+        if "enabled" not in payload:
+            raise ValueError("Missing enabled value")
+        return coerce_enabled_value(payload.get("enabled"))
+
+    values = request.form.getlist("enabled")
+    if not values:
+        raise ValueError("Missing enabled value")
+    return coerce_enabled_value(values[-1])
+
+
+def request_prefers_json() -> bool:
+    """Return True when the current request expects a JSON response."""
+
+    if request.is_json:
+        return True
+
+    best = request.accept_mimetypes.best
+    if best == "application/json" and (
+        request.accept_mimetypes["application/json"]
+        > request.accept_mimetypes["text/html"]
+    ):
+        return True
+
+    return False
+
+
+__all__ = [
+    "coerce_enabled_value",
+    "extract_enabled_value_from_request",
+    "request_prefers_json",
+]

--- a/templates/secrets.html
+++ b/templates/secrets.html
@@ -26,7 +26,7 @@
                 {% for secret in secrets %}
                 <div class="col-lg-6 mb-4">
                     <div class="card h-100">
-                        <div class="card-header d-flex justify-content-between align-items-center">
+                        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
                             <h5 class="card-title mb-0">
                                 <i class="fas fa-key me-2"></i>{{ secret.name }}
                                 {% if not secret.enabled %}
@@ -36,13 +36,39 @@
                                 <span class="badge text-bg-info ms-2">Template</span>
                                 {% endif %}
                             </h5>
-                            <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('main.view_secret', secret_name=secret.name) }}" class="btn btn-outline-primary btn-sm">
-                                    <i class="fas fa-eye me-1"></i>View
-                                </a>
-                                <a href="{{ url_for('main.edit_secret', secret_name=secret.name) }}" class="btn btn-outline-secondary btn-sm">
-                                    <i class="fas fa-edit me-1"></i>Edit
-                                </a>
+                            <div class="d-flex align-items-center gap-3">
+                                {% set toggle_id = 'secret-enabled-toggle-' ~ secret.name %}
+                                <form
+                                    method="post"
+                                    action="{{ url_for('main.update_secret_enabled', secret_name=secret.name) }}"
+                                    class="d-inline-block"
+                                >
+                                    <input type="hidden" name="enabled" value="0">
+                                    <div class="form-check form-switch d-inline-flex align-items-center gap-2 mb-0">
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"
+                                            role="switch"
+                                            id="{{ toggle_id }}"
+                                            name="enabled"
+                                            value="1"
+                                            {% if secret.enabled %}checked{% endif %}
+                                            aria-label="Toggle {{ secret.name }} secret"
+                                            onchange="this.form.submit()"
+                                        >
+                                        <label class="form-check-label small text-muted fw-semibold secret-enabled-label" for="{{ toggle_id }}">
+                                            {% if secret.enabled %}Enabled{% else %}Disabled{% endif %}
+                                        </label>
+                                    </div>
+                                </form>
+                                <div class="btn-group btn-group-sm">
+                                    <a href="{{ url_for('main.view_secret', secret_name=secret.name) }}" class="btn btn-outline-primary btn-sm">
+                                        <i class="fas fa-eye me-1"></i>View
+                                    </a>
+                                    <a href="{{ url_for('main.edit_secret', secret_name=secret.name) }}" class="btn btn-outline-secondary btn-sm">
+                                        <i class="fas fa-edit me-1"></i>Edit
+                                    </a>
+                                </div>
                             </div>
                         </div>
                         <div class="card-body">

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -29,6 +29,7 @@
                             <th scope="col">Variables</th>
                             <th scope="col">Secrets</th>
                             <th scope="col">Routes</th>
+                            <th scope="col" class="text-center">Enabled</th>
                             <th scope="col" class="text-end">Actions</th>
                         </tr>
                     </thead>
@@ -92,6 +93,32 @@
                                 {% else %}
                                 <span class="text-muted">None</span>
                                 {% endif %}
+                            </td>
+                            <td class="text-center">
+                                {% set toggle_id = 'server-enabled-toggle-' ~ server.name %}
+                                <form
+                                    method="post"
+                                    action="{{ url_for('main.update_server_enabled', server_name=server.name) }}"
+                                    class="d-inline-block"
+                                >
+                                    <input type="hidden" name="enabled" value="0">
+                                    <div class="form-check form-switch d-inline-flex align-items-center gap-2 mb-0 justify-content-center">
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"
+                                            role="switch"
+                                            id="{{ toggle_id }}"
+                                            name="enabled"
+                                            value="1"
+                                            {% if server.enabled %}checked{% endif %}
+                                            aria-label="Toggle {{ server.name }} server"
+                                            onchange="this.form.submit()"
+                                        >
+                                        <label class="form-check-label small text-muted fw-semibold server-enabled-label" for="{{ toggle_id }}">
+                                            {% if server.enabled %}Enabled{% else %}Disabled{% endif %}
+                                        </label>
+                                    </div>
+                                </form>
                             </td>
                             <td class="text-end">
                                 <div class="d-flex flex-wrap justify-content-end gap-2">

--- a/templates/variables.html
+++ b/templates/variables.html
@@ -26,7 +26,7 @@
                 {% for variable in variables %}
                 <div class="col-lg-6 mb-4">
                     <div class="card h-100">
-                        <div class="card-header d-flex justify-content-between align-items-center">
+                        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
                             <h5 class="card-title mb-0">
                                 <i class="fas fa-code me-2"></i>{{ variable.name }}
                                 {% if not variable.enabled %}
@@ -36,13 +36,39 @@
                                 <span class="badge text-bg-info ms-2">Template</span>
                                 {% endif %}
                             </h5>
-                            <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('main.view_variable', variable_name=variable.name) }}" class="btn btn-outline-primary btn-sm">
-                                    <i class="fas fa-eye me-1"></i>View
-                                </a>
-                                <a href="{{ url_for('main.edit_variable', variable_name=variable.name) }}" class="btn btn-outline-secondary btn-sm">
-                                    <i class="fas fa-edit me-1"></i>Edit
-                                </a>
+                            <div class="d-flex align-items-center gap-3">
+                                {% set toggle_id = 'variable-enabled-toggle-' ~ variable.name %}
+                                <form
+                                    method="post"
+                                    action="{{ url_for('main.update_variable_enabled', variable_name=variable.name) }}"
+                                    class="d-inline-block"
+                                >
+                                    <input type="hidden" name="enabled" value="0">
+                                    <div class="form-check form-switch d-inline-flex align-items-center gap-2 mb-0">
+                                        <input
+                                            class="form-check-input"
+                                            type="checkbox"
+                                            role="switch"
+                                            id="{{ toggle_id }}"
+                                            name="enabled"
+                                            value="1"
+                                            {% if variable.enabled %}checked{% endif %}
+                                            aria-label="Toggle {{ variable.name }} variable"
+                                            onchange="this.form.submit()"
+                                        >
+                                        <label class="form-check-label small text-muted fw-semibold variable-enabled-label" for="{{ toggle_id }}">
+                                            {% if variable.enabled %}Enabled{% else %}Disabled{% endif %}
+                                        </label>
+                                    </div>
+                                </form>
+                                <div class="btn-group btn-group-sm">
+                                    <a href="{{ url_for('main.view_variable', variable_name=variable.name) }}" class="btn btn-outline-primary btn-sm">
+                                        <i class="fas fa-eye me-1"></i>View
+                                    </a>
+                                    <a href="{{ url_for('main.edit_variable', variable_name=variable.name) }}" class="btn btn-outline-secondary btn-sm">
+                                        <i class="fas fa-edit me-1"></i>Edit
+                                    </a>
+                                </div>
                             </div>
                         </div>
                         <div class="card-body">


### PR DESCRIPTION
## Summary
- add a shared enabled-toggle helper so routes can parse toggle requests consistently
- expose enable/disable switches on the servers, variables, and secrets index pages
- persist toggle changes with dedicated endpoints and cover the new behavior with integration tests

## Testing
- pytest -m integration tests/integration/test_server_pages.py tests/integration/test_variable_pages.py tests/integration/test_secret_pages.py

------
https://chatgpt.com/codex/tasks/task_b_690763463d588331961024593251f7cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enable/disable toggle controls to the secrets, servers, and variables list pages for quick status management
  * Toggles save state immediately with visual feedback on enabled/disabled status

* **Tests**
  * Added comprehensive integration tests for enable/disable toggle functionality across all entity types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->