### PR TITLE
Reduce gauge specs GitHub Actions log output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,8 +490,7 @@ jobs:
           GAUGE_PYTHON_COMMAND: python3
           STEP_IMPL_DIR: "${{ github.workspace }}/step_impl"
           PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/step_impl:${{ github.workspace }}/tests"
-          PYPPETEER_DEBUG: "1"
-          DEBUG: "pyppeteer:*"
+          GAUGE_LOG_FILE: "${{ github.workspace }}/reports/html-report/gauge-execution.log"
         continue-on-error: true
 
       - name: Upload Gauge HTML report

--- a/gauge
+++ b/gauge
@@ -107,6 +107,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     suite = SuiteResult()
 
+    # Initialize log file if configured
+    log_file = os.environ.get("GAUGE_LOG_FILE")
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("w", encoding="utf-8") as f:
+            from datetime import datetime
+            timestamp = datetime.utcnow().isoformat() + "Z"
+            f.write(f"Gauge Specification Execution Log\n")
+            f.write(f"Started: {timestamp}\n")
+            f.write(f"Spec directory: {spec_root}\n")
+            f.write(f"{'=' * 80}\n")
+
     try:
         for hook in registry.before_suite_hooks:
             hook()
@@ -118,6 +131,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         for scenario in run_spec(spec_path, registry):
             suite.add_scenario(scenario)
             report_scenario(spec_path, scenario)
+
+    # Write summary to log file
+    if log_file:
+        with Path(log_file).open("a", encoding="utf-8") as f:
+            from datetime import datetime
+            timestamp = datetime.utcnow().isoformat() + "Z"
+            f.write(f"\n{'=' * 80}\n")
+            f.write(f"Completed: {timestamp}\n")
+            total_scenarios = len(suite.scenarios)
+            failed_scenarios = sum(1 for s in suite.scenarios if s.failed)
+            passed_scenarios = total_scenarios - failed_scenarios
+            f.write(f"Total scenarios: {total_scenarios}\n")
+            f.write(f"Passed: {passed_scenarios}\n")
+            f.write(f"Failed: {failed_scenarios}\n")
 
     return 1 if suite.failed else 0
 
@@ -255,13 +282,24 @@ def register_module_alias(name: str, module: ModuleType) -> None:
 def report_scenario(spec_path: Path, scenario: ScenarioResult) -> None:
     rel = spec_path.relative_to(Path.cwd())
     status = "FAILED" if scenario.failed else "PASSED"
-    print(f"{rel} :: {scenario.name} -> {status}")
-    for text, success, error in scenario.steps:
-        prefix = "  ✔" if success else "  ✖"
-        line = f"{prefix} {text}"
-        if error and not success:
-            line += f"\n      {error}"
-        print(line)
+
+    # Write detailed output to log file if configured
+    log_file = os.environ.get("GAUGE_LOG_FILE")
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(f"\n{rel} :: {scenario.name} -> {status}\n")
+            for text, success, error in scenario.steps:
+                prefix = "  ✔" if success else "  ✖"
+                line = f"{prefix} {text}"
+                if error and not success:
+                    line += f"\n      {error}"
+                f.write(line + "\n")
+
+    # Write summary to stdout (only scenario status, not individual steps)
+    status_symbol = "✖" if scenario.failed else "✔"
+    print(f"{status_symbol} {rel} :: {scenario.name}")
 
 
 if __name__ == "__main__":

--- a/tests/gauge_report.py
+++ b/tests/gauge_report.py
@@ -73,6 +73,13 @@ def enhance_gauge_report(
     index_html = _strip_marked_block(index_html, _STYLE_START, _STYLE_END)
     index_html = _strip_marked_block(index_html, _GALLERY_START, _GALLERY_END)
 
+    # Check if execution log exists
+    log_file = gauge_base / "gauge-execution.log"
+    log_link = ""
+    if log_file.exists():
+        log_href = _public_or_local_href("gauge-execution.log", public_base_url)
+        log_link = f'<p style="margin-top: 0.5rem;"><a href="{log_href}" target="_blank" rel="noopener">View detailed execution log</a></p>'
+
     style_block = dedent(
         """
         {start}
@@ -95,6 +102,7 @@ def enhance_gauge_report(
         {start}
         <section class="gauge-screenshot-gallery">
           <h2>Captured page screenshots</h2>
+          {log_link}
           <div class="gallery-grid">
         {items}
           </div>
@@ -104,6 +112,7 @@ def enhance_gauge_report(
     ).format(
         start=_GALLERY_START,
         end=_GALLERY_END,
+        log_link=log_link,
         items="\n".join(f"            {item}" for item in gallery_items),
     )
 


### PR DESCRIPTION
This change significantly reduces the console output from gauge specs in GitHub Actions while preserving all detailed information in log files.

Changes:
- Remove PYPPETEER_DEBUG and DEBUG environment variables from CI workflow (these generated verbose browser automation logs)
- Modify gauge stub to write detailed step execution to a log file when GAUGE_LOG_FILE environment variable is set
- Console now shows only scenario-level pass/fail instead of every step
- Log file includes full step details, errors, and execution summary
- Add link to execution log in the gauge HTML report
- Log file is published to GitHub Pages with other reports

The gauge specs still run with full functionality including screenshots. Screenshot capture uses pyppeteer but no longer logs debug output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional logging support for comprehensive test execution tracking with detailed scenario results and summaries.
  * Enhanced per-scenario reporting with status indicators displayed during test runs.
  * Added execution log link to HTML test reports for easy access to detailed test execution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->