### PR TITLE
Render related CIDs on meta page with popup link pair

### DIFF
--- a/routes/meta/meta_rendering.py
+++ b/routes/meta/meta_rendering.py
@@ -64,7 +64,7 @@ def render_cid_popup_pair(value: Any) -> Markup:
         cid_value = format_cid(value)
     elif isinstance(value, str):
         extracted = extract_cid_from_path(value)
-        if extracted:
+        if extracted and is_normalized_cid(extracted):
             cid_value = extracted
         elif _is_probable_cid(value):
             cid_value = format_cid(value)


### PR DESCRIPTION
## Summary
- render related CID entries on the /meta page using the standard CID link and metadata popup pair
- add helper functions to format related CID lists for HTML meta output
- cover the new CID presentation with a dedicated HTML meta route test

## Testing
- pytest tests/test_meta_route.py -k related_cids --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952b18772188331b6ef32b9e54ad25a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CIDs render as interactive links with adjacent metadata popup icons and embedded JS/CSS for dropdown behavior.
  * Related CIDs display as a formatted list of CID + popup pairs; arbitrary CID fields also get popup-enabled UI.
  * Rendering now correctly handles nested collections and parent-child metadata contexts for consistent popups.

* **Tests**
  * Added tests to verify related-CID popup rendering, dropdown behavior, and dynamic CID handling in metadata views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->