### PR TITLE
Migrate Google Ads/Contacts/Forms and PandaDoc to dispatch tables and shared executor

### DIFF
--- a/reference/templates/servers/definitions/pandadoc.py
+++ b/reference/templates/servers/definitions/pandadoc.py
@@ -5,47 +5,84 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-import requests
-
-from server_utils.external_api import ExternalApiClient, error_output, validation_error
+from server_utils.external_api import (
+    ExternalApiClient,
+    OperationDefinition,
+    RequiredField,
+    error_output,
+    execute_json_request,
+    validate_and_build_payload,
+    validation_error,
+)
 
 
 _DEFAULT_CLIENT = ExternalApiClient()
+
+_OPERATIONS = {
+    "list_documents": OperationDefinition(),
+    "get_document": OperationDefinition(
+        required=(RequiredField("document_id", "Missing required document_id"),),
+    ),
+    "create_document": OperationDefinition(
+        required=(
+            RequiredField("name", "Missing required name"),
+            RequiredField("template_uuid", "Missing required template_uuid"),
+            RequiredField("recipient_email", "Missing required recipient_email"),
+        ),
+        payload_builder=lambda name, template_uuid, recipient_email, recipient_first_name, recipient_last_name, **_: {
+            "name": name,
+            "template_uuid": template_uuid,
+            "recipients": [
+                {
+                    "email": recipient_email,
+                    "first_name": recipient_first_name or "Recipient",
+                    "last_name": recipient_last_name or "User",
+                    "role": "Signer",
+                }
+            ],
+        },
+    ),
+    "send_document": OperationDefinition(
+        required=(RequiredField("document_id", "Missing required document_id"),),
+        payload_builder=lambda message, **_: {
+            "message": message or "Please sign this document",
+        },
+    ),
+    "download_document": OperationDefinition(
+        required=(RequiredField("document_id", "Missing required document_id"),),
+    ),
+    "list_templates": OperationDefinition(),
+    "get_template": OperationDefinition(
+        required=(RequiredField("template_id", "Missing required template_id"),),
+    ),
+}
+
+_ENDPOINT_BUILDERS = {
+    "list_documents": lambda base_url, **_: f"{base_url}/documents",
+    "get_document": lambda base_url, document_id, **_: f"{base_url}/documents/{document_id}",
+    "create_document": lambda base_url, **_: f"{base_url}/documents",
+    "send_document": lambda base_url, document_id, **_: f"{base_url}/documents/{document_id}/send",
+    "download_document": lambda base_url, document_id, **_: (
+        f"{base_url}/documents/{document_id}/download"
+    ),
+    "list_templates": lambda base_url, **_: f"{base_url}/templates",
+    "get_template": lambda base_url, template_id, **_: f"{base_url}/templates/{template_id}",
+}
+
+_METHODS = {
+    "create_document": "POST",
+    "send_document": "POST",
+}
 
 
 def _build_preview(
     *,
     operation: str,
-    document_id: Optional[str],
-    template_id: Optional[str],
+    url: str,
+    method: str,
     params: Optional[Dict[str, Any]],
     payload: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    base_url = "https://api.pandadoc.com/public/v1"
-
-    if operation == "list_documents":
-        url = f"{base_url}/documents"
-    elif operation == "get_document" and document_id:
-        url = f"{base_url}/documents/{document_id}"
-    elif operation == "create_document":
-        url = f"{base_url}/documents"
-    elif operation == "send_document" and document_id:
-        url = f"{base_url}/documents/{document_id}/send"
-    elif operation == "download_document" and document_id:
-        url = f"{base_url}/documents/{document_id}/download"
-    elif operation == "list_templates":
-        url = f"{base_url}/templates"
-    elif operation == "get_template" and template_id:
-        url = f"{base_url}/templates/{template_id}"
-    else:
-        url = f"{base_url}/{operation}"
-
-    method_map = {
-        "create_document": "POST",
-        "send_document": "POST",
-    }
-    method = method_map.get(operation, "GET")
-
     preview: Dict[str, Any] = {
         "operation": operation,
         "url": url,
@@ -89,20 +126,6 @@ def main(
     - get_template: Get template details by ID
     """
 
-    normalized_operation = operation.lower()
-    valid_operations = {
-        "list_documents",
-        "get_document",
-        "create_document",
-        "send_document",
-        "download_document",
-        "list_templates",
-        "get_template",
-    }
-
-    if normalized_operation not in valid_operations:
-        return validation_error("Unsupported operation", field="operation")
-
     if not PANDADOC_API_KEY:
         return error_output(
             "Missing PANDADOC_API_KEY",
@@ -119,99 +142,78 @@ def main(
         "Accept": "application/json",
     }
 
+    if operation not in _OPERATIONS:
+        return validation_error("Unsupported operation", field="operation")
+
+    result = validate_and_build_payload(
+        operation,
+        _OPERATIONS,
+        document_id=document_id,
+        template_id=template_id,
+        name=name,
+        template_uuid=template_uuid,
+        recipient_email=recipient_email,
+        recipient_first_name=recipient_first_name,
+        recipient_last_name=recipient_last_name,
+        message=message,
+    )
+    if isinstance(result, tuple):
+        return validation_error(result[0], field=result[1])
+    payload = result
+
     params: Optional[Dict[str, Any]] = None
-    payload: Optional[Dict[str, Any]] = None
-
-    if normalized_operation == "list_documents":
-        params = {}
-        if status:
-            params["status"] = status
-    elif normalized_operation == "get_document":
-        if not document_id:
-            return validation_error("Missing required document_id", field="document_id")
-    elif normalized_operation == "create_document":
-        if not name:
-            return validation_error("Missing required name", field="name")
-        if not template_uuid:
-            return validation_error("Missing required template_uuid", field="template_uuid")
-        if not recipient_email:
-            return validation_error("Missing required recipient_email", field="recipient_email")
-
-        payload = {
-            "name": name,
-            "template_uuid": template_uuid,
-            "recipients": [
-                {
-                    "email": recipient_email,
-                    "first_name": recipient_first_name or "Recipient",
-                    "last_name": recipient_last_name or "User",
-                    "role": "Signer",
-                }
-            ],
-        }
-    elif normalized_operation == "send_document":
-        if not document_id:
-            return validation_error("Missing required document_id", field="document_id")
-        payload = {"message": message or "Please sign this document"}
-    elif normalized_operation == "download_document":
-        if not document_id:
-            return validation_error("Missing required document_id", field="document_id")
-    elif normalized_operation == "get_template":
-        if not template_id:
-            return validation_error("Missing required template_id", field="template_id")
+    if operation == "list_documents" and status:
+        params = {"status": status}
 
     if dry_run:
-        preview = _build_preview(
-            operation=normalized_operation,
+        url = _ENDPOINT_BUILDERS[operation](
+            base_url=base_url,
             document_id=document_id,
             template_id=template_id,
+        )
+        method = _METHODS.get(operation, "GET")
+        preview = _build_preview(
+            operation=operation,
+            url=url,
+            method=method,
             params=params,
             payload=payload,
         )
         return {"output": {"preview": preview, "message": "Dry run - no API call made"}}
 
-    # Build URL
-    if normalized_operation == "list_documents":
-        url = f"{base_url}/documents"
-    elif normalized_operation == "get_document":
-        url = f"{base_url}/documents/{document_id}"
-    elif normalized_operation == "create_document":
-        url = f"{base_url}/documents"
-    elif normalized_operation == "send_document":
-        url = f"{base_url}/documents/{document_id}/send"
-    elif normalized_operation == "download_document":
-        url = f"{base_url}/documents/{document_id}/download"
-    elif normalized_operation == "list_templates":
-        url = f"{base_url}/templates"
-    elif normalized_operation == "get_template":
-        url = f"{base_url}/templates/{template_id}"
-    else:
-        url = f"{base_url}/{normalized_operation}"
+    url = _ENDPOINT_BUILDERS[operation](
+        base_url=base_url,
+        document_id=document_id,
+        template_id=template_id,
+    )
+    method = _METHODS.get(operation, "GET")
 
-    try:
-        if normalized_operation in {"create_document", "send_document"}:
-            response = api_client.post(url, headers=headers, json=payload, timeout=timeout)
-        else:
+    if operation == "download_document":
+        try:
             response = api_client.get(url, headers=headers, params=params, timeout=timeout)
-    except requests.RequestException as exc:
-        status = getattr(getattr(exc, "response", None), "status_code", None)
-        return error_output("PandaDoc request failed", status_code=status, details=str(exc))
-
-    # Handle binary download for PDFs
-    if normalized_operation == "download_document" and response.ok:
-        return {"output": {"document": "PDF binary data", "content_type": "application/pdf"}}
-
-    try:
-        data = response.json()
-    except ValueError:
+        except Exception as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            return error_output("PandaDoc request failed", status_code=status, details=str(exc))
+        if getattr(response, "ok", False):
+            return {"output": {"document": "PDF binary data", "content_type": "application/pdf"}}
         return error_output(
-            "Invalid JSON response",
+            "PandaDoc API error",
             status_code=getattr(response, "status_code", None),
-            details=getattr(response, "text", None),
+            response=getattr(response, "text", None),
         )
 
-    if not getattr(response, "ok", False):
-        error_msg = data.get("detail", data.get("message", "PandaDoc API error"))
-        return error_output(error_msg, status_code=response.status_code, response=data)
-
-    return {"output": data}
+    return execute_json_request(
+        api_client,
+        method,
+        url,
+        headers=headers,
+        params=params,
+        json=payload,
+        timeout=timeout,
+        error_parser=lambda _response, data: (
+            data.get("detail", data.get("message", "PandaDoc API error"))
+            if isinstance(data, dict)
+            else "PandaDoc API error"
+        ),
+        request_error_message="PandaDoc request failed",
+    )

--- a/todo/structural_changes.md
+++ b/todo/structural_changes.md
@@ -17,7 +17,8 @@ This document proposes concrete structural changes to reduce cyclomatic complexi
 - ✅ Phase 10: Migrated servicenow.py, helpscout.py, etsy.py, figma.py, klaviyo.py, and quickbooks.py to dispatch tables and shared executor.
 - ✅ Phase 11: Migrated mailchimp.py, mailerlite.py, and zoho_crm.py to dispatch tables and shared executor.
 - ✅ Phase 12: Migrated calendly.py, pipedrive.py, gitlab.py, wordpress.py, and webflow.py to dispatch tables and shared executor.
-- ⏳ Remaining servers: 60+ servers with 10+ branches still need migration
+- ✅ Phase 13: Migrated google_ads.py, google_contacts.py, google_forms.py, and pandadoc.py to dispatch tables and shared executor.
+- ⏳ Remaining servers: 50+ servers with 10+ branches still need migration
 
 ## Summary of Improvements
 
@@ -50,8 +51,12 @@ Successfully migrated **20 high-complexity external API servers** to use dispatc
 | **gitlab.py** | TBD | TBD | TBD | ✅ Completed (Phase 12) |
 | **wordpress.py** | TBD | TBD | TBD | ✅ Completed (Phase 12) |
 | **webflow.py** | TBD | TBD | TBD | ✅ Completed (Phase 12) |
+| **google_ads.py** | TBD | TBD | TBD | ✅ Completed (Phase 13) |
+| **google_contacts.py** | TBD | TBD | TBD | ✅ Completed (Phase 13) |
+| **google_forms.py** | TBD | TBD | TBD | ✅ Completed (Phase 13) |
+| **pandadoc.py** | TBD | TBD | TBD | ✅ Completed (Phase 13) |
 
-**Total complexity reduction: 168+ branches eliminated across 20 servers (pending updated counts for Phase 11)**
+**Total complexity reduction: 168+ branches eliminated across 24 servers (pending updated counts for Phase 11-13)**
 
 ### Pattern Applied
 


### PR DESCRIPTION
### Motivation
- Reduce cyclomatic complexity by removing large `if`/`elif` dispatch chains in server templates and adopt a data-driven pattern for operations.
- Finish the remaining work from `todo/structural_changes.md` by migrating additional high-complexity servers to the shared helpers.
- Standardize payload validation and JSON request execution across server definitions to improve maintainability and testability.

### Description
- Rewrote `reference/templates/servers/definitions/google_ads.py` to use `OperationDefinition`/`RequiredField`, `_ENDPOINT_BUILDERS`/`_METHODS`, `validate_and_build_payload`, and `execute_json_request` for payload validation and request execution.
- Migrated `reference/templates/servers/definitions/google_contacts.py` and `reference/templates/servers/definitions/google_forms.py` to the dispatch-table pattern, adding payload builders and endpoint/method maps and delegating execution to `execute_json_request`.
- Refactored `reference/templates/servers/definitions/pandadoc.py` to use dispatch tables and `execute_json_request` while preserving the special-case binary download handling.
- Updated `todo/structural_changes.md` to record Phase 13 progress and adjust the remaining servers and summary counts.

### Testing
- No automated tests were run for these changes.
- Please run the full test suite with `./test` and (optionally) `python run_coverage.py --xml --html` before merging to verify behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69602c4eaa288331b4161c0162281cf2)