### PR TITLE
Fix misnamed automated tests

### DIFF
--- a/tests/test_alias_definition.py
+++ b/tests/test_alias_definition.py
@@ -20,7 +20,7 @@ from alias_definition import (
 )
 
 
-class SummarizeDefinitionLinesTests(unittest.TestCase):
+class TestSummarizeDefinitionLines(unittest.TestCase):
     def test_summarize_definition_lines_extracts_metadata(self):
         definition = textwrap.dedent(
             """
@@ -153,7 +153,7 @@ class SummarizeDefinitionLinesTests(unittest.TestCase):
         self.assertIn("does not contain an alias mapping", summary[1].parse_error.lower())
 
 
-class ParseAliasDefinitionValidationTests(unittest.TestCase):
+class TestParseAliasDefinitionValidation(unittest.TestCase):
     def test_rejects_definitions_without_mapping_lines(self):
         invalid_definitions = [
             "stuff # invalid",
@@ -293,7 +293,7 @@ class ParseAliasDefinitionValidationTests(unittest.TestCase):
         self.assertEqual(parsed.target_path, "/documentation")
 
 
-class DefinitionUtilityTests(unittest.TestCase):
+class TestDefinitionUtility(unittest.TestCase):
     def test_definition_contains_mapping_detects_primary_line(self):
         self.assertFalse(definition_contains_mapping(None))
         self.assertFalse(definition_contains_mapping("  # comment"))
@@ -340,7 +340,7 @@ class DefinitionUtilityTests(unittest.TestCase):
         self.assertEqual(updated, "docs -> /documentation\n\nNotes about the alias")
 
 
-class StripInlineCommentTests(unittest.TestCase):
+class TestStripInlineComment(unittest.TestCase):
     def test_strips_inline_comment(self):
         self.assertEqual(_strip_inline_comment("docs -> /docs # comment"), "docs -> /docs")
         self.assertEqual(_strip_inline_comment("docs -> /docs  # comment"), "docs -> /docs")
@@ -361,7 +361,7 @@ class StripInlineCommentTests(unittest.TestCase):
         self.assertEqual(_strip_inline_comment("  # comment"), "")
 
 
-class ExtractPrimaryLineTests(unittest.TestCase):
+class TestExtractPrimaryLine(unittest.TestCase):
     def test_extracts_first_mapping_line(self):
         definition = "# comment\ndocs -> /documentation\nother -> /other"
         self.assertEqual(_extract_primary_line(definition), "docs -> /documentation")
@@ -384,7 +384,7 @@ class ExtractPrimaryLineTests(unittest.TestCase):
         self.assertEqual(_extract_primary_line(definition), "docs -> /documentation # inline comment")
 
 
-class NormalizeVariableMapTests(unittest.TestCase):
+class TestNormalizeVariableMap(unittest.TestCase):
     def test_handles_none_and_empty(self):
         self.assertEqual(_normalize_variable_map(None), {})
         self.assertEqual(_normalize_variable_map({}), {})
@@ -448,7 +448,7 @@ class NormalizeVariableMapTests(unittest.TestCase):
         self.assertEqual(result, {})
 
 
-class SubstituteVariablesTests(unittest.TestCase):
+class TestSubstituteVariables(unittest.TestCase):
     def test_substitutes_single_variable(self):
         text = "Path: {var1}"
         variables = {"var1": "value1"}
@@ -484,7 +484,7 @@ class SubstituteVariablesTests(unittest.TestCase):
         self.assertEqual(_substitute_variables(text, variables), "a/b/c")
 
 
-class FormatPrimaryAliasLineTests(unittest.TestCase):
+class TestFormatPrimaryAliasLine(unittest.TestCase):
     def test_formats_literal_match_without_options(self):
         result = format_primary_alias_line("literal", "/docs", "/documentation", alias_name="docs")
         self.assertEqual(result, "docs -> /documentation")
@@ -526,7 +526,7 @@ class FormatPrimaryAliasLineTests(unittest.TestCase):
         self.assertEqual(result, "/docs/* -> /documentation [glob]")
 
 
-class GetPrimaryAliasRouteTests(unittest.TestCase):
+class TestGetPrimaryAliasRoute(unittest.TestCase):
     def test_returns_first_route(self):
         definition = "docs -> /documentation\napi -> /api"
         alias = SimpleNamespace(name="docs", definition=definition)
@@ -541,7 +541,7 @@ class GetPrimaryAliasRouteTests(unittest.TestCase):
         self.assertIsNone(route)
 
 
-class CollectAliasRoutesEdgeCasesTests(unittest.TestCase):
+class TestCollectAliasRoutesEdgeCases(unittest.TestCase):
     def test_handles_empty_definition(self):
         alias = SimpleNamespace(name="docs", definition="")
         routes = collect_alias_routes(alias)
@@ -614,7 +614,7 @@ class CollectAliasRoutesEdgeCasesTests(unittest.TestCase):
         self.assertEqual(routes[0].target_path, "/documentation/value1")
 
 
-class ParseAliasDefinitionEdgeCasesTests(unittest.TestCase):
+class TestParseAliasDefinitionEdgeCases(unittest.TestCase):
     def test_handles_none_definition(self):
         with self.assertRaises(AliasDefinitionError) as exc_info:
             parse_alias_definition(None)

--- a/tests/test_alias_model.py
+++ b/tests/test_alias_model.py
@@ -3,7 +3,7 @@ import unittest
 from models import Alias
 
 
-class AliasModelTests(unittest.TestCase):
+class TestAliasModel(unittest.TestCase):
     """Test the Alias model helper methods."""
 
     def test_get_primary_target_path_simple_definition(self):

--- a/tests/test_alias_routes_integration.py
+++ b/tests/test_alias_routes_integration.py
@@ -5,7 +5,7 @@ from alias_definition import collect_alias_routes
 from models import Alias
 
 
-class AliasRoutesIntegrationTests(unittest.TestCase):
+class TestAliasRoutesIntegration(unittest.TestCase):
     """Test that collect_alias_routes works with the new Alias model structure."""
 
     def test_collect_routes_simple_alias(self):

--- a/tests/test_alias_view_definition_targets.py
+++ b/tests/test_alias_view_definition_targets.py
@@ -4,7 +4,7 @@ from app import create_app
 from routes.aliases import _describe_target_path
 
 
-class AliasDefinitionTargetRenderingTests(unittest.TestCase):
+class TestAliasDefinitionTargetRendering(unittest.TestCase):
     def setUp(self) -> None:
         self.app = create_app({'TESTING': True})
         self.app_ctx = self.app.app_context()

--- a/tests/test_boot_cid_importer.py
+++ b/tests/test_boot_cid_importer.py
@@ -17,7 +17,7 @@ from db_access import create_cid_record
 from models import Alias, Export, Server
 
 
-class BootCidImporterTestCase(unittest.TestCase):
+class TestBootCidImporter(unittest.TestCase):
     def setUp(self):
         self.app = create_app({
             'TESTING': True,

--- a/tests/test_db_access_alias_integration.py
+++ b/tests/test_db_access_alias_integration.py
@@ -5,7 +5,7 @@ from models import Alias
 from db_access import get_alias_by_target_path
 
 
-class DbAccessAliasIntegrationTests(unittest.TestCase):
+class TestDbAccessAliasIntegration(unittest.TestCase):
     """Test that db_access functions work with the new Alias model structure."""
 
     def setUp(self):

--- a/tests/test_enabled_field_import_export.py
+++ b/tests/test_enabled_field_import_export.py
@@ -19,7 +19,7 @@ from models import Alias, Server, Variable, Secret
 from alias_definition import format_primary_alias_line
 
 
-class EnabledFieldImportExportTestCase(unittest.TestCase):
+class TestEnabledFieldImportExport(unittest.TestCase):
     """Integration tests for enabled field in import/export operations."""
 
     def setUp(self):

--- a/tests/test_enabled_field_persistence.py
+++ b/tests/test_enabled_field_persistence.py
@@ -16,7 +16,7 @@ from database import db
 from models import Alias, Server, Variable, Secret
 
 
-class EnabledFieldPersistenceTestCase(unittest.TestCase):
+class TestEnabledFieldPersistence(unittest.TestCase):
     """Test suite for enabled field persistence across all models."""
 
     def setUp(self):

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -25,7 +25,7 @@ from forms import ExportForm, ImportForm
 from models import CID, Alias, EntityInteraction, Export, Secret, Server, Variable
 
 
-class ImportExportRoutesTestCase(unittest.TestCase):
+class TestImportExportRoutes(unittest.TestCase):
     def setUp(self):
         self.app = create_app({
             'TESTING': True,

--- a/tests/test_routes_overview.py
+++ b/tests/test_routes_overview.py
@@ -11,7 +11,7 @@ from database import db  # noqa: E402
 from models import Alias, Server  # noqa: E402
 
 
-class RoutesOverviewTestCase(unittest.TestCase):
+class TestRoutesOverview(unittest.TestCase):
     """Tests for the routes overview page."""
 
     def setUp(self):


### PR DESCRIPTION
Renamed 20 test classes to start with 'Test' prefix for proper test discovery:
- EnabledFieldImportExportTestCase → TestEnabledFieldImportExport
- EnabledFieldPersistenceTestCase → TestEnabledFieldPersistence
- ImportExportRoutesTestCase → TestImportExportRoutes
- RoutesOverviewTestCase → TestRoutesOverview
- BootCidImporterTestCase → TestBootCidImporter
- SummarizeDefinitionLinesTests → TestSummarizeDefinitionLines
- ParseAliasDefinitionValidationTests → TestParseAliasDefinitionValidation
- DefinitionUtilityTests → TestDefinitionUtility
- StripInlineCommentTests → TestStripInlineComment
- ExtractPrimaryLineTests → TestExtractPrimaryLine
- NormalizeVariableMapTests → TestNormalizeVariableMap
- SubstituteVariablesTests → TestSubstituteVariables
- FormatPrimaryAliasLineTests → TestFormatPrimaryAliasLine
- GetPrimaryAliasRouteTests → TestGetPrimaryAliasRoute
- CollectAliasRoutesEdgeCasesTests → TestCollectAliasRoutesEdgeCases
- ParseAliasDefinitionEdgeCasesTests → TestParseAliasDefinitionEdgeCases
- AliasModelTests → TestAliasModel
- AliasDefinitionTargetRenderingTests → TestAliasDefinitionTargetRendering
- AliasRoutesIntegrationTests → TestAliasRoutesIntegration
- DbAccessAliasIntegrationTests → TestDbAccessAliasIntegration

These tests were not being discovered by pytest due to improper naming. Test classes must start with 'Test' to be automatically discovered and run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized test infrastructure naming conventions across the test suite for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->