### PR TITLE
Fix dead fixtures check to include integration tests

### DIFF
--- a/scripts/checks/run_dead_fixtures.sh
+++ b/scripts/checks/run_dead_fixtures.sh
@@ -5,4 +5,5 @@ cd "${SCRIPT_DIR}"
 # shellcheck source=../../goto_root
 source ../../goto_root
 # Run dead-fixtures check across all tests (including integration tests)
-python -m pytest --dead-fixtures -q "$@"
+# Clear addopts from pytest.ini to include integration tests
+python -m pytest --override-ini addopts= --dead-fixtures -q "$@"


### PR DESCRIPTION
The dead-fixtures check was previously excluding integration tests with '-m "not integration"', causing it to incorrectly report integration fixtures as unused. This fix removes that filter so the check analyzes all tests, including integration tests.

This resolves false positives for fixtures like login_default_user, sample_entities, app_factory, integration_app, and client that are only used in integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded dead-fixtures detection to run across all test suites (including integration tests), improving coverage validation and the reliability of test-cleanup detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->