### PR TITLE
Render help docs via help routes

### DIFF
--- a/docs/help-default.md
+++ b/docs/help-default.md
@@ -108,8 +108,8 @@ With the default boot image, you have access to:
 ## Help Resources
 
 - [General Help](/help) - Complete help documentation
-- [Boot CID Documentation](/source/docs/BOOT_CID_USAGE.md) - Boot image system details
-- [Import/Export Guide](/source/docs/import-export-json-format.md) - Data transfer format
+- [Boot CID Documentation](/help/BOOT_CID_USAGE.md) - Boot image system details
+- [Import/Export Guide](/help/import-export-json-format.md) - Data transfer format
 - [Gauge Specs](/source/specs/) - Behavioral specifications
 
 ---

--- a/docs/help-minimal.md
+++ b/docs/help-minimal.md
@@ -123,15 +123,15 @@ Unlike the default boot image, minimal boot:
 ### Build a Template Library
 1. Create reusable entity definitions
 2. Store them as a variable named `templates`
-3. Format according to the [template specification](/source/docs/json-template-format.md)
+3. Format according to the [template specification](/help/json-template-format.md)
 
 ## Help Resources
 
 - [General Help](/help) - Complete help documentation
 - [Creating Aliases](/help#aliases) - Alias syntax and examples
 - [Creating Servers](/help#servers) - Server development guide
-- [Import/Export Guide](/source/docs/import-export-json-format.md) - Data transfer format
-- [Template Format](/source/docs/json-template-format.md) - Build your own templates
+- [Import/Export Guide](/help/import-export-json-format.md) - Data transfer format
+- [Template Format](/help/json-template-format.md) - Build your own templates
 - [Gauge Specs](/source/specs/) - Behavioral specifications
 
 ## Need Examples?

--- a/docs/help-readonly.md
+++ b/docs/help-readonly.md
@@ -165,9 +165,9 @@ Will result in an error message explaining that the operation is not permitted i
 ## Help Resources
 
 - [General Help](/help) - Complete help documentation
-- [Readonly Mode Documentation](/source/docs/readonly_mode.md) - Technical details
-- [Boot CID Usage](/source/docs/BOOT_CID_USAGE.md) - Boot image system
-- [Export Format](/source/docs/import-export-json-format.md) - Export file structure
+- [Readonly Mode Documentation](/help/readonly_mode.md) - Technical details
+- [Boot CID Usage](/help/BOOT_CID_USAGE.md) - Boot image system
+- [Export Format](/help/import-export-json-format.md) - Export file structure
 - [Gauge Specs](/source/specs/) - Behavioral specifications
 
 ## Common Questions

--- a/docs/help.md
+++ b/docs/help.md
@@ -136,7 +136,7 @@ CIDs are used for:
 - Import/export payloads
 - Boot image content
 
-For technical details, see [CID documentation](/source/docs/import-export-json-format.md#cid-content-identifier-references).
+For technical details, see [CID documentation](/help/import-export-json-format.md#cid-content-identifier-references).
 
 ## Boot Images
 
@@ -168,7 +168,7 @@ Boot images are defined in `reference_templates/` and generated using:
 python generate_boot_image.py
 ```
 
-This reads the source files and creates CID-based boot images. See [Boot CID Usage](/source/docs/BOOT_CID_USAGE.md) for more information.
+This reads the source files and creates CID-based boot images. See [Boot CID Usage](/help/BOOT_CID_USAGE.md) for more information.
 
 ## Importing and Exporting
 
@@ -198,7 +198,7 @@ Exports use a JSON format with CID references for efficient content storage. The
 - Content deduplication
 - Integrity verification
 
-See [Import/Export Format](/source/docs/import-export-json-format.md) for the complete specification.
+See [Import/Export Format](/help/import-export-json-format.md) for the complete specification.
 
 ### Command-Line Import
 
@@ -273,10 +273,10 @@ Viewer includes comprehensive behavioral specifications:
 
 ### Documentation Files
 
-- [Boot CID Usage](/source/docs/BOOT_CID_USAGE.md)
-- [Import/Export Format](/source/docs/import-export-json-format.md)
-- [JSON Template Format](/source/docs/json-template-format.md)
-- [Readonly Mode](/source/docs/readonly_mode.md)
+- [Boot CID Usage](/help/BOOT_CID_USAGE.md)
+- [Import/Export Format](/help/import-export-json-format.md)
+- [JSON Template Format](/help/json-template-format.md)
+- [Readonly Mode](/help/readonly_mode.md)
 
 ## Getting Help
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -144,7 +144,7 @@
                             <li><a href="{{ url_for('main.source_browser') }}">Source Browser</a> - Browse application source code</li>
                             <li><a href="{{ url_for('main.openapi_docs') }}">API Documentation</a> - OpenAPI specification</li>
                             <li><a href="{{ url_for('main.history') }}">History</a> - View change history</li>
-                            <li><a href="{{ url_for('main.source_browser', requested_path='docs/') }}">Documentation Files</a> - Detailed documentation</li>
+                            <li><a href="{{ url_for('main.help_markdown', doc_path='help.md') }}">Documentation Files</a> - Detailed documentation</li>
                             <li><a href="{{ url_for('main.source_browser', requested_path='specs/') }}">Gauge Specifications</a> - Behavioral specifications</li>
                         </ul>
 
@@ -155,7 +155,7 @@
                             <ul>
                                 {% for doc_file in docs_files %}
                                     <li>
-                                        <a href="{{ url_for('main.source_browser', requested_path='docs/' + doc_file) }}">{{ doc_file }}</a>
+                                        <a href="{{ url_for('main.help_markdown', doc_path=doc_file) }}">{{ doc_file }}</a>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/tests/integration/test_help_docs_reachability.py
+++ b/tests/integration/test_help_docs_reachability.py
@@ -40,10 +40,12 @@ def test_all_docs_files_are_linked_and_reachable_from_help(client):
     docs_files = sorted(
         entry.name
         for entry in docs_dir.iterdir()
-        if entry.is_file() and not entry.name.startswith(".")
+        if entry.is_file()
+        and not entry.name.startswith(".")
+        and entry.suffix.lower() == ".md"
     )
 
-    expected_paths: list[str] = [f"/source/docs/{name}" for name in docs_files]
+    expected_paths: list[str] = [f"/help/{name}" for name in docs_files]
 
     for expected in expected_paths:
         assert expected in hrefs
@@ -52,3 +54,6 @@ def test_all_docs_files_are_linked_and_reachable_from_help(client):
         linked_path = linked.path
         linked_response = client.get(linked_path)
         assert linked_response.status_code == 200
+        body = linked_response.get_data(as_text=True)
+        assert '<main class="markdown-body">' in body
+        assert "<a" in body

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -47,3 +47,17 @@ class TestHelpRoutes:
         with memory_db_app.test_request_context():
             url = url_for('main.help_page')
             assert url == '/help'
+
+    def test_help_markdown_renders_document(self, memory_client):
+        """Help markdown endpoint renders docs as HTML."""
+        response = memory_client.get("/help/help.md")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert '<main class="markdown-body">' in body
+        assert '<a href="/aliases">' in body
+        assert '/help/import-export-json-format.md' in body
+
+    def test_help_markdown_rejects_traversal(self, memory_client):
+        """Traversal attempts return 404."""
+        response = memory_client.get("/help/../app.py")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add /help/<doc> route to render markdown files and reuse markdown list helper
- update help page links and docs content to point at rendered /help URLs instead of source browser
- expand tests to cover markdown rendering, safe path handling, and updated help doc links

## Testing
- ./run_unit_tests.sh tests/test_help.py tests/integration/test_help_docs_reachability.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694978d26048833193e25158275f54a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an integrated help system that renders Markdown documentation files directly within the application via a new help route.
  
* **Documentation**
  * Updated all internal documentation links to use the new consolidated help directory structure.
  * Added validation and path-traversal protection for documentation access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->