### PR TITLE
Promote app imports to module scope

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from logfire.exceptions import LogfireConfigError
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from ai_defaults import ensure_ai_stub_for_all_users
+from analytics import make_session_permanent, track_page_view
 from css_defaults import ensure_css_alias_for_all_users
 from cid_directory_loader import load_cids_from_directory
 from cid_presenter import (
@@ -34,6 +35,8 @@ from link_presenter import (
     server_path,
 )
 from response_formats import register_response_format_handlers
+from routes import main_bp
+from routes.core import internal_error, not_found_error
 
 # Load environment variables from .env file
 load_dotenv()
@@ -153,9 +156,6 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
     init_db(flask_app)
 
     # Register application components
-    from analytics import make_session_permanent, track_page_view
-    from routes import main_bp
-
     flask_app.before_request(make_session_permanent)
     flask_app.after_request(track_page_view)
 
@@ -167,9 +167,6 @@ def create_app(config_override: Optional[dict] = None) -> Flask:
         """Expose the always-on user to templates."""
 
         return {"current_user": current_user}
-
-    # Register error handlers that work even in debug mode
-    from routes.core import internal_error, not_found_error
 
     # Force registration of custom error handlers even in debug mode
     # This ensures our enhanced error pages with source links always work

--- a/remaining_pylint_issues.md
+++ b/remaining_pylint_issues.md
@@ -3,7 +3,7 @@
 The project still has a large number of pylint violations reported in the most recent full run (`pylint *.py */*.py`). The items below highlight the issues that remain in the files touched by this iteration, along with context for future follow-up. Broader clean-up work (for example, cyclic-import warnings and the many trailing-newline notices across other modules) will require coordinated refactors and is not attempted here.
 
 ## app.py
-- `C0415` at lines 156-196: Several imports stay inside `create_app` to avoid circular dependencies during application factory setup. Pulling these to module scope will need a broader dependency untangling across analytics and route modules.
+- The previous `C0415` warning for lazy imports has been resolved by promoting the analytics and route imports to module scope and verifying the application still initialises correctly.
 - The broad Logfire exception guards are now explicitly documented in code to clarify why the defensive catch-all behaviour is preserved.
 
 ## alias_definition.py


### PR DESCRIPTION
## Summary
- promote the analytics and routes imports in `app.py` to module scope now that they no longer create circular dependencies
- refresh `remaining_pylint_issues.md` to document the resolved warning and retain rationale for the defensive Logfire guard

## Testing
- pytest tests/test_app_startup.py

------
https://chatgpt.com/codex/tasks/task_b_690d0993cea4833197755ee36ff55a35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of error handling registration during application initialization, including in debug mode.

* **Chores**
  * Updated documentation to reflect import handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->