### PR TITLE
Improve alias definition coverage and refactor route collection

### DIFF
--- a/tests/test_alias_routes_integration.py
+++ b/tests/test_alias_routes_integration.py
@@ -229,6 +229,18 @@ class AliasRoutesIntegrationTests(unittest.TestCase):
         self.assertEqual(route.target_path, "/test")
         self.assertFalse(route.ignore_case)
 
+    def test_collect_routes_rejects_external_target_fallback(self):
+        """Routes are not generated when the definition targets an external URL."""
+        alias = Alias(
+            name="docs",
+            definition="docs -> //external",
+            user_id="user1",
+        )
+
+        routes = collect_alias_routes(alias)
+
+        self.assertEqual(routes, [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add focused unit tests covering alias definition validation helpers and utilities
- extend integration coverage to ensure external targets do not produce fallback routes
- refactor collect_alias_routes to simplify control flow and reuse a shared literal fallback helper

## Testing
- pytest tests/test_alias_definition.py tests/test_alias_routes_integration.py

------
https://chatgpt.com/codex/tasks/task_b_690827e666a48331a6a0b17729830429