### PR TITLE
Fix pylint import warning in alias_definition

### DIFF
--- a/remaining_pylint_issues.md
+++ b/remaining_pylint_issues.md
@@ -7,7 +7,7 @@ The project still has a large number of pylint violations reported in the most r
 - The broad Logfire exception guards are now explicitly documented in code to clarify why the defensive catch-all behaviour is preserved.
 
 ## alias_definition.py
-- `C0415` at line 196: The lazy import of `get_user_variables` prevents a circular dependency on `db_access`. Resolving it likely means restructuring how variable resolution interacts with persistence helpers.
+- No outstanding pylint issues in this module; the previous `C0415` warning was resolved by importing `get_user_variables` directly from `db_access.variables`, which avoids the circular dependency exposed by the package-level re-export.
 
 ## formdown_renderer.py
 - Multiple `W0621` warnings (lines 159-427): Several helper closures reuse the name `field` while shadowing the outer scope. Addressing this would involve refactoring the rendering helpers to pass explicit argument names or extracting the repeated logic into standalone functions.


### PR DESCRIPTION
## Summary
- import `get_user_variables` from `db_access.variables` at module scope to resolve the pylint lazy-import warning
- retain graceful degradation when the helper is unavailable and document the reasoning for the import location
- update `remaining_pylint_issues.md` to reflect the resolved warning

## Testing
- pylint alias_definition.py
- pytest tests/test_alias_definition.py

------
https://chatgpt.com/codex/tasks/task_b_690d0c2b24348331a1985c8a2de0754c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized module import handling to improve performance and reduce redundant operations.

* **Chores**
  * Resolved code quality issues to enhance system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->