### PR TITLE
Add more detailed transform command examples

### DIFF
--- a/docs/bash_commands.md
+++ b/docs/bash_commands.md
@@ -127,7 +127,7 @@ Pattern scanning and text processing language
 ben designer
 " | awk '{print $1}'`
           - Output:
-            ```
+            ```text
             alice
             ben
             ```
@@ -136,7 +136,7 @@ ben designer
 admin:example.org
 " | awk -F : '{print $2}'`
           - Output:
-            ```
+            ```text
             example.com
             example.org
             ```
@@ -191,7 +191,7 @@ Ana 29
 Ben 31
 " | column -t`
           - Output:
-            ```
+            ```text
             name  age
             Ana   29
             Ben   31
@@ -202,7 +202,7 @@ Ravi,Delhi
 Mia,Rome
 " | column -s , -t`
           - Output:
-            ```
+            ```text
             name  city
             Ravi  Delhi
             Mia   Rome
@@ -242,7 +242,7 @@ Ada	Boston
 Terry	Denver
 " | cut -f1`
           - Output:
-            ```
+            ```text
             name
             Ada
             Terry
@@ -253,7 +253,7 @@ anna,anna@example.com
 bob,bob@example.net
 " | cut -d , -f2`
           - Output:
-            ```
+            ```text
             email
             anna@example.com
             bob@example.net
@@ -437,7 +437,7 @@ First lines/bytes
 11
 " | head`
           - Output:
-            ```
+            ```text
             1
             2
             3
@@ -456,7 +456,7 @@ gamma
 delta
 " | head -n 3`
           - Output:
-            ```
+            ```text
             alpha
             beta
             gamma
@@ -615,15 +615,15 @@ Merge lines as columns
 second
 " | paste - -`
           - Output:
-            ```
-            first	second
+            ```text
+            first<TAB>second
             ```
         - Custom delimiter with `-d ,`: [Execute](/paste/-d%20,%20-/_/printf%20%22apples%5Cnoranges%5Cn%22) · [Debug](/paste/-d%20,%20-/_/printf%20%22apples%5Cnoranges%5Cn%22?debug=true)
           - Bash: `printf "apples
 oranges
 " | paste -d , - -`
           - Output:
-            ```
+            ```text
             apples,oranges
             ```
 
@@ -716,7 +716,7 @@ Reverse characters per line
 star
 " | rev`
           - Output:
-            ```
+            ```text
             pool
             rats
             ```
@@ -739,7 +739,7 @@ foo middle
 plain
 " | sed 's/foo/bar/'`
           - Output:
-            ```
+            ```text
             bar start
             bar middle
             plain
@@ -749,7 +749,7 @@ plain
 other-path
 " | sed 's/-/\//g'`
           - Output:
-            ```
+            ```text
             path/with/dashes
             other/path
             ```
@@ -788,7 +788,7 @@ apple
 ochard
 " | sort`
           - Output:
-            ```
+            ```text
             apple
             banana
             chard
@@ -799,7 +799,7 @@ ochard
 5
 " | sort -r`
           - Output:
-            ```
+            ```text
             5
             2
             10
@@ -863,7 +863,7 @@ Last lines/bytes
 11
 " | tail`
           - Output:
-            ```
+            ```text
             2
             3
             4
@@ -882,7 +882,7 @@ gamma
 delta
 " | tail -n 2`
           - Output:
-            ```
+            ```text
             gamma
             delta
             ```
@@ -918,7 +918,7 @@ Translate/delete characters
 - Default transliteration example (lowercase to uppercase): [Execute](/tr/a-z/A-Z/_/echo/hello) · [Debug](/tr/a-z/A-Z/_/echo/hello?debug=true)
           - Bash: `echo hello | tr a-z A-Z`
           - Output:
-            ```
+            ```text
             HELLO
             ```
         - Delete characters with `-d`: [Execute](/tr/-d%200-9/_/printf%20%22room101%5Cnlevel42%5Cn%22) · [Debug](/tr/-d%200-9/_/printf%20%22room101%5Cnlevel42%5Cn%22?debug=true)
@@ -926,7 +926,7 @@ Translate/delete characters
 level42
 " | tr -d 0-9`
           - Output:
-            ```
+            ```text
             room
             level
             ```
@@ -964,18 +964,18 @@ Convert spaces to tabs
     mid
 " | unexpand`
           - Output:
-            ```
-            	start
-            	mid
+            ```text
+            <TAB>start
+            <TAB>mid
             ```
         - Convert all spaces every 4 columns with `-a -t 4`: [Execute](/unexpand/-a%20-t%204/_/printf%20%22word%20%20gap%5Cnwide%20%20%20%20space%5Cn%22) · [Debug](/unexpand/-a%20-t%204/_/printf%20%22word%20%20gap%5Cnwide%20%20%20%20space%5Cn%22?debug=true)
           - Bash: `printf "word  gap
 wide    space
 " | unexpand -a -t 4`
           - Output:
