### PR TITLE
Fix Pylint trailing whitespace issues

### DIFF
--- a/scripts/checks/validate_cids.py
+++ b/scripts/checks/validate_cids.py
@@ -112,7 +112,7 @@ def validate_cids(cid_dir: Path) -> ValidationSummary:
     for path in cid_files:
         content = path.read_bytes()
         total_bytes += len(content)
-        
+
         # Check if filename is less than 94 characters (literal CID)
         if len(path.name) < 94:
             failures.append(
@@ -124,7 +124,7 @@ def validate_cids(cid_dir: Path) -> ValidationSummary:
                 )
             )
             continue
-        
+
         # Check if computed CID matches filename
         computed = generate_cid(content)
         if computed != path.name:
@@ -171,7 +171,7 @@ def write_report(summary: ValidationSummary, output_dir: Path) -> None:
                     f"- {failure.filename} (length: {len(failure.filename)}, {failure.size_bytes} bytes)"
                 )
             report_lines.append("")
-        
+
         if summary.mismatch_failures:
             report_lines.append("CID Mismatch Failures:")
             for failure in summary.mismatch_failures:

--- a/scripts/generate_ai_eval_reports.py
+++ b/scripts/generate_ai_eval_reports.py
@@ -63,14 +63,14 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
     interactions = interaction_data.get('interactions', [])
     passed = interaction_data.get('passed', False)
     failed = interaction_data.get('failed', False)
-    
+
     # Load and highlight test source
     source_code = load_test_source(test_file_path) if test_file_path else None
     if source_code:
         highlighted_source, syntax_css = highlight_python_code(source_code)
     else:
         highlighted_source, syntax_css = None, None
-    
+
     # Determine status badge
     if passed:
         status_badge = '<span class="badge badge-success">✓ PASSED</span>'
@@ -78,7 +78,7 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
         status_badge = '<span class="badge badge-failed">✗ FAILED</span>'
     else:
         status_badge = '<span class="badge badge-unknown">? UNKNOWN</span>'
-    
+
     # Build interactions HTML
     interactions_html = []
     for idx, interaction in enumerate(interactions, 1):
@@ -86,22 +86,22 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
         response = interaction.get('response', {})
         status = interaction.get('status', 'N/A')
         timestamp = interaction.get('timestamp', 'N/A')
-        
+
         # Format request
         request_text = request.get('request_text', '')
         original_text = request.get('original_text', '')
         target_label = request.get('target_label', '')
-        
+
         # Format response
         updated_text = response.get('updated_text', '')
         error = response.get('error', '')
-        
+
         interaction_html = f"""
         <div class="interaction">
             <h3>Interaction {idx}</h3>
             <p class="timestamp">Timestamp: {timestamp}</p>
             <p class="status">HTTP Status: {status}</p>
-            
+
             <h4>Request</h4>
             <div class="request-details">
                 <p><strong>Target:</strong> {target_label}</p>
@@ -109,7 +109,7 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
                 <pre class="request-text">{request_text}</pre>
                 {f'<p><strong>Original Text:</strong></p><pre class="original-text">{original_text}</pre>' if original_text else ''}
             </div>
-            
+
             <h4>Response</h4>
             <div class="response-details">
                 {f'<p class="error"><strong>Error:</strong> {error}</p>' if error else ''}
@@ -118,9 +118,9 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
         </div>
         """
         interactions_html.append(interaction_html)
-    
+
     interactions_section = '\n'.join(interactions_html) if interactions_html else '<p class="no-interactions">No interactions recorded</p>'
-    
+
     # Generate HTML page
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -156,20 +156,20 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
 <body>
     <div class="container">
         <a href="index.html" class="back-link">← Back to Index</a>
-        
+
         <h1>{test_name} {status_badge}</h1>
-        
+
         {f'<div class="test-info"><p><strong>Description:</strong> {test_doc}</p></div>' if test_doc else ''}
