### PR TITLE
Fix Pylint errors in test_ai_editor module

### DIFF
--- a/tests/test_ai_editor.py
+++ b/tests/test_ai_editor.py
@@ -18,7 +18,7 @@ def load_ai_editor_module():
     )
     namespace: dict = {}
     with open(ai_editor_path, "r", encoding="utf-8") as handle:
-        exec(handle.read(), namespace)
+        exec(handle.read(), namespace)  # pylint: disable=exec-used
     return namespace
 
 
@@ -38,7 +38,7 @@ class TestAiEditorBasics:
     """Basic behaviour checks for the AI editor server."""
 
     def setup_method(self):
-        self.module = load_ai_editor_module()
+        self.module = load_ai_editor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_main_exists_and_returns_html(self):
         result = self.module["main"]()
@@ -64,7 +64,7 @@ class TestAiEditorPayloadHandling:
     """Payload extraction and embedding behaviour."""
 
     def setup_method(self):
-        self.module = load_ai_editor_module()
+        self.module = load_ai_editor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_embeds_payload_from_json_request(self):
         payload = {

--- a/tests/test_urleditor.py
+++ b/tests/test_urleditor.py
@@ -10,14 +10,14 @@ def load_urleditor_module():
 
     # Read the urleditor.py file
     urleditor_path = Path(__file__).parent.parent / "reference_templates" / "servers" / "definitions" / "urleditor.py"
-    with open(urleditor_path, 'r') as f:
+    with open(urleditor_path, 'r', encoding='utf-8') as f:
         code = f.read()
 
     # Create a module namespace
     module_namespace = {}
 
     # Execute the code in the namespace
-    exec(code, module_namespace)
+    exec(code, module_namespace)  # pylint: disable=exec-used
 
     return module_namespace
 
@@ -27,7 +27,7 @@ class TestURLEditorServerBasics:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.module = load_urleditor_module()
+        self.module = load_urleditor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_main_function_exists(self):
         """Test that the main function exists."""
@@ -69,7 +69,7 @@ class TestURLEditorHelperFunctions:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.module = load_urleditor_module()
+        self.module = load_urleditor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_should_redirect_returns_false_for_root(self):
         """Test that _should_redirect returns False for root path."""
@@ -125,7 +125,7 @@ class TestURLEditorWithRequest:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.module = load_urleditor_module()
+        self.module = load_urleditor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_main_with_urleditor_path(self):
         """Test main with request path /urleditor."""
@@ -166,7 +166,7 @@ class TestURLEditorMetaLinks:
     """Ensure metadata links are rendered for navigation support."""
 
     def setup_method(self):
-        self.module = load_urleditor_module()
+        self.module = load_urleditor_module()  # pylint: disable=attribute-defined-outside-init
 
     def test_meta_links_point_to_history_and_server_events(self, monkeypatch):
         from datetime import datetime, timezone as real_timezone


### PR DESCRIPTION
- Add encoding='utf-8' to open() call in test_urleditor.py
- Add pylint disable comments for exec-used warnings (needed for dynamic module loading in tests)
- Add pylint disable comments for attribute-defined-outside-init in setup_method (standard pytest pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test file encoding specifications.
  * Updated test setup configuration to enhance code quality compliance.

* **Chores**
  * Improved internal code standards in test infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->