### PR TITLE
Ensure export JSON lists cid_values last

### DIFF
--- a/routes/import_export.py
+++ b/routes/import_export.py
@@ -1089,7 +1089,12 @@ def _build_export_payload(
             cid: cid_writer.cid_map_entries[cid] for cid in sorted(cid_writer.cid_map_entries)
         }
 
-    json_payload = json.dumps(payload, indent=2, sort_keys=True)
+    ordered_keys = sorted(key for key in payload if key != 'cid_values')
+    if 'cid_values' in payload:
+        ordered_keys.append('cid_values')
+
+    ordered_payload = {key: payload[key] for key in ordered_keys}
+    json_payload = json.dumps(ordered_payload, indent=2)
     json_bytes = json_payload.encode('utf-8')
 
     if store_content:

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1351,6 +1351,11 @@ class ImportExportRoutesTestCase(unittest.TestCase):
         self.assertEqual(result['cid_value'], f'cid-{len(store_bytes_stub.calls)}')
         self.assertEqual(result['download_path'], '/downloads/export.json')
         self.assertGreaterEqual(len(store_bytes_stub.calls), 1)
+        ordered_pairs = json.loads(result['json_payload'], object_pairs_hook=list)
+        top_level_keys = [key for key, _ in ordered_pairs]
+        self.assertIn('cid_values', top_level_keys)
+        self.assertEqual(top_level_keys[:-1], sorted(top_level_keys[:-1]))
+        self.assertEqual(top_level_keys[-1], 'cid_values')
         payload = json.loads(store_bytes_stub.calls[-1].decode('utf-8'))
         self.assertIn('aliases', payload)
         self.assertIn('cid_values', payload)


### PR DESCRIPTION
## Summary
- ensure the export payload orders its top-level keys alphabetically while forcing `cid_values` to appear last
- cover the export payload ordering with a regression test on the alias export path

## Testing
- pytest tests/test_import_export.py::ImportExportRoutesTestCase::test_build_export_payload_collects_aliases

------
https://chatgpt.com/codex/tasks/task_b_69076bfd62ec833183eab83806bad982