### PR TITLE
Refine db_access exports

### DIFF
--- a/db_access.py
+++ b/db_access.py
@@ -19,5 +19,81 @@ All imports from this module continue to work, but new code should
 import directly from db_access or the specific submodules.
 """
 
-# Re-export everything from the package for backward compatibility
-from db_access import *  # noqa: F403, F401
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from db_access import _exports
+from db_access._exports import LEGACY_DEFAULTS
+
+__all__ = list(_exports.__all__)
+globals().update(_exports.EXPORTS)
+globals().update(LEGACY_DEFAULTS)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from db_access._exports import (  # pylint: disable=unused-import
+        DEFAULT_ACTION,
+        DEFAULT_AI_ALIAS_NAME,
+        DEFAULT_AI_SERVER_NAME,
+        DEFAULT_CSS_ALIAS_NAME,
+        EntityInteractionLookup,
+        EntityInteractionRequest,
+        MAX_MESSAGE_LENGTH,
+        ServerInvocationInput,
+        count_cids,
+        count_page_views,
+        count_secrets,
+        count_servers,
+        count_unique_page_view_paths,
+        count_user_aliases,
+        count_user_page_views,
+        count_user_secrets,
+        count_user_servers,
+        count_user_variables,
+        count_variables,
+        create_cid_record,
+        create_server_invocation,
+        delete_entity,
+        find_cids_by_prefix,
+        find_entity_interaction,
+        find_server_invocations_by_cid,
+        get_all_servers,
+        get_alias_by_name,
+        get_alias_by_target_path,
+        get_cid_by_path,
+        get_cids_by_paths,
+        get_entity_interactions,
+        get_first_alias_name,
+        get_first_cid,
+        get_first_secret_name,
+        get_first_server_name,
+        get_first_variable_name,
+        get_popular_page_paths,
+        get_recent_cids,
+        get_recent_entity_interactions,
+        get_secret_by_name,
+        get_server_by_name,
+        get_user_aliases,
+        get_user_exports,
+        get_user_profile_data,
+        get_user_secrets,
+        get_user_server_invocations,
+        get_user_server_invocations_by_result_cids,
+        get_user_server_invocations_by_server,
+        get_user_servers,
+        get_user_template_aliases,
+        get_user_template_secrets,
+        get_user_template_servers,
+        get_user_template_variables,
+        get_user_uploads,
+        get_user_variables,
+        get_variable_by_name,
+        paginate_user_page_views,
+        record_entity_interaction,
+        record_export,
+        rollback_session,
+        save_entity,
+        save_page_view,
+        update_alias_cid_reference,
+        update_cid_references,
+    )

--- a/db_access/__init__.py
+++ b/db_access/__init__.py
@@ -1,196 +1,80 @@
-"""Database access functions organized by domain.
+"""Database access functions organised by domain."""
 
-This package provides database access functions split into domain-specific modules:
-- servers: Server CRUD operations
-- aliases: Alias CRUD operations and CID reference management
-- variables: Variable CRUD operations
-- secrets: Secret CRUD operations
-- cids: CID management operations
-- page_views: Page view tracking and analytics
-- interactions: Entity interaction tracking
-- invocations: Server invocation tracking
-- profile: User profile data operations
-- _common: Shared utilities and constants
+from __future__ import annotations
 
