### PR TITLE
Clean up gauge specs documentation

### DIFF
--- a/todo/fix_gauge_specs.md
+++ b/todo/fix_gauge_specs.md
@@ -1,57 +1,12 @@
-# Gauge spec failures
+# Gauge Spec Failures - Remediation Plan
 
-The latest run of `scripts/checks/run_gauge_specs.sh` surfaced multiple failing specs concentrated in specific areas:
-
-- **AI editor**: Default boot image missing server support plus editor page/actions failures and chain rejection cases remain broken. 【c4cad4†L1-L5】【d05d1b†L1-L6】
-- **Authorization API**: API requests are still being denied even though other authorization behaviors pass. 【11e105†L1-L6】
-- **Default boot servers**: Echo and shell boot servers are not responding with the expected HTML or form outputs. 【98ec73†L1-L6】
-- **Server command chaining**: All chaining scenarios (CID inputs, default servers, language-specific CID literals, and server events dashboard) are failing, indicating foundational breakage in chaining and server event tracking. 【c4cad4†L1-L36】
-- **UI suggestions**: Viewing a variable with no UI suggestions fails. 【c4019b†L1-L9】
-- **Upload templates**: Embedded CID execution guide is missing from the upload page. 【c4019b†L6-L10】
-- **URL editor**: Boot image availability, page loading, redirect handling, chain rejection, UI layout, button behaviors, newline handling, and metadata endpoint usage are failing in most URL editor scenarios. 【4204e8†L1-L22】
-
-## Plan to fix
-
-1. **Investigate boot image contents and server registration** for AI editor and URL editor to ensure their servers are included and enabled; update boot image generation or fixture loading as needed. 【d05d1b†L1-L6】【4204e8†L1-L22】
-2. **Debug editor route handlers (ai_editor and urleditor)** to serve correct pages, redirects, and client assets; add integration tests to validate page structure and required elements. 【d05d1b†L1-L6】【4204e8†L1-L22】
-3. **Review chain rejection logic** for AI and URL editors to confirm they explicitly disallow chaining with appropriate responses. 【d05d1b†L4-L6】【4204e8†L3-L5】
-4. **Fix authorization middleware for API paths** so API requests authenticate/authorize correctly without blocking valid calls. 【11e105†L1-L3】
-5. **Restore default boot server behaviors** (echo/shell) to return expected HTML and form responses; verify routing and templates. 【98ec73†L1-L6】
-6. **Rebuild command chaining pipeline** to correctly pass CIDs through default, named, and literal servers across languages; validate server events dashboard surfacing executions. 【c4cad4†L1-L36】
-7. **Address UI suggestions retrieval** for variables to mirror alias/server behavior when no suggestions exist. 【c4019b†L1-L4】
-8. **Ensure upload page lists embedded CID execution guide** when templates are configured. 【c4019b†L6-L10】
-
-Tracking these areas and resolving them iteratively should clear the remaining Gauge spec failures.
-
-## Progress
-
-- Enabled the Gauge test app to load CID fixtures and import the default boot image even in testing mode, ensuring default servers and resources are available during specs.
-- UI suggestions scenarios now pass after loading the boot image into the shared test app; other areas (AI/URL editors, chaining, upload templates, default boot servers, and authorization API) still need follow-up.
-- Default boot server specs now exercise the rendered HTML instead of redirect placeholders by following redirects in shared Gauge requests.
-- Fixed the echo default boot server template by importing HTML escaping utilities so it renders the expected HTML instead of erroring during execution.
-- Added Gauge steps and fixtures to load enabled servers from the default boot image and exercise the AI editor POST flow along with the embedded CID upload guide template.
-- Captured redirect responses separately from followed content in shared Gauge web helpers and added URL editor interaction steps for copying/opening URLs and fragment assertions.
-- Surfaced upload template descriptions, including the embedded CID execution guide details, so the upload page lists guidance text alongside template buttons.
-- Exposed a `/api/routes` JSON endpoint to unblock authorization specs that expect the routes overview API.
-- Added metadata/history/server events links to the URL editor page with timestamped targets for navigation during Gauge specs.
-- Normalized Gauge request helpers to detect redirects via status codes and headers, unblocking authorization, boot server, and UI suggestion specs that depend on following redirect chains.
-- Restored missing imports in the server chaining Gauge steps so chaining scenarios can execute against the shared test app.
-- Captured multiline URL editor input in Gauge steps to build fragments and preview counts, covering newline-separated chains and repeated preview-row assertions.
-- Provisioned the AI and URL editor servers during default resource initialization and refreshed chaining step dependencies so default editors and chaining flows load without import errors.
-- Added the remaining chaining step imports (Gauge decorators, shared app helpers, CID utilities) so chaining scenarios can create servers and CIDs without NameErrors.
-- Added fallback stubs for TypeScript/Clojure runners, expanded chaining step definitions to create language-specific CIDs with placeholders, and wired placeholder substitution into shared web steps to keep Gauge chaining specs executing despite missing runtimes.
-
-## Current Status (2025-12-11)
+## Current Status
 
 **Test Results:** 66 passing, 47 failing
 