-            ```
-            word	gap
-            wide	space
+            ```text
+            word<TAB>gap
+            wide<TAB>space
             ```
 
 ### `uniq` (Transform)
@@ -990,7 +990,7 @@ banana
 banana
 " | uniq`
           - Output:
-            ```
+            ```text
             apple
             banana
             ```
@@ -1002,7 +1002,7 @@ blue
 blue
 " | uniq -c`
           - Output:
-            ```
+            ```text
                 2 red
                 3 blue
             ```
@@ -1024,7 +1024,7 @@ Count lines/words/bytes
 second line
 " | wc`
           - Output:
-            ```
+            ```text
                   2       4      24
             ```
         - Line-only count with `-l`: [Execute](/wc/-l/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cn%22) · [Debug](/wc/-l/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cn%22?debug=true)
@@ -1033,7 +1033,7 @@ beta
 gamma
 " | wc -l`
           - Output:
-            ```
+            ```text
             3
             ```
 

--- a/docs/bash_commands_builder.py
+++ b/docs/bash_commands_builder.py
@@ -29,14 +29,14 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default field selection (prints the first column): [Execute](/awk/%7Bprint%20$1%7D/_/printf%20%22alice%20engineer%5Cnben%20designer%5Cn%22) · [Debug](/awk/%7Bprint%20$1%7D/_/printf%20%22alice%20engineer%5Cnben%20designer%5Cn%22?debug=true)
           - Bash: `printf "alice engineer\nben designer\n" | awk '{print $1}'`
           - Output:
-            ```
+            ```text
             alice
             ben
             ```
         - Custom delimiter to grab the domain column: [Execute](/awk/-F%20:%20%27{print%20$2}%27/_/printf%20%22user%3Aexample.com%5Cnadmin%3Aexample.org%5Cn%22) · [Debug](/awk/-F%20:%20%27{print%20$2}%27/_/printf%20%22user%3Aexample.com%5Cnadmin%3Aexample.org%5Cn%22?debug=true)
           - Bash: `printf "user:example.com\nadmin:example.org\n" | awk -F : '{print $2}'`
           - Output:
-            ```
+            ```text
             example.com
             example.org
             ```
@@ -47,7 +47,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default (tab-delimited) field extraction: [Execute](/cut/-f1/_/printf%20%22name%5Ctcity%5CnAda%5CtBoston%5CnTerry%5CtDenver%5Cn%22) · [Debug](/cut/-f1/_/printf%20%22name%5Ctcity%5CnAda%5CtBoston%5CnTerry%5CtDenver%5Cn%22?debug=true)
           - Bash: `printf "name\tcity\nAda\tBoston\nTerry\tDenver\n" | cut -f1`
           - Output:
-            ```
+            ```text
             name
             Ada
             Terry
@@ -55,7 +55,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Custom delimiter for CSV-style input: [Execute](/cut/-d%20,%20-f2/_/printf%20%22user%2Cemail%5Cnanna%2Canna%40example.com%5Cnbob%2Cbob%40example.net%5Cn%22) · [Debug](/cut/-d%20,%20-f2/_/printf%20%22user%2Cemail%5Cnanna%2Canna%40example.com%5Cnbob%2Cbob%40example.net%5Cn%22?debug=true)
           - Bash: `printf "user,email\nanna,anna@example.com\nbob,bob@example.net\n" | cut -d , -f2`
           - Output:
-            ```
+            ```text
             email
             anna@example.com
             bob@example.net
@@ -67,7 +67,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default first 10 lines: [Execute](/head/_/printf%20%221%5Cn2%5Cn3%5Cn4%5Cn5%5Cn6%5Cn7%5Cn8%5Cn9%5Cn10%5Cn11%5Cn%22) · [Debug](/head/_/printf%20%221%5Cn2%5Cn3%5Cn4%5Cn5%5Cn6%5Cn7%5Cn8%5Cn9%5Cn10%5Cn11%5Cn%22?debug=true)
           - Bash: `printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n" | head`
           - Output:
-            ```
+            ```text
             1
             2
             3
@@ -82,7 +82,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Custom line count with `-n 3`: [Execute](/head/-n%203/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cndelta%5Cn%22) · [Debug](/head/-n%203/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cndelta%5Cn%22?debug=true)
           - Bash: `printf "alpha\nbeta\ngamma\ndelta\n" | head -n 3`
           - Output:
-            ```
+            ```text
             alpha
             beta
             gamma