-All functions are re-exported here for backward compatibility with existing code.
-"""
+from typing import TYPE_CHECKING
 
-# Import all functions and classes for backward compatibility
-from db_access._common import (
-    DEFAULT_AI_ALIAS_NAME,
-    DEFAULT_AI_SERVER_NAME,
-    DEFAULT_CSS_ALIAS_NAME,
-    DEFAULT_ACTION,
-    MAX_MESSAGE_LENGTH,
-    delete_entity,
-    rollback_session,
-    save_entity,
-)
+from . import _exports
+from ._exports import LEGACY_DEFAULTS
 
-from db_access.aliases import (
-    count_user_aliases,
-    get_alias_by_name,
-    get_alias_by_target_path,
-    get_first_alias_name,
-    get_user_aliases,
-    get_user_template_aliases,
-    update_alias_cid_reference,
-)
+__all__ = list(_exports.__all__)
+globals().update(_exports.EXPORTS)
+globals().update(LEGACY_DEFAULTS)
 
-from db_access.cids import (
-    count_cids,
-    create_cid_record,
-    find_cids_by_prefix,
-    get_cid_by_path,
-    get_cids_by_paths,
-    get_first_cid,
-    get_recent_cids,
-    get_user_uploads,
-    update_cid_references,
-)
-
-from db_access.interactions import (
-    EntityInteractionLookup,
-    EntityInteractionRequest,
-    find_entity_interaction,
-    get_entity_interactions,
-    get_recent_entity_interactions,
-    record_entity_interaction,
-)
-
-from db_access.invocations import (
-    ServerInvocationInput,
-    create_server_invocation,
-    find_server_invocations_by_cid,
-    get_user_server_invocations,
-    get_user_server_invocations_by_result_cids,
-    get_user_server_invocations_by_server,
-)
-
-from db_access.page_views import (
-    count_page_views,
-    count_unique_page_view_paths,
-    count_user_page_views,
-    get_popular_page_paths,
-    paginate_user_page_views,
-    save_page_view,
-)
-
-from db_access.profile import get_user_profile_data
-
-from db_access.secrets import (
-    count_secrets,
-    count_user_secrets,
-    get_first_secret_name,
-    get_secret_by_name,
-    get_user_secrets,
-    get_user_template_secrets,
-)
-
-from db_access.servers import (
-    count_servers,
-    count_user_servers,
-    get_all_servers,
-    get_first_server_name,
-    get_server_by_name,
-    get_user_servers,
-    get_user_template_servers,
-)
-
-from db_access.variables import (
-    count_user_variables,
-    count_variables,
-    get_first_variable_name,
-    get_variable_by_name,
-    get_user_template_variables,
-    get_user_variables,
-)
-
-from db_access.exports import (
-    get_user_exports,
-    record_export,
-)
-
-# Re-export constants that were previously module-level
-_DEFAULT_AI_SERVER_NAME = DEFAULT_AI_SERVER_NAME
-_DEFAULT_AI_ALIAS_NAME = DEFAULT_AI_ALIAS_NAME
-_DEFAULT_CSS_ALIAS_NAME = DEFAULT_CSS_ALIAS_NAME
-
-__all__ = [
-    # Common utilities
-    "save_entity",
-    "delete_entity",
-    "rollback_session",
-    # Constants
-    "DEFAULT_AI_SERVER_NAME",
-    "DEFAULT_AI_ALIAS_NAME",
-    "DEFAULT_CSS_ALIAS_NAME",
-    "DEFAULT_ACTION",
-    "MAX_MESSAGE_LENGTH",
-    # Servers
-    "get_user_servers",
-    "get_user_template_servers",
-    "get_server_by_name",
-    "get_first_server_name",
-    "count_user_servers",
-    "get_all_servers",
-    "count_servers",
-    # Aliases
-    "get_user_aliases",
-    "get_user_template_aliases",
-    "get_alias_by_name",
-    "get_first_alias_name",
-    "get_alias_by_target_path",
-    "count_user_aliases",
-    "update_alias_cid_reference",
-    # Variables
-    "get_user_variables",
-    "get_user_template_variables",
-    "get_variable_by_name",
-    "get_first_variable_name",
-    "count_user_variables",
-    "count_variables",
-    # Secrets
-    "get_user_secrets",
-    "get_user_template_secrets",
-    "get_secret_by_name",
-    "get_first_secret_name",
-    "count_user_secrets",
-    "count_secrets",
-    # CIDs
-    "get_cid_by_path",
-    "find_cids_by_prefix",
-    "create_cid_record",
-    "get_user_uploads",
-    "get_cids_by_paths",
-    "get_recent_cids",
-    "get_first_cid",
-    "count_cids",
-    "update_cid_references",
-    # Page views
-    "save_page_view",
-    "count_user_page_views",
-    "count_unique_page_view_paths",
-    "get_popular_page_paths",
-    "paginate_user_page_views",
-    "count_page_views",
-    # Interactions
-    "EntityInteractionRequest",
-    "EntityInteractionLookup",
-    "record_entity_interaction",
-    "get_recent_entity_interactions",
-    "find_entity_interaction",
-    "get_entity_interactions",
-    # Invocations
-    "ServerInvocationInput",
-    "create_server_invocation",
-    "get_user_server_invocations",
-    "get_user_server_invocations_by_server",
-    "get_user_server_invocations_by_result_cids",
-    "find_server_invocations_by_cid",
-    # Exports
-    "record_export",
-    "get_user_exports",
-    # Profile
-    "get_user_profile_data",
-]
+if TYPE_CHECKING:  # pragma: no cover
+    from ._exports import (  # pylint: disable=unused-import
+        DEFAULT_ACTION,
+        DEFAULT_AI_ALIAS_NAME,
+        DEFAULT_AI_SERVER_NAME,
+        DEFAULT_CSS_ALIAS_NAME,
+        EntityInteractionLookup,
+        EntityInteractionRequest,
+        MAX_MESSAGE_LENGTH,
+        ServerInvocationInput,
+        count_cids,
+        count_page_views,
+        count_secrets,
+        count_servers,
+        count_unique_page_view_paths,
+        count_user_aliases,
+        count_user_page_views,
+        count_user_secrets,
+        count_user_servers,
+        count_user_variables,
+        count_variables,
+        create_cid_record,
+        create_server_invocation,
+        delete_entity,
+        find_cids_by_prefix,
+        find_entity_interaction,
+        find_server_invocations_by_cid,
+        get_all_servers,
+        get_alias_by_name,
+        get_alias_by_target_path,
+        get_cid_by_path,
+        get_cids_by_paths,
+        get_entity_interactions,
+        get_first_alias_name,
+        get_first_cid,
+        get_first_secret_name,
+        get_first_server_name,
+        get_first_variable_name,
+        get_popular_page_paths,
+        get_recent_cids,
+        get_recent_entity_interactions,
+        get_secret_by_name,
+        get_server_by_name,
+        get_user_aliases,
+        get_user_exports,
+        get_user_profile_data,
+        get_user_secrets,
+        get_user_server_invocations,
+        get_user_server_invocations_by_result_cids,
+        get_user_server_invocations_by_server,
+        get_user_servers,
+        get_user_template_aliases,
+        get_user_template_secrets,
+        get_user_template_servers,
+        get_user_template_variables,
+        get_user_uploads,
+        get_user_variables,
+        get_variable_by_name,
+        paginate_user_page_views,
+        record_entity_interaction,
+        record_export,
+        rollback_session,
+        save_entity,
+        save_page_view,
+        update_alias_cid_reference,
+        update_cid_references,
+    )

--- a/db_access/_common.py
+++ b/db_access/_common.py
@@ -49,4 +49,3 @@ def normalize_cid_value(value: str | None) -> str:
         return ""
     normalized = value.strip().lstrip("/")
     return normalized
-

--- a/db_access/_exports.py
+++ b/db_access/_exports.py
@@ -1,0 +1,189 @@
+"""Centralised export definitions for the :mod:`db_access` package."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ._common import (
+    DEFAULT_ACTION,
+    DEFAULT_AI_ALIAS_NAME,
+    DEFAULT_AI_SERVER_NAME,
+    DEFAULT_CSS_ALIAS_NAME,
+    MAX_MESSAGE_LENGTH,
+    delete_entity,
+    rollback_session,
+    save_entity,
+)
+from .aliases import (
+    count_user_aliases,
+    get_alias_by_name,
+    get_alias_by_target_path,
+    get_first_alias_name,
+    get_user_aliases,
+    get_user_template_aliases,
+    update_alias_cid_reference,
+)
+from .cids import (
+    count_cids,
+    create_cid_record,
+    find_cids_by_prefix,
+    get_cid_by_path,
+    get_cids_by_paths,
+    get_first_cid,
+    get_recent_cids,
+    get_user_uploads,
+    update_cid_references,
+)
+from .exports import (
+    get_user_exports,
+    record_export,
+)
+from .interactions import (
+    EntityInteractionLookup,
+    EntityInteractionRequest,
+    find_entity_interaction,
+    get_entity_interactions,
+    get_recent_entity_interactions,
+    record_entity_interaction,
+)
+from .invocations import (
+    ServerInvocationInput,
+    create_server_invocation,
+    find_server_invocations_by_cid,
+    get_user_server_invocations,
+    get_user_server_invocations_by_result_cids,
+    get_user_server_invocations_by_server,
+)
+from .page_views import (
+    count_page_views,
+    count_unique_page_view_paths,
+    count_user_page_views,
+    get_popular_page_paths,
+    paginate_user_page_views,
+    save_page_view,
+)
+from .profile import get_user_profile_data
+from .secrets import (
+    count_secrets,
+    count_user_secrets,
+    get_first_secret_name,
+    get_secret_by_name,
+    get_user_secrets,
+    get_user_template_secrets,
+)
+from .servers import (
+    count_servers,
+    count_user_servers,
+    get_all_servers,
+    get_first_server_name,
+    get_server_by_name,
+    get_user_servers,
+    get_user_template_servers,
+)
+from .variables import (
+    count_user_variables,
+    count_variables,
+    get_first_variable_name,
+    get_user_template_variables,
+    get_user_variables,
+    get_variable_by_name,
+)
+
+__all__ = [
+    # Common utilities
+    "save_entity",
+    "delete_entity",
+    "rollback_session",
+    # Constants
+    "DEFAULT_AI_SERVER_NAME",
+    "DEFAULT_AI_ALIAS_NAME",
+    "DEFAULT_CSS_ALIAS_NAME",
+    "DEFAULT_ACTION",
+    "MAX_MESSAGE_LENGTH",
+    # Servers
+    "get_user_servers",
+    "get_user_template_servers",
+    "get_server_by_name",
+    "get_first_server_name",
+    "count_user_servers",
+    "get_all_servers",
+    "count_servers",
+    # Aliases
+    "get_user_aliases",
+    "get_user_template_aliases",
+    "get_alias_by_name",
+    "get_first_alias_name",
+    "get_alias_by_target_path",
+    "count_user_aliases",
+    "update_alias_cid_reference",
+    # Variables
+    "get_user_variables",
+    "get_user_template_variables",
+    "get_variable_by_name",
+    "get_first_variable_name",
+    "count_user_variables",
+    "count_variables",
+    # Secrets
+    "get_user_secrets",
+    "get_user_template_secrets",
+    "get_secret_by_name",
+    "get_first_secret_name",
+    "count_user_secrets",
+    "count_secrets",
+    # CIDs
+    "get_cid_by_path",
+    "find_cids_by_prefix",
+    "create_cid_record",
+    "get_user_uploads",
+    "get_cids_by_paths",
+    "get_recent_cids",
+    "get_first_cid",
+    "count_cids",
+    "update_cid_references",
+    # Page views
+    "save_page_view",
+    "count_user_page_views",
+    "count_unique_page_view_paths",
+    "get_popular_page_paths",
+    "paginate_user_page_views",
+    "count_page_views",
+    # Interactions
+    "EntityInteractionRequest",
+    "EntityInteractionLookup",
+    "record_entity_interaction",
+    "get_recent_entity_interactions",
+    "find_entity_interaction",
+    "get_entity_interactions",
+    # Invocations
+    "ServerInvocationInput",
+    "create_server_invocation",
+    "get_user_server_invocations",
+    "get_user_server_invocations_by_server",
+    "get_user_server_invocations_by_result_cids",
+    "find_server_invocations_by_cid",
+    # Exports
+    "record_export",
+    "get_user_exports",
+    # Profile
+    "get_user_profile_data",
+]
+
+# Legacy alias constants maintained for backward compatibility.
+_DEFAULT_AI_SERVER_NAME = DEFAULT_AI_SERVER_NAME
+_DEFAULT_AI_ALIAS_NAME = DEFAULT_AI_ALIAS_NAME
+_DEFAULT_CSS_ALIAS_NAME = DEFAULT_CSS_ALIAS_NAME
+
+LEGACY_DEFAULTS: Dict[str, Any] = {
+    "_DEFAULT_AI_SERVER_NAME": DEFAULT_AI_SERVER_NAME,
+    "_DEFAULT_AI_ALIAS_NAME": DEFAULT_AI_ALIAS_NAME,
+    "_DEFAULT_CSS_ALIAS_NAME": DEFAULT_CSS_ALIAS_NAME,
+}
+
+
+def _collect_exports() -> Dict[str, Any]:
+    """Return a mapping of public attribute names to exportable objects."""
+
+    return {name: globals()[name] for name in __all__}
+
+
+EXPORTS: Dict[str, Any] = _collect_exports()

