### PR TITLE
Fix hadolint package installation in CI workflow

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -177,10 +177,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Hadolint
         run: |
+          set -e
           HADOLINT_VERSION=2.12.0
-          wget -q https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 -O hadolint
+          HADOLINT_URL="https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64"
+
+          echo "Downloading hadolint v${HADOLINT_VERSION}..."
+          if ! wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -q "${HADOLINT_URL}" -O hadolint; then
+            echo "Error: Failed to download hadolint from ${HADOLINT_URL}" >&2
+            exit 1
+          fi
+
+          if [ ! -f hadolint ] || [ ! -s hadolint ]; then
+            echo "Error: Downloaded hadolint file is missing or empty" >&2
+            exit 1
+          fi
+
           chmod +x hadolint
           sudo mv hadolint /usr/local/bin/hadolint
+          echo "Hadolint installed successfully"
       - name: Lint Dockerfile
         id: run_hadolint
         run: |


### PR DESCRIPTION
Replace apt-get installation with direct binary download from GitHub releases. Hadolint is not available in Ubuntu's apt repositories, so we now download version 2.12.0 directly from the official releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to streamline development tooling installation and improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->