### PR TITLE
Fix TEST_INDEX.md git commit detection issue

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -319,6 +319,9 @@ jobs:
       - name: Verify test index
         id: verify_test_index
         run: |
+          # Fix git ownership issue in container
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           mkdir -p test-index-report
           STATUS=0
           ./scripts/checks/verify_test_index.sh > test-index-report/output.txt 2>&1 || STATUS=$?


### PR DESCRIPTION
The test-index job was failing with "No committed version of TEST_INDEX.md found in git!" even though the file exists in the repository. This was caused by a git ownership issue when running in a Docker container.

When GitHub Actions checks out code in a container, git considers the directory unsafe due to ownership mismatches. The `git show HEAD:TEST_INDEX.md` command in check-test-index.sh was failing silently (due to 2>/dev/null redirection), causing the script to create an empty temp file and report the error.

This fix adds the `git config --global --add safe.directory` command to the test-index job, matching the pattern already used in the pylint job (line 43).

Fixes the error displayed at https://curtcox.github.io/Viewer/test-index/index.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to resolve container environment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->