--- a/db_access/aliases.py
+++ b/db_access/aliases.py
@@ -297,4 +297,3 @@ def _replace_cid_text(
     if updated == text:
         return text, False
     return updated, True
-

--- a/db_access/cids.py
+++ b/db_access/cids.py
@@ -197,4 +197,3 @@ def _replace_cid_text(
     if updated == text:
         return text, False
     return updated, True
-

--- a/db_access/exports.py
+++ b/db_access/exports.py
@@ -21,4 +21,3 @@ def get_user_exports(user_id: str, limit: int = 100) -> List[Export]:
         .limit(limit)
         .all()
     )
-

--- a/db_access/interactions.py
+++ b/db_access/interactions.py
@@ -131,4 +131,3 @@ def get_entity_interactions(
         .order_by(EntityInteraction.created_at.asc(), EntityInteraction.id.asc())
         .all()
     )
-

--- a/db_access/invocations.py
+++ b/db_access/invocations.py
@@ -138,4 +138,3 @@ def find_server_invocations_by_cid(cid_value: str) -> List[ServerInvocation]:
     ]
 
     return ServerInvocation.query.filter(or_(*filters)).all()
-

--- a/db_access/page_views.py
+++ b/db_access/page_views.py
@@ -56,4 +56,3 @@ def paginate_user_page_views(user_id: str, page: int, per_page: int = 50) -> Pag
 def count_page_views() -> int:
     """Return the total number of page view records."""
     return PageView.query.count()
