### PR TITLE
Fix boot image reference template integration tests

### DIFF
--- a/tests/integration/test_boot_image_reference_templates.py
+++ b/tests/integration/test_boot_image_reference_templates.py
@@ -96,7 +96,7 @@ class TestBootImageReferenceTemplates:
         with self.app.app_context():
             alias = Alias.query.filter_by(name='ai').first()
             assert alias is not None, "Alias 'ai' should be loaded from boot image"
-            assert 'ai -> /ai_stub' in alias.definition
+            assert 'ai -> /ai_assist' in alias.definition
             assert alias.enabled is True
 
     def test_boot_image_loads_servers(self, tmp_path):


### PR DESCRIPTION
The test was checking for 'ai -> /ai_stub' but the actual boot.source.json defines the alias as 'ai -> /ai_assist'. Updated the test expectation to match the current boot image configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for AI assistant alias routing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->