### PR TITLE
Fix git dubious ownership error in CI pipeline

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run Pylint
         id: run_pylint
         run: |
+          # Fix git ownership issue in container
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           mkdir -p pylint-report
           STATUS=0
           ./scripts/checks/run_pylint.sh > pylint-report/output.txt 2>&1 || STATUS=$?


### PR DESCRIPTION
Add git config command to mark workspace as safe directory before running git commands. This fixes the "dubious ownership" error that occurs when running git ls-files in a Docker container where the repository owner doesn't match the container user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to ensure proper git workspace handling in containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->