### PR TITLE
Add job outputs to GitHub Pages site

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -465,12 +465,21 @@ jobs:
   deploy-reports:
     name: Publish Test Reports
     needs:
-      - unit-tests
-      - integration-tests
-      - gauge-specs
-      - property-tests
+      - ruff
+      - pylint
+      - mypy
       - radon
       - vulture
+      - shellcheck
+      - hadolint
+      - eslint
+      - stylelint
+      - uncss
+      - test-index
+      - unit-tests
+      - property-tests
+      - integration-tests
+      - gauge-specs
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     container:
@@ -481,6 +490,28 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Capture job statuses
+        run: |
+          cat > job-statuses.json << 'EOF'
+          {
+            "ruff": "${{ needs.ruff.result }}",
+            "pylint": "${{ needs.pylint.result }}",
+            "mypy": "${{ needs.mypy.result }}",
+            "radon": "${{ needs.radon.result }}",
+            "vulture": "${{ needs.vulture.result }}",
+            "shellcheck": "${{ needs.shellcheck.result }}",
+            "hadolint": "${{ needs.hadolint.result }}",
+            "eslint": "${{ needs.eslint.result }}",
+            "stylelint": "${{ needs.stylelint.result }}",
+            "uncss": "${{ needs.uncss.result }}",
+            "test-index": "${{ needs.test-index.result }}",
+            "unit-tests": "${{ needs.unit-tests.result }}",
+            "property-tests": "${{ needs.property-tests.result }}",
+            "integration-tests": "${{ needs.integration-tests.result }}",
+            "gauge-specs": "${{ needs.gauge-specs.result }}"
+          }
+          EOF
+          cat job-statuses.json
       - name: Download unit test report
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -526,6 +557,7 @@ jobs:
             --property-artifacts site/property-tests \
             --radon-artifacts site/radon \
             --vulture-artifacts site/vulture \
+            --job-statuses job-statuses.json \
             --output site
       - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Enhanced the GitHub Pages landing page to display status information for all CI jobs from full-checks.yml workflow:

Workflow changes:
- Added all 15 jobs to deploy-reports needs list (ruff, pylint, mypy, shellcheck, hadolint, eslint, stylelint, uncss, test-index, etc.)
- Added step to capture job statuses using needs context
- Job statuses are written to job-statuses.json and passed to build-report-site.py

Site builder changes:
- Added JobMetadata dataclass to define job display properties
- Each job now shows:
  * Status indicator (green ● for success, red ✖ for failure)
  * Tool icon/emoji (⚡ for Ruff, 🔍 for Pylint, etc.)
  * Tool name
  * Check type description
  * Link to report (when available)
- Updated landing page CSS with flexbox layout for job items
- Added _format_job_list() to generate styled job status HTML
- Updated parse_args and build_site to handle job statuses

All 15 jobs from the workflow are now visible on the landing page with clear visual indicators of their pass/fail status.