-        
+
         <h2>Test Source Code</h2>
         {highlighted_source if highlighted_source else '<p class="no-interactions">Source code not available</p>'}
-        
+
         <h2>AI Interactions</h2>
         {interactions_section}
     </div>
 </body>
 </html>"""
-    
+
     # Write the HTML file
     output_path.write_text(html, encoding='utf-8')
     print(f"Generated detail page: {output_path}")
@@ -177,7 +177,7 @@ def generate_detail_page(interaction_data: Dict, output_path: Path) -> None:
 
 def generate_index_page(interaction_files: List[Path], output_path: Path) -> None:
     """Generate the index page listing all AI eval tests."""
-    
+
     # Load all interaction data
     tests = []
     for json_file in sorted(interaction_files):
@@ -191,7 +191,7 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
                 'failed': data.get('failed', False),
                 'detail_page': f"{json_file.stem}.html"
             })
-    
+
     # Build test list HTML
     test_items = []
     for test in tests:
@@ -204,9 +204,9 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
         else:
             status_icon = '?'
             status_class = 'status-unknown'
-        
+
         doc_text = test['doc'][:MAX_DOC_LENGTH] + '...' if len(test['doc']) > MAX_DOC_LENGTH else test['doc']
-        
+
         test_item = f"""
         <li class="test-item">
             <span class="status-icon {status_class}">{status_icon}</span>
@@ -217,14 +217,14 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
         </li>
         """
         test_items.append(test_item)
-    
+
     test_list = '\n'.join(test_items) if test_items else '<p class="no-tests">No tests found</p>'
-    
+
     # Count stats
     total = len(tests)
     passed = sum(1 for t in tests if t['passed'])
     failed = sum(1 for t in tests if t['failed'])
-    
+
     # Generate HTML
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -259,7 +259,7 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
 <body>
     <div class="container">
         <h1>AI Evaluation Tests</h1>
-        
+
         <div class="stats">
             <div class="stat stat-total">
                 <div class="stat-number">{total}</div>
@@ -274,7 +274,7 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
                 <div class="stat-label">Failed</div>
             </div>
         </div>
-        
+
         <h2>Test Cases</h2>
         <ul class="test-list">
             {test_list}
@@ -282,7 +282,7 @@ def generate_index_page(interaction_files: List[Path], output_path: Path) -> Non
     </div>
 </body>
 </html>"""
-    
+
     # Write the HTML file
     output_path.write_text(html, encoding='utf-8')
     print(f"Generated index page: {output_path}")
@@ -293,39 +293,39 @@ def main():
     # Paths
     interactions_dir = Path('test-results/ai-interactions')
     output_dir = Path('test-results/ai-eval-reports')
-    
+
     # Check if interactions directory exists
     if not interactions_dir.exists():
         print(f"Error: Interactions directory not found: {interactions_dir}", file=sys.stderr)
         print("Run the AI eval tests first to generate interaction data.", file=sys.stderr)
         return 1
-    
+
     # Find all interaction JSON files
     json_files = list(interactions_dir.glob('*.json'))
     if not json_files:
         print(f"Warning: No interaction JSON files found in {interactions_dir}", file=sys.stderr)
         return 1
-    
+
     print(f"Found {len(json_files)} test interaction files")
-    
+
     # Create output directory
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Generate detail pages for each test
     for json_file in json_files:
         interaction_data = load_interaction_file(json_file)
         if interaction_data:
             detail_page = output_dir / f"{json_file.stem}.html"
             generate_detail_page(interaction_data, detail_page)
-    
+
     # Generate index page
     index_page = output_dir / 'index.html'
     generate_index_page(json_files, index_page)
-    
+
     print("\n✓ Report generation complete!")
     print(f"  Index: {index_page}")
     print("  View via source browser at: /source/test-results/ai-eval-reports/index.html")
-    
+
     return 0
 
 