-### Investigation Findings
+### Key Finding
 
-- Verified that `ai_editor` and `urleditor` servers ARE being loaded correctly by `ensure_default_resources()`
-- Standalone tests confirm both servers are available in the database with `enabled=True`
-- The shared gauge app context also shows servers are properly loaded
-- Some gauge specs pass (e.g., "Accessing ai_editor shows the editor page") while others fail (e.g., "Server is available in default boot image")
-- This suggests possible test infrastructure issues rather than code issues
+Investigation revealed that `ai_editor` and `urleditor` servers ARE being loaded correctly by `ensure_default_resources()` and are available in the database with `enabled=True`. Some specs pass while others fail, suggesting possible test infrastructure issues rather than code issues.
 
 ### Remaining Failures by Category
 
@@ -78,8 +33,70 @@ Tracking these areas and resolving them iteratively should clear the remaining G
    - Multiple path element previews
    - Preview links
 
-### Notes
+## Plan to Eliminate Remaining Failures
 
-- Server availability tests may have timing or test framework issues since servers ARE loaded
-- The failures may be related to gauge test execution context rather than actual functionality
-- Significant progress has been made with 66 tests now passing
+### 1. Investigate Test Infrastructure Issues
+
+Since servers are confirmed to be loaded but "availability" tests still fail, investigate:
+- How Gauge specs check for "server is available in default boot image"
+- Timing issues in test setup/teardown
+- Context isolation between test scenarios
+- Whether tests are checking the right database/state
+
+**Priority: High** - This may resolve many failures at once
+
+### 2. Fix Server Command Chaining (34 failures)
+
+Debug the chaining pipeline to understand why CID execution and server chaining scenarios fail:
+- Verify CID creation and storage in test scenarios
+- Check request routing for chained commands
+- Validate language-specific runner stubs (TypeScript/Clojure placeholders may be incomplete)
+- Ensure server events are being tracked and surfaced correctly
+
+**Priority: High** - Largest category of failures
+
+### 3. Fix AI Editor Failures (3 failures)
+
+Address remaining AI editor issues:
+- Debug "availability" test (likely infrastructure issue per key finding above)
+- Verify request payload embedding in editor page
+- Confirm chain rejection logic returns appropriate responses
+
+**Priority: Medium** - Small number but important functionality
+
+### 4. Fix URL Editor Failures (6 failures)
+
+Address remaining URL editor issues:
+- Debug "availability" test (likely infrastructure issue)
+- Verify subpath-to-fragment redirect logic
+- Confirm chain rejection behavior
+- Validate required page elements are rendered
+- Fix preview functionality for multiple path elements
+- Ensure preview links work correctly
+
+**Priority: Medium** - Important user-facing feature
+
+### 5. Fix Server Dependencies Display (3 failures)
+
+Ensure dependency information displays correctly on servers list page:
+- Verify dependency data collection
+- Check template rendering logic
+- Validate test assertions match actual UI structure
+
+**Priority: Low** - Smaller impact
+
+### 6. Fix Server Events Dashboard (1 failure)
+
+Resolve dashboard accessibility issue:
+- Verify route registration
+- Check authentication/authorization requirements
+- Ensure dashboard page renders correctly
+
+**Priority: Low** - Single failure
+
+## Recommended Approach
+
+1. Start with test infrastructure investigation (#1) - could resolve multiple categories
+2. Tackle server command chaining (#2) - largest failure category
+3. Address editor issues (#3, #4) in parallel
+4. Clean up remaining issues (#5, #6)


### PR DESCRIPTION
Remove historical progress details and outdated plan. Keep only current status, investigation findings, and a clear prioritized plan for eliminating the remaining 47 test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined Gauge specification failure tracking documentation with a condensed remediation plan and prioritized action items for improved clarity and focus on resolution efforts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->