### PR TITLE
Debug Mac test failure with file paths

### DIFF
--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1237,7 +1237,7 @@ class ImportExportRoutesTestCase(unittest.TestCase):
                 base_path.resolve(),
                 warnings,
             )
-            self.assertEqual(resolved, local_file)
+            self.assertEqual(resolved, local_file.resolve())
 
             content = import_export._load_source_entry_bytes(resolved, parsed, warnings)
             self.assertEqual(content, file_bytes)


### PR DESCRIPTION
On macOS, /var is a symlink to /private/var. The test was comparing:
- resolved path (with symlinks followed): /private/var/...
- unresolved path: /var/...

This caused the test to fail even though the paths refer to the same file.

The fix resolves both paths before comparison, ensuring they're in canonical form on all platforms (macOS, Linux, etc.).