### PR TITLE
Fix remaining test isolation issues

### DIFF
--- a/tests/test_server_auto_main.py
+++ b/tests/test_server_auto_main.py
@@ -298,7 +298,8 @@ def test_auto_main_reads_cid_content_for_remaining_parameter(monkeypatch):
         lambda path: SimpleNamespace(file_data=cid_bytes) if path == f"/{cid_value}" else None,
     )
 
-    monkeypatch.setattr(server_execution, "find_matching_alias", lambda path: None)
+    # Patch find_matching_alias where it's used (in code_execution)
+    monkeypatch.setattr(code_execution, "find_matching_alias", lambda path: None)
 
     with app.test_request_context(f"/outer/{cid_value}"):
         result = server_execution.execute_server_code_from_definition(


### PR DESCRIPTION
Fixed the last 3 failing tests to achieve 100% test pass rate (978/978 passing):

1. test_variables_secrets_issue.py (2 tests):
   - Replaced patch.dict approach with app.test_request_context()
   - Fixed "Working outside of request context" errors by using proper Flask context

2. test_server_auto_main.py (1 test):
   - Fixed monkeypatch location for find_matching_alias
   - Patched code_execution.find_matching_alias instead of server_execution.find_matching_alias
   - Resolved "no such table: alias" error caused by unpatched database query

Test results improved from 3 failed, 975 passed to 0 failed, 978 passed.

Updated documentation to reflect completed fixes and provide guidance for similar issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test isolation documentation to reflect current testing status and fix details.

* **Tests**
  * Improved test context management and mocking strategies for enhanced test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->