### PR TITLE
Find first page missing gauge specs

### DIFF
--- a/specs/alias_view.spec
+++ b/specs/alias_view.spec
@@ -1,0 +1,29 @@
+# Alias view
+
+## Alias detail page displays basic information
+* Given there is an alias named "test-alias" pointing to /test-target
+* When I visit the alias detail page for "test-alias"
+* Then the response status should be 200
+* And the page should contain "Alias Details"
+* And the page should contain "test-alias"
+* And the page should contain "/test-target"
+
+## Alias detail page shows navigation buttons
+* Given there is an alias named "nav-test" pointing to /guides
+* When I visit the alias detail page for "nav-test"
+* Then the response status should be 200
+* And the page should contain "Back to Aliases"
+* And the page should contain "Edit Alias"
+
+## Alias detail page displays status badge
+* Given there is an enabled alias named "active-alias" pointing to /active
+* When I visit the alias detail page for "active-alias"
+* Then the response status should be 200
+* And the page should contain "Enabled"
+
+## Alias detail page shows definition section
+* Given there is an alias named "def-test" pointing to /definition-target
+* When I visit the alias detail page for "def-test"
+* Then the response status should be 200
+* And the page should contain "Alias Definition"
+* And the page should contain "How it Works"

--- a/step_impl/alias_steps.py
+++ b/step_impl/alias_steps.py
@@ -261,3 +261,42 @@ def record_alias_path_coverage(alias_name: str) -> None:
     """Acknowledge alias detail path coverage for documentation purposes."""
 
     assert alias_name, "Alias name placeholder should not be empty."
+
+
+@step('When I visit the alias detail page for <alias_name>')
+def when_i_visit_alias_detail_page(alias_name: str) -> None:
+    """Navigate to the alias detail page for the specified alias."""
+
+    alias_name = alias_name.strip().strip('"')
+    path = f"/aliases/{alias_name}"
+    when_i_visit_path(path)
+
+
+@step('Given there is an enabled alias named <alias_name> pointing to <target_path>')
+def given_enabled_alias_exists(alias_name: str, target_path: str) -> None:
+    """Persist an enabled alias with the provided name and target path."""
+
+    client = _require_client()
+    _login_default_user(client)
+
+    alias_name = alias_name.strip().strip('"')
+    target_path = target_path.strip().strip('"')
+
+    with _app_context():
+        user = ensure_default_user()
+        definition_text = format_primary_alias_line(
+            match_type="literal",
+            match_pattern=None,
+            target_path=target_path,
+            alias_name=alias_name,
+        )
+        alias = Alias(
+            name=alias_name,
+            user_id=user.id,
+            definition=definition_text,
+            enabled=True,
+        )
+        db.session.add(alias)
+        db.session.commit()
+
+    _scenario_state["alias_name"] = alias_name


### PR DESCRIPTION
- Create alias_view.spec with comprehensive test scenarios
- Add step implementations for alias detail page testing
- Test basic alias details display
- Test navigation buttons (Back to Aliases, Edit Alias)
- Test status badge display
- Test definition and "How it Works" sections

This addresses the first missing page spec identified in docs/page_test_cross_reference.md for templates/alias_view.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test specifications for the alias detail page, covering display of basic alias information, navigation buttons, enabled status indicators, and alias definition sections. Includes supporting automation steps for test scenario execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->