-

--- a/db_access/profile.py
+++ b/db_access/profile.py
@@ -18,4 +18,3 @@ def get_user_profile_data(user_id: str) -> Dict[str, Any]:
         "needs_terms_acceptance": False,
         "current_terms_version": None,
     }
-

--- a/db_access/secrets.py
+++ b/db_access/secrets.py
@@ -42,4 +42,3 @@ def count_user_secrets(user_id: str) -> int:
 def count_secrets() -> int:
     """Return the total count of secrets."""
     return Secret.query.count()
-

--- a/db_access/servers.py
+++ b/db_access/servers.py
@@ -58,4 +58,3 @@ def get_all_servers() -> List[Server]:
 def count_servers() -> int:
     """Return the total count of servers."""
     return Server.query.count()
-

--- a/db_access/variables.py
+++ b/db_access/variables.py
@@ -42,4 +42,3 @@ def count_user_variables(user_id: str) -> int:
 def count_variables() -> int:
     """Return the total count of variables."""
     return Variable.query.count()
-

--- a/remaining_pylint_issues.md
+++ b/remaining_pylint_issues.md
@@ -1,31 +1,26 @@
 # Plan to eliminate remaining pylint issues
 
-1. Stabilize the `db_access` package interface.
-   - Replace the self-referential wildcard import in `db_access.py` with explicit re-exports or helper modules so callers can keep importing from `db_access` without triggering `import-self`, `wildcard-import`, or `unused-wildcard-import` warnings.
-   - As part of the same sweep, normalise the `db_access` package layout (including `db_access/__init__.py` if needed) so that each public function is defined in exactly one place, documented, and imported explicitly by users.
-   - Remove the trailing newline warnings reported in `db_access` submodules while touching the files, and run the full pylint command to confirm the `db_access` warnings are cleared without introducing regressions.
-
-2. Refactor CID- and identity-related modules to support top-level imports.
+1. Refactor CID- and identity-related modules to support top-level imports.
    - Investigate the runtime dependencies that forced lazy imports in `ai_defaults.py`, `css_defaults.py`, `cid_storage.py`, `cid_utils.py`, `content_rendering.py`, `models.py`, and `app.py`.
    - Break dependency cycles (for example, by extracting shared helpers into new modules) so these modules can import their collaborators at module scope, then move the imports accordingly and rerun pylint to ensure all related `C0415` warnings disappear.
 
