### PR TITLE
Ensure AI request payloads are captured for AI stub invocations

### DIFF
--- a/server_execution/invocation_tracking.py
+++ b/server_execution/invocation_tracking.py
@@ -14,6 +14,23 @@ from models import ServerInvocation
 
 def request_details():
     """Collect request details for server execution context."""
+    try:
+        json_body = request.get_json(silent=True)
+    except (UnicodeDecodeError, ValueError):
+        json_body = None
+
+    try:
+        raw_body = request.get_data(cache=True)
+    except Exception:  # pragma: no cover - defensive fallback for unexpected request failures
+        raw_body = b""
+
+    body_text: Optional[str] = None
+    if raw_body:
+        try:
+            body_text = raw_body.decode("utf-8")
+        except UnicodeDecodeError:
+            body_text = raw_body.decode("utf-8", errors="replace")
+
     return {
         "path": request.path,
         "query_string": request.query_string.decode("utf-8"),
@@ -26,6 +43,8 @@ def request_details():
         "scheme": request.scheme,
         "host": request.host,
         "method": request.method,
+        "json": json_body,
+        "body": body_text,
     }
 
 

--- a/tests/test_server_execution.py
+++ b/tests/test_server_execution.py
@@ -478,6 +478,8 @@ class TestRequestDetails(unittest.TestCase):
         with app.test_request_context(
             "/test?key=value",
             method="POST",
+            data=json.dumps({"request_text": "Update"}),
+            content_type="application/json",
             headers={"User-Agent": "TestAgent", "Cookie": "session=xyz"},
         ):
             result = request_details()
@@ -487,6 +489,8 @@ class TestRequestDetails(unittest.TestCase):
         assert result["method"] == "POST"
         assert "User-Agent" in result["headers"]
         assert "Cookie" not in result["headers"]
+        assert result["json"] == {"request_text": "Update"}
+        assert "Update" in (result["body"] or "")
 
 
 class TestBuildRequestArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary
- include JSON and raw body data when recording server request details so AI payloads are retained
- extend request_details unit coverage to check JSON bodies are captured
- add an integration test confirming AI invocations log their request payloads for server events

## Testing
- pytest tests/test_server_execution.py::TestRequestDetails
- pytest -m integration tests/integration/test_server_events_page.py::test_ai_request_details_capture_json_body


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69310181f60883318f3c7610e4695a57)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request details tracking now captures and exposes request body information in both JSON and text formats.

* **Tests**
  * Added integration test validating JSON body capture in server invocation tracking.
  * Updated existing tests to verify proper request body handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->