### PR TITLE
Add shellcheck annotations for goto_root includes

### DIFF
--- a/scripts/checks/run_eslint.sh
+++ b/scripts/checks/run_eslint.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 if [[ ! -d node_modules ]]; then
   if [[ "${SKIP_NPM_INSTALL:-0}" == "1" ]]; then

--- a/scripts/checks/run_gauge_specs.sh
+++ b/scripts/checks/run_gauge_specs.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 REPO_ROOT=$(pwd)
 export GAUGE_PYTHON_COMMAND="${GAUGE_PYTHON_COMMAND:-python3}"

--- a/scripts/checks/run_hadolint.sh
+++ b/scripts/checks/run_hadolint.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 if ! command -v hadolint >/dev/null 2>&1; then
   echo "hadolint is not installed. Please install hadolint to run this check." >&2

--- a/scripts/checks/run_integration_tests.sh
+++ b/scripts/checks/run_integration_tests.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 scripts/run-integration.sh -- --testmon "$@"

--- a/scripts/checks/run_mypy.sh
+++ b/scripts/checks/run_mypy.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 mypy "$@"

--- a/scripts/checks/run_property_tests.sh
+++ b/scripts/checks/run_property_tests.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 pytest tests/property --testmon "$@"

--- a/scripts/checks/run_pylint.sh
+++ b/scripts/checks/run_pylint.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 pylint --disable=C0114,C0115,C0116 "$@" .

--- a/scripts/checks/run_radon.sh
+++ b/scripts/checks/run_radon.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 OUTPUT_DIR="radon-report"
 SUMMARY_FILE="${OUTPUT_DIR}/summary.md"

--- a/scripts/checks/run_ruff.sh
+++ b/scripts/checks/run_ruff.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 ruff check "$@"

--- a/scripts/checks/run_shellcheck.sh
+++ b/scripts/checks/run_shellcheck.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 mapfile -t shell_scripts < <(git ls-files '*.sh')
 if [[ "${#shell_scripts[@]}" -eq 0 ]]; then

--- a/scripts/checks/run_stylelint.sh
+++ b/scripts/checks/run_stylelint.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 if [[ ! -d node_modules ]]; then
   if [[ "${SKIP_NPM_INSTALL:-0}" == "1" ]]; then

--- a/scripts/checks/run_uncss_check.sh
+++ b/scripts/checks/run_uncss_check.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 if [[ ! -d node_modules ]]; then
   if [[ "${SKIP_NPM_INSTALL:-0}" == "1" ]]; then

--- a/scripts/checks/run_unit_tests_full.sh
+++ b/scripts/checks/run_unit_tests_full.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 ./test-unit --coverage --summary-file coverage-report.txt "$@"

--- a/scripts/checks/run_unit_tests_impacted.sh
+++ b/scripts/checks/run_unit_tests_impacted.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 ./test-unit --testmon -- --maxfail=1 -q "$@"

--- a/scripts/checks/run_unit_tests_quick.sh
+++ b/scripts/checks/run_unit_tests_quick.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 ./test-unit -- --maxfail=1 -q "$@"

--- a/scripts/checks/run_vulture.sh
+++ b/scripts/checks/run_vulture.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 OUTPUT_DIR="vulture-report"
 SUMMARY_FILE="${OUTPUT_DIR}/summary.md"

--- a/scripts/checks/verify_test_index.sh
+++ b/scripts/checks/verify_test_index.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "${SCRIPT_DIR}"
+# shellcheck source=../../goto_root
 source ../../goto_root
 python generate_test_index.py
 bash scripts/check-test-index.sh


### PR DESCRIPTION
## Summary
- add shellcheck source annotations before sourcing goto_root in check scripts

## Testing
- `./scripts/checks/run_shellcheck.sh scripts/checks/run_eslint.sh` *(fails: shellcheck: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f8feffddc8331ae5d3cd0bf7f5f7b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling with improved static analysis directives and stronger error handling mechanisms in internal build verification scripts. Updates to multiple check utilities strengthen the development verification pipeline, improving reliability and consistency across code quality, testing, and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->