-3. Normalise import order and positioning in operational scripts and entry points.
+2. Normalise import order and positioning in operational scripts and entry points.
    - Update modules such as `inspect_db.py`, `migrate_add_server_cid.py`, `tests/test_ai_stub_server.py`, and `routes/__init__.py` to follow standard import grouping so the `C0411`/`C0413` warnings go away without reintroducing cyclic dependencies.
    - Document any necessary lazy imports with targeted `# pylint: disable` comments and justification when restructuring is impossible, and verify with pylint afterwards.
 
-4. Replace broad `except Exception` handlers with precise error management.
+3. Replace broad `except Exception` handlers with precise error management.
    - Catalogue each `W0718` site across core logic (`alias_matching.py`, `alias_routing.py`, `analytics.py`, `content_rendering.py`, `server_execution.py`, etc.), route handlers, scripts, and tests.
    - For each block, determine the specific exceptions that should be caught or restructure the code to avoid blanket suppression; only retain broad handlers with explicit justification comments and `# pylint: disable=broad-exception-caught` markers.
    - Add regression tests where behaviour changes so the narrower exception handling is covered.
 
-5. Decompose oversized and high-complexity route and execution modules.
+4. Decompose oversized and high-complexity route and execution modules.
    - Split `server_execution.py`, `routes/import_export.py`, `routes/meta.py`, and `routes/openapi.py` into cohesive submodules to drop below the `C0302` module-length threshold and expose clearer public APIs.
    - While extracting code, address the nested block (`R1702`), redefined name (`W0621`), and too-many-positional-arguments (`R0917`) warnings in the affected functions, and expand or add tests to cover the new module boundaries.
 
