### PR TITLE
Suppress shellcheck false positive warnings in CI

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,7 @@
+# ShellCheck configuration file
+# See: https://github.com/koalaman/shellcheck/wiki/Ignore
+
+# SC1091: Not following sourced files
+# Disabled because our scripts source goto_root using relative paths that work
+# at runtime but ShellCheck can't follow during static analysis
+disable=SC1091


### PR DESCRIPTION
SC1091 is triggered when shellcheck can't follow sourced files during static analysis. Our scripts correctly source ../../goto_root which exists and works at runtime, but shellcheck can't verify the path from its analysis context. This is a false positive affecting 17 scripts.

Added .shellcheckrc to globally suppress SC1091 rather than adding inline suppressions to each affected script.