### PR TITLE
Remove test index validation from quick-checks

### DIFF
--- a/.github/workflows/quick-checks.yml
+++ b/.github/workflows/quick-checks.yml
@@ -88,17 +88,6 @@ jobs:
         run: |
           SKIP_NPM_INSTALL=1 ./scripts/checks/run_stylelint.sh
 
-  test-index:
-    name: Test Index Validation
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/viewer-ci:latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Verify test index
-        run: ./scripts/checks/verify_test_index.sh
-
   dead-fixtures:
     name: Dead Fixtures Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Remove test-index job from quick-checks.yml (still runs in full-checks.yml)
- Fix check-test-index.sh to properly show diff between committed and generated index
- Replace git diff with git show HEAD:file + diff -u to avoid "not a git repository" errors
- Add proper git repository detection before attempting git operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Test Index Validation job from continuous integration workflow
  * Enhanced test index validation with improved comparison logic against committed versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->