### PR TITLE
Improve context reference extraction coverage and refactor helper

### DIFF
--- a/tests/test_extract_context_references.py
+++ b/tests/test_extract_context_references.py
@@ -1,0 +1,60 @@
+"""Tests for :func:`routes.servers._extract_context_references`."""
+
+from __future__ import annotations
+
+from routes.servers import _extract_context_references
+
+
+def test_returns_empty_collections_for_blank_definitions() -> None:
+    """Missing or empty definitions should result in empty lists."""
+
+    assert _extract_context_references(None) == {"variables": [], "secrets": []}
+    assert _extract_context_references("") == {"variables": [], "secrets": []}
+
+
+def test_detects_direct_and_alias_based_context_usage() -> None:
+    """Variables and secrets accessed directly or via aliases should be reported."""
+
+    definition = """
+variables_alias = context['variables']
+secrets_alias = context.get('secrets', {})
+
+direct_var = context['variables']['direct']
+explicit_secret = context['secrets'].get('explicit')
+
+alias_index = variables_alias['alias-index']
+alias_get = variables_alias.get('alias-get')
+
+token = secrets_alias.get('token')
+password = secrets_alias['password']
+
+# Duplicate references should not change the outcome
+extra_direct = context['variables']['direct']
+unused = secrets_alias.get('token')
+"""
+
+    references = _extract_context_references(definition)
+
+    assert references["variables"] == ["alias-get", "alias-index", "direct"]
+    assert references["secrets"] == ["explicit", "password", "token"]
+
+
+def test_alias_matching_requires_word_boundaries() -> None:
+    """Accesses using identifiers that merely contain an alias should be ignored."""
+
+    definition = """
+vars = context['variables']
+secret_alias = context['secrets']
+
+city = vars['city']
+# These should not match because the alias is part of a larger identifier
+other = myvars['country']
+ignored = secret_alias_extra.get('ignored')
+
+token = secret_alias.get('token')
+"""
+
+    references = _extract_context_references(definition)
+
+    assert references["variables"] == ["city"]
+    assert references["secrets"] == ["token"]


### PR DESCRIPTION
## Summary
- add targeted tests for `_extract_context_references` covering blank definitions, alias usage, and boundary handling
- refactor the helper to consolidate match collection and improve readability while preserving behavior

## Testing
- pytest tests/test_extract_context_references.py tests/test_server_template_references.py

------
https://chatgpt.com/codex/tasks/task_b_6908278772b083318d2439a6159e3bca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal context reference extraction logic for better performance and accuracy in detecting variables and secrets.

* **Tests**
  * Added comprehensive test coverage for context reference detection, including direct and alias-based access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->