### PR TITLE
Load CID fixtures during app startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from os import getenv
+from pathlib import Path
 from typing import Any, Optional
 
 import logfire
@@ -11,6 +12,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from ai_defaults import ensure_ai_stub_for_all_users
 from css_defaults import ensure_css_alias_for_all_users
+from cid_directory_loader import load_cids_from_directory
 from cid_presenter import (
     cid_full_url,
     cid_path,
@@ -117,6 +119,7 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
         "GITHUB_REPOSITORY_URL",
         os.environ.get("GITHUB_REPOSITORY_URL", "https://github.com/curtcox/Viewer"),
     )
+    app.config.setdefault("CID_DIRECTORY", str(Path(app.root_path) / "cids"))
 
     if config_override:
         app.config.update(config_override)
@@ -190,7 +193,8 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
         db.create_all()
         logging.info("Database tables created")
 
-        ensure_default_user()
+        default_user = ensure_default_user()
+        load_cids_from_directory(app, default_user.id)
 
         # Set up observability status for template context
         logfire_enabled = logfire_available

--- a/cid_directory_loader.py
+++ b/cid_directory_loader.py
@@ -1,0 +1,82 @@
+"""Utilities for loading CID fixtures from the filesystem."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from flask import Flask
+
+from cid_utils import generate_cid, is_normalized_cid
+from db_access import create_cid_record, get_cid_by_path
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _iter_candidate_files(directory: Path) -> Iterable[Path]:
+    """Yield files from the directory that could contain CID fixtures."""
+
+    for entry in sorted(directory.iterdir()):
+        if entry.name.startswith("."):
+            # Hidden files (such as .gitignore) are not CID fixtures.
+            continue
+        if not entry.is_file():
+            continue
+        yield entry
+
+
+def load_cids_from_directory(app: Flask, user_id: str) -> None:
+    """Ensure the database contains CID entries for files in the directory.
+
+    The directory defaults to ``app.root_path / "cids"`` but can be overridden via
+    the ``CID_DIRECTORY`` configuration option. Each file's name must exactly match
+    the generated CID for its contents. Any mismatch terminates the application
+    immediately.
+    """
+
+    configured_directory = app.config.get("CID_DIRECTORY")
+    directory = Path(configured_directory) if configured_directory else Path(app.root_path) / "cids"
+
+    directory.mkdir(parents=True, exist_ok=True)
+
+    if not directory.is_dir():
+        message = f"CID directory {directory} is not a directory"
+        LOGGER.error(message)
+        raise SystemExit(message)
+
+    for file_path in _iter_candidate_files(directory):
+        filename = file_path.name
+
+        if not is_normalized_cid(filename):
+            message = (
+                f"CID filename {filename!r} in {directory} is not a valid normalized CID"
+            )
+            LOGGER.error(message)
+            raise SystemExit(message)
+
+        file_bytes = file_path.read_bytes()
+        generated_cid = generate_cid(file_bytes)
+
+        if filename != generated_cid:
+            message = (
+                f"CID filename mismatch for {file_path}: "
+                f"filename {filename} does not match generated CID {generated_cid}"
+            )
+            LOGGER.error(message)
+            raise SystemExit(message)
+
+        cid_path = f"/{generated_cid}"
+        existing = get_cid_by_path(cid_path)
+
+        if existing is None:
+            create_cid_record(generated_cid, file_bytes, user_id)
+            LOGGER.info("Loaded CID %s from %s", generated_cid, file_path)
+        else:
+            if existing.file_data != file_bytes:
+                message = (
+                    f"CID {generated_cid} already exists in the database with different content"
+                )
+                LOGGER.error(message)
+                raise SystemExit(message)
+            LOGGER.debug("CID %s already present in database; skipping", generated_cid)

--- a/cids/.gitignore
+++ b/cids/.gitignore
@@ -1,0 +1,3 @@
+# Keep the cids directory in version control without shipping fixtures.
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- load CID fixtures from a configurable directory when the Flask app starts and ensure filenames match their content-derived CIDs
- add a loader utility that validates CID files, skips hidden entries, and populates the database while aborting on inconsistencies
- extend the startup test suite to cover successful CID imports and immediate termination on CID mismatches

## Testing
- pytest tests/test_app_startup.py


------
https://chatgpt.com/codex/tasks/task_b_6907865bc1a48331b58d36cd97f50d44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically loads content identifier fixtures from a designated directory during startup.
  * Added validation to ensure fixture file contents match their identifiers, with error handling for mismatches.

* **Tests**
  * Added tests for successful fixture loading and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->