-6. Resolve remaining function-level style warnings.
+5. Resolve remaining function-level style warnings.
    - Tackle outstanding `unused-argument`, `redefined-outer-name`, `attribute-defined-outside-init`, logging format (`W1203`), and dictionary/iteration style warnings across modules like `routes.aliases`, `routes.search`, `generate_page_test_cross_reference.py`, `routes.context_processors.py`, `routes.uploads.py`, `scripts/run_radon.py`, and `step_impl/web_steps.py`.
    - Adjust function signatures or usage patterns (for example, by renaming unused parameters to `_` or extracting helpers) and confirm pylint accepts the updated code.
 
-7. Fix repository-wide formatting nits.
+6. Fix repository-wide formatting nits.
    - Remove trailing newline violations from all flagged modules (including `db_access` subpackages, route modules, scripts, and tests) and ensure editors or formatting hooks prevent reintroduction.
    - Standardise string formatting (switch to f-strings where recommended) and iterate over dictionaries/sequences idiomatically to silence the remaining stylistic warnings, validating with pylint at the end.


### PR DESCRIPTION
## Summary
- centralize the db_access public API in a new helper module and share the explicit re-export list
- update the db_access compatibility shim and package initializer to consume the helper and preserve legacy aliases
- remove trailing newline lint issues in db_access submodules and clear the completed pylint follow-up item

## Testing
- pylint *.py */*.py
- pytest tests/test_db_access.py tests/test_db_access_alias_integration.py *(fails: TestDBAccess::test_cid_lookup_helpers expects an empty CID table but load_cids_from_directory seeds fixtures)*
- pytest tests/test_db_access_alias_integration.py

------
https://chatgpt.com/codex/tasks/task_b_690d2939b3b88331ad4d0d9b461a4916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized package exports to use centralized explicit definitions instead of wildcard imports, maintaining backward compatibility with the public API.

* **Chores**
  * Removed trailing whitespace across modules.
  * Updated documentation wording for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->