### PR TITLE
Handle __future__ imports in text functions

### DIFF
--- a/tests/test_text_function_runner.py
+++ b/tests/test_text_function_runner.py
@@ -30,6 +30,19 @@ return z + w
         result = self.run_text_function(body, argmap)
         self.assertEqual(result, 26)  # (10 * 2) + (5 + 1) = 20 + 6 = 26
 
+    def test_future_imports_are_hoisted(self):
+        """__future__ imports should not raise syntax errors."""
+        body = """
+from __future__ import annotations
+
+def render(label: str) -> str:
+    return label
+
+return render(value)
+"""
+        result = self.run_text_function(body, {"value": "hello"})
+        self.assertEqual(result, "hello")
+
     def test_param_order_specified(self):
         """Test that param_order fixes the function signature."""
         body = "return f'{a}-{b}-{c}'"


### PR DESCRIPTION
## Summary
- hoist __future__ imports out of dynamically wrapped server code so definitions remain valid
- add regression coverage to ensure future imports execute without syntax errors

## Testing
- python -m pytest tests/test_text_function_runner.py::TestRunTextFunction::test_future_imports_are_hoisted
- python -m pytest -m integration tests/integration/test_boot_image_reference_templates.py::TestBootImageReferenceTemplates::test_qr_server_returns_png_images

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69498a68f90c8331990eecff10ad3bf7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test to verify `__future__` imports are processed correctly without triggering syntax errors.

* **Bug Fixes**
  * Improved handling of `__future__` imports to prevent syntax errors and enable proper code execution with annotations and other future features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->