### PR TITLE
Fix Pylint report status on GitHub Pages

### DIFF
--- a/scripts/build-report-site.py
+++ b/scripts/build-report-site.py
@@ -548,7 +548,8 @@ def _build_linter_index(linter_dir: Path, title: str, linter_name: str) -> None:
         summary_content = summary_path.read_text(encoding="utf-8")
         summary_lines = summary_content.strip().split("\n")
         summary_items = "".join(f"<li>{escape(line)}</li>" for line in summary_lines if line.strip())
-        summary_html = f"<h2>Summary</h2><ul>{summary_items}</ul>"
+        if summary_items:  # Only show summary if we have non-empty items
+            summary_html = f"<h2>Summary</h2><ul>{summary_items}</ul>"
 
     output_content = "No output was captured."
     if output_path.exists():
@@ -591,7 +592,8 @@ def _build_test_index_page(test_index_dir: Path) -> None:
         summary_content = summary_path.read_text(encoding="utf-8")
         summary_lines = summary_content.strip().split("\n")
         summary_items = "".join(f"<li>{escape(line)}</li>" for line in summary_lines if line.strip())
-        summary_html = f"<h2>Summary</h2><ul>{summary_items}</ul>"
+        if summary_items:  # Only show summary if we have non-empty items
+            summary_html = f"<h2>Summary</h2><ul>{summary_items}</ul>"
 
     test_index_link = ""
     if test_index_md.exists():

--- a/tests/test_build_report_site.py
+++ b/tests/test_build_report_site.py
@@ -98,3 +98,59 @@ def test_write_landing_page_includes_notice(tmp_path) -> None:
     content = index_path.read_text(encoding="utf-8")
 
     assert notice in content
+
+
+def test_build_linter_index_empty_summary(tmp_path) -> None:
+    """Test that empty summary.txt shows 'No summary available' message."""
+    linter_dir = tmp_path / "pylint"
+    linter_dir.mkdir(parents=True)
+
+    # Create empty summary.txt
+    (linter_dir / "summary.txt").write_text("", encoding="utf-8")
+    (linter_dir / "output.txt").write_text("No issues found", encoding="utf-8")
+
+    build_report._build_linter_index(linter_dir, "Pylint Report", "Pylint")
+
+    index_path = linter_dir / "index.html"
+    content = index_path.read_text(encoding="utf-8")
+
+    assert "No summary available." in content
+    assert "<h2>Summary</h2><ul></ul>" not in content
+
+
+def test_build_linter_index_whitespace_only_summary(tmp_path) -> None:
+    """Test that summary.txt with only whitespace shows 'No summary available' message."""
+    linter_dir = tmp_path / "pylint"
+    linter_dir.mkdir(parents=True)
+
+    # Create summary.txt with only whitespace
+    (linter_dir / "summary.txt").write_text("  \n  \n\t\n", encoding="utf-8")
+    (linter_dir / "output.txt").write_text("No issues found", encoding="utf-8")
+
+    build_report._build_linter_index(linter_dir, "Pylint Report", "Pylint")
+
+    index_path = linter_dir / "index.html"
+    content = index_path.read_text(encoding="utf-8")
+
+    assert "No summary available." in content
+    assert "<h2>Summary</h2><ul></ul>" not in content
+
+
+def test_build_linter_index_valid_summary(tmp_path) -> None:
+    """Test that summary.txt with valid content is displayed correctly."""
+    linter_dir = tmp_path / "pylint"
+    linter_dir.mkdir(parents=True)
+
+    # Create summary.txt with valid content
+    (linter_dir / "summary.txt").write_text("Exit code: 1\nStatus: ✗ Issues found", encoding="utf-8")
+    (linter_dir / "output.txt").write_text("Some pylint errors", encoding="utf-8")
+
+    build_report._build_linter_index(linter_dir, "Pylint Report", "Pylint")
+
+    index_path = linter_dir / "index.html"
+    content = index_path.read_text(encoding="utf-8")
+
+    assert "<h2>Summary</h2>" in content
+    assert "Exit code: 1" in content
+    assert "Status: ✗ Issues found" in content
+    assert "No summary available." not in content


### PR DESCRIPTION
When summary.txt exists but contains only whitespace or empty lines, the report was displaying a "Summary" heading with an empty list. This created confusion when the main index showed Pylint as failing but the detail page showed no visible summary.

Changes:
- Add check for non-empty summary_items before displaying summary
- Apply fix to both _build_linter_index and _build_test_index_page
- Add comprehensive tests for empty, whitespace-only, and valid summaries

Fixes the discrepancy where pylint/index.html shows no summary while the main report index correctly shows Pylint as failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Summary sections now only display when content is available; empty summaries show a "No summary available." message instead of blank sections.

* **Tests**
  * Added tests for summary rendering behavior with empty, whitespace-only, and valid content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->