@@ -94,7 +94,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default last 10 lines: [Execute](/tail/_/printf%20%221%5Cn2%5Cn3%5Cn4%5Cn5%5Cn6%5Cn7%5Cn8%5Cn9%5Cn10%5Cn11%5Cn%22) · [Debug](/tail/_/printf%20%221%5Cn2%5Cn3%5Cn4%5Cn5%5Cn6%5Cn7%5Cn8%5Cn9%5Cn10%5Cn11%5Cn%22?debug=true)
           - Bash: `printf "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n" | tail`
           - Output:
-            ```
+            ```text
             2
             3
             4
@@ -109,7 +109,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Custom line count with `-n 2`: [Execute](/tail/-n%202/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cndelta%5Cn%22) · [Debug](/tail/-n%202/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cndelta%5Cn%22?debug=true)
           - Bash: `printf "alpha\nbeta\ngamma\ndelta\n" | tail -n 2`
           - Output:
-            ```
+            ```text
             gamma
             delta
             ```
@@ -120,7 +120,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default ascending sort: [Execute](/sort/_/printf%20%22banana%5Cnapple%5Cnochard%5Cn%22) · [Debug](/sort/_/printf%20%22banana%5Cnapple%5Cnochard%5Cn%22?debug=true)
           - Bash: `printf "banana\napple\nochard\n" | sort`
           - Output:
-            ```
+            ```text
             apple
             banana
             chard
@@ -128,7 +128,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Reverse sort with `-r`: [Execute](/sort/-r/_/printf%20%222%5Cn10%5Cn5%5Cn%22) · [Debug](/sort/-r/_/printf%20%222%5Cn10%5Cn5%5Cn%22?debug=true)
           - Bash: `printf "2\n10\n5\n" | sort -r`
           - Output:
-            ```
+            ```text
             5
             2
             10
@@ -140,7 +140,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default substitution (replaces first match on each line): [Execute](/sed/s/foo/bar/_/printf%20%22foo%20start%5Cnfoo%20middle%5Cnplain%5Cn%22) · [Debug](/sed/s/foo/bar/_/printf%20%22foo%20start%5Cnfoo%20middle%5Cnplain%5Cn%22?debug=true)
           - Bash: `printf "foo start\nfoo middle\nplain\n" | sed 's/foo/bar/'`
           - Output:
-            ```
+            ```text
             bar start
             bar middle
             plain
@@ -148,7 +148,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Global substitution with `g` flag: [Execute](/sed/s/-/\//g/_/printf%20%22path-with-dashes%5Cnother-path%5Cn%22) · [Debug](/sed/s/-/\//g/_/printf%20%22path-with-dashes%5Cnother-path%5Cn%22?debug=true)
           - Bash: `printf "path-with-dashes\nother-path\n" | sed 's/-/\//g'`
           - Output:
-            ```
+            ```text
             path/with/dashes
             other/path
             ```
@@ -159,13 +159,13 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default transliteration example (lowercase to uppercase): [Execute](/tr/a-z/A-Z/_/echo/hello) · [Debug](/tr/a-z/A-Z/_/echo/hello?debug=true)
           - Bash: `echo hello | tr a-z A-Z`
           - Output:
-            ```
+            ```text
             HELLO
             ```
         - Delete characters with `-d`: [Execute](/tr/-d%200-9/_/printf%20%22room101%5Cnlevel42%5Cn%22) · [Debug](/tr/-d%200-9/_/printf%20%22room101%5Cnlevel42%5Cn%22?debug=true)
           - Bash: `printf "room101\nlevel42\n" | tr -d 0-9`
           - Output:
-            ```
+            ```text
             room
             level
             ```
@@ -176,7 +176,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Tab-align whitespace-separated columns (default): [Execute](/column/-t/_/printf%20%22name%20age%5CnAna%2029%5CnBen%2031%5Cn%22) · [Debug](/column/-t/_/printf%20%22name%20age%5CnAna%2029%5CnBen%2031%5Cn%22?debug=true)
           - Bash: `printf "name age\nAna 29\nBen 31\n" | column -t`
           - Output:
-            ```
+            ```text
             name  age
             Ana   29
             Ben   31
@@ -184,7 +184,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Custom delimiter with `-s , -t`: [Execute](/column/-s%20,%20-t/_/printf%20%22name,city%5CnRavi,Delhi%5CnMia,Rome%5Cn%22) · [Debug](/column/-s%20,%20-t/_/printf%20%22name,city%5CnRavi,Delhi%5CnMia,Rome%5Cn%22?debug=true)
           - Bash: `printf "name,city\nRavi,Delhi\nMia,Rome\n" | column -s , -t`
           - Output:
-            ```
+            ```text
             name  city
             Ravi  Delhi
             Mia   Rome
@@ -196,13 +196,13 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Combine two columns from stdin (default tab delimiter): [Execute](/paste/-/_/printf%20%22first%5Cnsecond%5Cn%22) · [Debug](/paste/-/_/printf%20%22first%5Cnsecond%5Cn%22?debug=true)
           - Bash: `printf "first\nsecond\n" | paste - -`
           - Output:
-            ```
-            first\tsecond
+            ```text
+            first<TAB>second
             ```
         - Custom delimiter with `-d ,`: [Execute](/paste/-d%20,%20-/_/printf%20%22apples%5Cnoranges%5Cn%22) · [Debug](/paste/-d%20,%20-/_/printf%20%22apples%5Cnoranges%5Cn%22?debug=true)
           - Bash: `printf "apples\noranges\n" | paste -d , - -`
           - Output:
-            ```
+            ```text
             apples,oranges
             ```
         """
@@ -212,7 +212,7 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Reverse text by line (default behavior): [Execute](/rev/_/printf%20%22loop%5Cnstar%5Cn%22) · [Debug](/rev/_/printf%20%22loop%5Cnstar%5Cn%22?debug=true)
           - Bash: `printf "loop\nstar\n" | rev`
           - Output:
-            ```
+            ```text
             pool
             rats
             ```
@@ -223,16 +223,16 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Convert leading spaces to tabs (default tab stop every 8): [Execute](/unexpand/_/printf%20%22%20%20%20%20%20%20%20%20start%5Cn%20%20%20%20mid%5Cn%22) · [Debug](/unexpand/_/printf%20%22%20%20%20%20%20%20%20%20start%5Cn%20%20%20%20mid%5Cn%22?debug=true)
           - Bash: `printf "        start\n    mid\n" | unexpand`
           - Output:
-            ```
-            \tstart
-            \tmid
+            ```text
+            <TAB>start
+            <TAB>mid
             ```
         - Convert all spaces every 4 columns with `-a -t 4`: [Execute](/unexpand/-a%20-t%204/_/printf%20%22word%20%20gap%5Cnwide%20%20%20%20space%5Cn%22) · [Debug](/unexpand/-a%20-t%204/_/printf%20%22word%20%20gap%5Cnwide%20%20%20%20space%5Cn%22?debug=true)
           - Bash: `printf "word  gap\nwide    space\n" | unexpand -a -t 4`
           - Output:
-            ```
-            word\tgap
-            wide\tspace
+            ```text
+            word<TAB>gap
+            wide<TAB>space
             ```
         """
     ).strip().splitlines(),
@@ -241,14 +241,14 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default unique filtering (drops repeated neighbors): [Execute](/uniq/_/printf%20%22apple%5Cnapple%5Cnbanana%5Cnbanana%5Cnbanana%5Cn%22) · [Debug](/uniq/_/printf%20%22apple%5Cnapple%5Cnbanana%5Cnbanana%5Cnbanana%5Cn%22?debug=true)
           - Bash: `printf "apple\napple\nbanana\nbanana\nbanana\n" | uniq`
           - Output:
-            ```
+            ```text
             apple
             banana
             ```
         - Count occurrences with `-c`: [Execute](/uniq/-c/_/printf%20%22red%5Cnred%5Cnblue%5Cnblue%5Cnblue%5Cn%22) · [Debug](/uniq/-c/_/printf%20%22red%5Cnred%5Cnblue%5Cnblue%5Cnblue%5Cn%22?debug=true)
           - Bash: `printf "red\nred\nblue\nblue\nblue\n" | uniq -c`
           - Output:
-            ```
+            ```text
                 2 red
                 3 blue
             ```
@@ -259,13 +259,13 @@ COMMAND_EXAMPLE_OVERRIDES: dict[str, list[str]] = {
         - Default counts (lines, words, bytes): [Execute](/wc/_/printf%20%22hello%20world%5Cnsecond%20line%5Cn%22) · [Debug](/wc/_/printf%20%22hello%20world%5Cnsecond%20line%5Cn%22?debug=true)
           - Bash: `printf "hello world\nsecond line\n" | wc`
           - Output:
-            ```
+            ```text
                   2       4      24
             ```
         - Line-only count with `-l`: [Execute](/wc/-l/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cn%22) · [Debug](/wc/-l/_/printf%20%22alpha%5Cnbeta%5Cngamma%5Cn%22?debug=true)
           - Bash: `printf "alpha\nbeta\ngamma\n" | wc -l`
           - Output:
-            ```
+            ```text
             3
             ```
         """


### PR DESCRIPTION
## Summary
- add concrete bash input/output examples for column, paste, rev, unexpand, uniq, and wc
- illustrate both default behaviors and customized options for these transform commands

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694d70ba13588331bfa3e3ab04f88545)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Bash command reference with many concrete, copy-ready examples and explicit input/output blocks for tools like awk, cut, sed, sort, uniq, wc, and more.
  * Documentation rendering now uses curated, command-specific example blocks to provide consistent, practical sample inputs, commands, and expected outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->