--- a/step_impl/server_dependencies_steps.py
+++ b/step_impl/server_dependencies_steps.py
@@ -107,7 +107,7 @@ def then_page_should_not_contain(text: str) -> None:
     """Assert that the current page response does not contain the provided text."""
     response = get_scenario_state().get("response")
     assert response is not None, "No response recorded. Call `When I request ...` first."
-    
+
     text = _normalize_path(text)
     body = response.get_data(as_text=True)
     assert text not in body, f"Expected NOT to find {text!r} in the response body, but it was present."

--- a/step_impl/urleditor_steps.py
+++ b/step_impl/urleditor_steps.py
@@ -1,3 +1,4 @@
+"""Step implementations for URL Editor server specs."""
 from __future__ import annotations
 
 from getgauge.python import step
@@ -5,8 +6,6 @@ from getgauge.python import step
 from identity import ensure_default_resources
 from step_impl.shared_app import get_shared_app, get_shared_client
 from step_impl.shared_state import get_scenario_state, store
-
-"""Step implementations for URL Editor server specs."""
 
 
 @step("When I check the available servers")

--- a/tests/ai_use_cases/assertions.py
+++ b/tests/ai_use_cases/assertions.py
@@ -29,6 +29,7 @@ def assert_valid_json(text: str) -> dict:
         return json.loads(text)
     except json.JSONDecodeError as e:
         pytest.fail(f"Invalid JSON: {e}\n\nText:\n{text}")
+        return {}  # Never reached, but satisfies pylint
 
 
 def assert_original_content_preserved(result: str, original: str):

--- a/tests/ai_use_cases/conftest.py
+++ b/tests/ai_use_cases/conftest.py
@@ -30,7 +30,7 @@ def setup_ai_assist_server(memory_db_app):
         if not ai_server:
             # Read the server definition from file
             definition_path = 'reference_templates/servers/definitions/ai_assist.py'
-            with open(definition_path) as f:
+            with open(definition_path, encoding='utf-8') as f:
                 definition = f.read()
 
             ai_server = Server(
@@ -119,16 +119,16 @@ def ai_interaction_tracker(request):
     test_file = request.node.fspath.basename
     test_module = request.node.module.__name__
     test_doc = request.node.function.__doc__ or ""
-    
+
     # Determine test status - handle passed, failed, and other states (e.g., skipped)
     passed = hasattr(request.node, 'rep_call') and getattr(request.node.rep_call, 'passed', False)
     failed = hasattr(request.node, 'rep_call') and getattr(request.node.rep_call, 'failed', False)
-    
+
     output_dir = 'test-results/ai-interactions'
     os.makedirs(output_dir, exist_ok=True)
 
     output_file = os.path.join(output_dir, f'{test_name}.json')
-    with open(output_file, 'w') as f:
+    with open(output_file, 'w', encoding='utf-8') as f:
         json.dump({
             'test_name': test_name,
             'test_file': test_file,

--- a/tests/test_validate_cids.py
+++ b/tests/test_validate_cids.py
@@ -27,23 +27,23 @@ class TestValidateCids(unittest.TestCase):
         """Test that CIDs with filenames < 94 characters are reported as failures."""
         with TemporaryDirectory() as tmpdir:
             cid_dir = Path(tmpdir)
-            
+
             # Create a CID with a short filename (literal CID)
             short_content = b"test"
             short_cid = generate_cid(short_content)
             self.assertLess(len(short_cid), 94, "Test setup: should have short CID")
-            
+
             short_file = cid_dir / short_cid
             short_file.write_bytes(short_content)
-            
+
             # Run validation
             summary = validate_cids(cid_dir)
-            
+
             # Should have 1 file, 0 valid, 1 failure
             self.assertEqual(summary.cid_count, 1)
             self.assertEqual(summary.valid_count, 0)
             self.assertEqual(len(summary.failures), 1)
-            
+
             # Check the failure details
             failure = summary.failures[0]
             self.assertEqual(failure.filename, short_cid)
@@ -54,19 +54,19 @@ class TestValidateCids(unittest.TestCase):
         """Test that CIDs with filenames >= 94 characters are validated correctly."""
         with TemporaryDirectory() as tmpdir:
             cid_dir = Path(tmpdir)
-            
+
             # Create a CID with a long filename (hashed CID)
             # Need content > 64 bytes to get a 94-char CID
             long_content = b"x" * 100
             long_cid = generate_cid(long_content)
             self.assertEqual(len(long_cid), 94, "Test setup: should have 94-char CID")
-            
+
             long_file = cid_dir / long_cid
             long_file.write_bytes(long_content)
-            
+
             # Run validation
             summary = validate_cids(cid_dir)
-            
+
             # Should have 1 file, 1 valid, 0 failures
             self.assertEqual(summary.cid_count, 1)
             self.assertEqual(summary.valid_count, 1)
@@ -76,20 +76,20 @@ class TestValidateCids(unittest.TestCase):
         """Test validation with both short and long filenames."""
         with TemporaryDirectory() as tmpdir:
             cid_dir = Path(tmpdir)
-            
+
             # Create a short CID
             short_content = b"short"
             short_cid = generate_cid(short_content)
             (cid_dir / short_cid).write_bytes(short_content)
-            
+
             # Create a long CID
             long_content = b"x" * 100
             long_cid = generate_cid(long_content)
             (cid_dir / long_cid).write_bytes(long_content)
-            
+
             # Run validation
             summary = validate_cids(cid_dir)
-            
+
             # Should have 2 files, 1 valid, 1 failure
             self.assertEqual(summary.cid_count, 2)
             self.assertEqual(summary.valid_count, 1)
@@ -101,22 +101,22 @@ class TestValidateCids(unittest.TestCase):
         """Test that mismatched CIDs are still reported correctly."""
         with TemporaryDirectory() as tmpdir:
             cid_dir = Path(tmpdir)
-            
+
             # Create a file with wrong name
             content = b"x" * 100
             correct_cid = generate_cid(content)
             wrong_name = "A" * 94  # Wrong but right length
-            
+
             (cid_dir / wrong_name).write_bytes(content)
-            
+
             # Run validation
             summary = validate_cids(cid_dir)
-            
+
             # Should have 1 file, 0 valid, 1 failure
             self.assertEqual(summary.cid_count, 1)
             self.assertEqual(summary.valid_count, 0)
             self.assertEqual(len(summary.failures), 1)
-            
+
             # Check it's a mismatch failure, not a short filename
             failure = summary.failures[0]
             self.assertEqual(failure.failure_type, "mismatch")
@@ -128,9 +128,9 @@ class TestValidateCids(unittest.TestCase):
         """Test validation with an empty directory."""
         with TemporaryDirectory() as tmpdir:
             cid_dir = Path(tmpdir)
-            
+
             summary = validate_cids(cid_dir)
-            
+
             self.assertEqual(summary.cid_count, 0)
             self.assertEqual(summary.valid_count, 0)
             self.assertEqual(len(summary.failures), 0)


### PR DESCRIPTION
Fixed the following Pylint issues:
- Removed trailing whitespace from multiple files (C0303)
- Fixed pointless-string-statement in urleditor_steps.py (W0105)
- Fixed inconsistent-return-statements in assertions.py (R1710)
- Added encoding='utf-8' to open() calls in conftest.py (W1514)

Files modified:
- scripts/checks/validate_cids.py
- scripts/generate_ai_eval_reports.py
- step_impl/server_dependencies_steps.py
- step_impl/urleditor_steps.py
- tests/ai_use_cases/assertions.py
- tests/ai_use_cases/conftest.py
- tests/test_validate_cids.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code quality improvements including formatting cleanup, whitespace adjustments, and enhanced file encoding specifications across test and utility scripts.
  * Added module-level documentation for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->